### PR TITLE
Fix network check spinner logic

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -15,6 +15,11 @@ app.use(express.json());
 app.use('/api/clientes', clientesRouter);
 app.use(passwordResetRouter);
 
+// Endpoint simples para verificar a disponibilidade do servidor
+app.get('/status', (_req, res) => {
+  res.json({ status: 'ok' });
+});
+
 app.get('/reset-password', (_req, res) => {
   res.sendFile(path.join(__dirname, '../src/login/reset-password.html'));
 });

--- a/src/js/checking.js
+++ b/src/js/checking.js
@@ -3,6 +3,10 @@
 const checkBtn = document.getElementById('networkCheck');
 const icon = checkBtn ? checkBtn.querySelector('i') : null;
 
+/**
+ * Consulta o endpoint /status para verificar se o servidor responde.
+ * Altera a cor do ícone conforme o resultado.
+ */
 async function verifyConnection() {
     if (!checkBtn || !icon) return;
     if (!navigator.onLine) {
@@ -11,13 +15,12 @@ async function verifyConnection() {
         return;
     }
     try {
-        const res = await window.electronAPI.checkPin();
-        if (res && res.success) {
+        const resp = await fetch('http://localhost:3000/status', { cache: 'no-store' });
+        if (resp.ok) {
             checkBtn.style.color = 'var(--color-green)';
             if (!icon.classList.contains('rotating')) icon.classList.add('rotating');
         } else {
-            checkBtn.style.color = 'var(--color-red)';
-            icon.classList.remove('rotating');
+            throw new Error('Status não OK');
         }
     } catch (err) {
         checkBtn.style.color = 'var(--color-red)';
@@ -25,6 +28,7 @@ async function verifyConnection() {
     }
 }
 
+// verifica ao iniciar e a cada 30s
 verifyConnection();
 if (checkBtn) checkBtn.addEventListener('click', verifyConnection);
-setInterval(verifyConnection, 10000);
+setInterval(verifyConnection, 30000);


### PR DESCRIPTION
## Summary
- restore `/status` endpoint in backend API
- revert network checker script to use HTTP endpoint

## Testing
- `npm run verify-smtp` *(fails: connect ECONNREFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_6887b6337dd48322b5f70e992846d76a