### PR TITLE
Implement settings page and connection check

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -15,6 +15,11 @@ app.use(express.json());
 app.use('/api/clientes', clientesRouter);
 app.use(passwordResetRouter);
 
+// Endpoint simples para verificar a disponibilidade do servidor
+app.get('/status', (_req, res) => {
+  res.json({ status: 'ok' });
+});
+
 app.get('/reset-password', (_req, res) => {
   res.sendFile(path.join(__dirname, '../src/login/reset-password.html'));
 });

--- a/src/css/configuracoes.css
+++ b/src/css/configuracoes.css
@@ -1,0 +1,38 @@
+:root {
+    --color-primary: #b6a03e;
+    --color-primary-light: #d4c169;
+    --color-primary-dark: #7f6a27;
+    --color-violet: #A394A7;
+    --color-bordeaux: #6a152c;
+    --color-bg-deep: #310017;
+    --color-surface: rgba(255, 255, 255, 0.08);
+    --color-green: #a2ffa6;
+    --color-red: #ff5858;
+    --color-blue: #8aa7f3;
+    --neutral-100: #f9fafb;
+    --neutral-500: #6b7280;
+}
+
+body {
+    background: linear-gradient(135deg, var(--color-bg-deep) 0%, #1a0009 100%);
+    min-height: 100vh;
+}
+
+.glass-surface {
+    background: var(--color-surface);
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
+}
+
+.animate-fade-in-up {
+    animation: fadeInUp 0.6s ease-out forwards;
+    opacity: 0;
+    transform: translateY(20px);
+}
+
+@keyframes fadeInUp {
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}

--- a/src/html/configuracoes.html
+++ b/src/html/configuracoes.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Configurações - Santíssimo Decor</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="../css/configuracoes.css">
+</head>
+<body class="text-white p-6">
+    <div class="max-w-7xl mx-auto">
+        <div class="mb-8 animate-fade-in-up">
+            <h1 class="text-3xl font-bold mb-2">Configurações</h1>
+            <p style="color: var(--color-violet)">Ajuste preferências e parâmetros do sistema</p>
+        </div>
+        <div class="glass-surface rounded-xl p-6 animate-fade-in-up">
+            <p>Em desenvolvimento...</p>
+        </div>
+    </div>
+</body>
+</html>

--- a/src/html/menu.html
+++ b/src/html/menu.html
@@ -33,11 +33,11 @@
                 </div>
                 
                 <div class="flex items-center space-x-2">
-                    <button class="p-2 rounded-lg transition-colors duration-150 hover:bg-white/10" style="color: var(--color-violet)" onmouseover="this.style.color='var(--color-primary-light)'" onmouseout="this.style.color='var(--color-violet)'">
+                    <button id="settingsBtn" class="p-2 rounded-lg transition-colors duration-150 hover:bg-white/10" style="color: var(--color-violet)" onmouseover="this.style.color='var(--color-primary-light)'" onmouseout="this.style.color='var(--color-violet)'">
                         <i class="fas fa-cog w-5 h-5"></i>
                     </button>
-                    
-                    <button class="p-2 rounded-lg transition-colors duration-150 hover:bg-white/10" style="color: var(--color-green)">
+
+                    <button id="networkCheck" class="p-2 rounded-lg transition-colors duration-150 hover:bg-white/10" style="color: var(--color-green)">
                         <i class="fas fa-sync-alt w-4 h-4 rotating"></i>
                     </button>
                     
@@ -338,5 +338,6 @@
 
     <!-- Script de controle do menu -->
     <script src="../js/menu.js"></script>
+    <script src="../js/checking.js"></script>
 </body>
 </html>

--- a/src/js/checking.js
+++ b/src/js/checking.js
@@ -1,0 +1,31 @@
+// Verificação periódica de conectividade com o backend
+// Usa o botão de sincronização existente para exibir o status
+const checkBtn = document.getElementById('networkCheck');
+const icon = checkBtn ? checkBtn.querySelector('i') : null;
+
+/**
+ * Consulta o endpoint /status para verificar se o servidor responde.
+ * Altera a cor do ícone conforme o resultado.
+ */
+async function verifyConnection() {
+    if (!checkBtn || !icon) return;
+    try {
+        const resp = await fetch('http://localhost:3000/status', { cache: 'no-store' });
+        if (resp.ok) {
+            checkBtn.style.color = 'var(--color-green)';
+            if (!icon.classList.contains('rotating')) icon.classList.add('rotating');
+        } else {
+            throw new Error('Status não OK');
+        }
+    } catch (err) {
+        checkBtn.style.color = 'var(--color-red)';
+        icon.classList.remove('rotating');
+    }
+}
+
+// verifica ao iniciar e a cada 30s
+verifyConnection();
+if (checkBtn) {
+    checkBtn.addEventListener('click', verifyConnection);
+}
+setInterval(verifyConnection, 30000);

--- a/src/js/configuracoes.js
+++ b/src/js/configuracoes.js
@@ -1,0 +1,16 @@
+// Script do módulo de Configurações
+// Exibe animação básica na entrada da página
+function initConfiguracoes() {
+    document.querySelectorAll('.animate-fade-in-up').forEach((el, index) => {
+        setTimeout(() => {
+            el.style.opacity = '1';
+            el.style.transform = 'translateY(0)';
+        }, index * 100);
+    });
+}
+
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initConfiguracoes);
+} else {
+    initConfiguracoes();
+}

