### PR TITLE
Add connectivity check

### DIFF
--- a/src/html/menu.html
+++ b/src/html/menu.html
@@ -37,7 +37,7 @@
                         <i class="fas fa-cog w-5 h-5"></i>
                     </button>
                     
-                    <button class="p-2 rounded-lg transition-colors duration-150 hover:bg-white/10" style="color: var(--color-green)">
+                    <button id="networkCheck" class="p-2 rounded-lg transition-colors duration-150 hover:bg-white/10" style="color: var(--color-green)">
                         <i class="fas fa-sync-alt w-4 h-4 rotating"></i>
                     </button>
                     
@@ -338,5 +338,6 @@
 
     <!-- Script de controle do menu -->
     <script src="../js/menu.js"></script>
+    <script src="../js/checking.js"></script>
 </body>
 </html>

--- a/src/js/checking.js
+++ b/src/js/checking.js
@@ -1,0 +1,30 @@
+// Verificação periódica de conectividade com o backend
+// Usa o botão de sincronização existente para exibir o status
+const checkBtn = document.getElementById('networkCheck');
+const icon = checkBtn ? checkBtn.querySelector('i') : null;
+
+async function verifyConnection() {
+    if (!checkBtn || !icon) return;
+    if (!navigator.onLine) {
+        checkBtn.style.color = 'var(--color-red)';
+        icon.classList.remove('rotating');
+        return;
+    }
+    try {
+        const res = await window.electronAPI.checkPin();
+        if (res && res.success) {
+            checkBtn.style.color = 'var(--color-green)';
+            if (!icon.classList.contains('rotating')) icon.classList.add('rotating');
+        } else {
+            checkBtn.style.color = 'var(--color-red)';
+            icon.classList.remove('rotating');
+        }
+    } catch (err) {
+        checkBtn.style.color = 'var(--color-red)';
+        icon.classList.remove('rotating');
+    }
+}
+
+verifyConnection();
+if (checkBtn) checkBtn.addEventListener('click', verifyConnection);
+setInterval(verifyConnection, 10000);


### PR DESCRIPTION
## Summary
- monitor network status using the existing spinner button in the header
- wire menu page to load new connection checking script

## Testing
- `node --check src/js/checking.js`

------
https://chatgpt.com/codex/tasks/task_e_6887b190dfbc83228ccb4b6852c99fb2