### PR TITLE
Fix network check button and settings menu

### DIFF
--- a/src/html/menu.html
+++ b/src/html/menu.html
@@ -46,7 +46,7 @@
                         </button>
                     </div>
                 
-                    <button class="p-2 rounded-lg transition-colors duration-150 hover:bg-white/10" style="color: var(--color-green)">
+                    <button id="networkCheck" class="p-2 rounded-lg transition-colors duration-150 hover:bg-white/10" style="color: var(--color-green)">
                         <i class="fas fa-sync-alt w-4 h-4 rotating"></i>
                     </button>
                     
@@ -348,6 +348,7 @@
 
     <!-- Script de controle do menu -->
     <script src="../js/menu.js"></script>
+    <script src="../utils/userActions.js"></script>
     <script src="../js/checking.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- hook up network check button in dashboard
- load user actions script so settings button works
- install dependencies for running `verify-smtp` test

## Testing
- `npm install`
- `npm run verify-smtp` *(fails: connect ECONNREFUSED 127.0.0.1:465)*

------
https://chatgpt.com/codex/tasks/task_e_6887b49c34588322b04af5cb4cfccf09