### PR TITLE
Improve network check icon

### DIFF
--- a/src/js/checking.js
+++ b/src/js/checking.js
@@ -2,6 +2,7 @@
 // Usa o botão de sincronização existente para exibir o status
 const checkBtn = document.getElementById('networkCheck');
 const icon = checkBtn ? checkBtn.querySelector('i') : null;
+let checkTimeout;
 
 /**
  * Consulta o endpoint /status para verificar se o servidor responde.
@@ -12,23 +13,34 @@ async function verifyConnection() {
     if (!navigator.onLine) {
         checkBtn.style.color = 'var(--color-red)';
         icon.classList.remove('rotating');
+        icon.classList.remove('fa-check');
+        icon.classList.add('fa-sync-alt');
         return;
     }
     try {
         const resp = await fetch('http://localhost:3000/status', { cache: 'no-store' });
         if (resp.ok) {
             checkBtn.style.color = 'var(--color-green)';
-            if (!icon.classList.contains('rotating')) icon.classList.add('rotating');
+            icon.classList.remove('rotating');
+            icon.classList.remove('fa-sync-alt');
+            icon.classList.add('fa-check');
+            clearTimeout(checkTimeout);
+            checkTimeout = setTimeout(() => {
+                icon.classList.remove('fa-check');
+                icon.classList.add('fa-sync-alt', 'rotating');
+            }, 2000);
         } else {
             throw new Error('Status não OK');
         }
     } catch (err) {
         checkBtn.style.color = 'var(--color-red)';
+        icon.classList.remove('fa-check');
         icon.classList.remove('rotating');
+        icon.classList.add('fa-sync-alt');
     }
 }
 
-// verifica ao iniciar e a cada 30s
+// verifica ao iniciar e a cada 10s
 verifyConnection();
 if (checkBtn) checkBtn.addEventListener('click', verifyConnection);
-setInterval(verifyConnection, 30000);
+setInterval(verifyConnection, 10000);


### PR DESCRIPTION
## Summary
- show a check icon briefly when the connection is OK
- perform connection check every 10s

## Testing
- `npm install`
- `npm start` *(fails: libatk-1.0.so.0 missing)*
- `npm run verify-smtp` *(fails: connect ECONNREFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_6887b92065548322bbe5832e1c51f5ec