--- a/src/js/menu.js
+++ b/src/js/menu.js
@@ -7,37 +7,16 @@ const menuToggle = document.getElementById('menuToggle');
 const crmToggle = document.getElementById('crmToggle');
 const crmSubmenu = document.getElementById('crmSubmenu');
 const chevron = crmToggle.querySelector('.chevron');
-
-// Carrega páginas modulares dentro da div#content
-function loadPage(page) {
-    const content = document.getElementById('content');
-    if (!content) return;
-    fetch(`../html/${page}.html`)
-        .then(resp => resp.text())
-        .then(html => {
-            content.innerHTML = html;
-            document.dispatchEvent(new Event('module-change'));
-
-            const oldCss = document.getElementById('page-style');
-            if (oldCss) oldCss.remove();
-            const link = document.createElement('link');
-            link.id = 'page-style';
-            link.rel = 'stylesheet';
-            link.href = `../css/${page}.css`;
-            document.head.appendChild(link);
-
-            const oldScript = document.getElementById('page-script');
-            if (oldScript) oldScript.remove();
-            const script = document.createElement('script');
-            script.id = 'page-script';
-            script.src = `../js/${page}.js`;
-            document.body.appendChild(script);
-        });
-}
-window.loadPage = loadPage;
+const settingsBtn = document.getElementById('settingsBtn');
 
 let sidebarExpanded = false;
 let crmExpanded = false;
+
+// Abre a tela de configurações quando o botão da engrenagem é clicado
+settingsBtn?.addEventListener('click', () => {
+    document.querySelector('h1').textContent = pageNames.configuracoes;
+    loadPage('configuracoes');
+});
 
 // Expande a sidebar quando necessário
 function expandSidebar() {
@@ -133,6 +112,7 @@ async function loadPage(page) {
         console.error('Erro ao carregar página', page, err);
     }
 }
+window.loadPage = loadPage;
 
 // Navegação interna
 document.querySelectorAll('.sidebar-item[data-page], .submenu-item[data-page]').forEach(item => {
@@ -166,6 +146,9 @@ document.querySelectorAll('.sidebar-item[data-page], .submenu-item[data-page]').
         }
         if (page === 'usuarios') {
             loadPage('usuarios');
+        }
+        if (page === 'configuracoes') {
+            loadPage('configuracoes');
         }
     });
 });


### PR DESCRIPTION
## Summary
- enable settings access through gear icon and sidebar
- create Configurações page with basic styling
- add network check indicator using existing refresh button
- expose backend `/status` endpoint for connectivity tests

## Testing
- `npm install dotenv`
- `node backend/server.js & sleep 1; kill $!`

------
https://chatgpt.com/codex/tasks/task_e_6887ac9d3f4c832290579e8a7126cd08