### PR TITLE
Fix module loading structure

### DIFF
--- a/src/css/calendario.css
+++ b/src/css/calendario.css
@@ -14,9 +14,10 @@
     --neutral-500: #6b7280;
 }
 
+/* Uso do background global da aplicação */
 body {
-    background: linear-gradient(135deg, var(--color-bg-deep) 0%, #1a0009 100%);
-    min-height: 100vh;
+    background: transparent;
+    min-height: auto;
 }
 
 .glass-surface {

--- a/src/css/clientes.css
+++ b/src/css/clientes.css
@@ -14,9 +14,10 @@
     --neutral-500: #6b7280;
 }
 
+/* Uso do background global da aplicação */
 body {
-    background: linear-gradient(135deg, var(--color-bg-deep) 0%, #1a0009 100%);
-    min-height: 100vh;
+    background: transparent;
+    min-height: auto;
 }
 
 .glass-surface {

--- a/src/css/contatos.css
+++ b/src/css/contatos.css
@@ -15,9 +15,10 @@
     --neutral-500: #6b7280;
 }
 
+/* Uso do background global da aplicação */
 body {
-    background: linear-gradient(135deg, var(--color-bg-deep) 0%, #1a0009 100%);
-    min-height: 100vh;
+    background: transparent;
+    min-height: auto;
 }
 
 .glass-surface {

--- a/src/css/materia-prima.css
+++ b/src/css/materia-prima.css
@@ -14,9 +14,10 @@
     --neutral-500: #6b7280;
 }
 
+/* Uso do background global da aplicação */
 body {
-    background: linear-gradient(135deg, var(--color-bg-deep) 0%, #1a0009 100%);
-    min-height: 100vh;
+    background: transparent;
+    min-height: auto;
 }
 
 .glass-surface {

--- a/src/css/orcamentos.css
+++ b/src/css/orcamentos.css
@@ -14,9 +14,10 @@
     --neutral-500: #6b7280;
 }
 
+/* Uso do background global da aplicação */
 body {
-    background: linear-gradient(135deg, var(--color-bg-deep) 0%, #1a0009 100%);
-    min-height: 100vh;
+    background: transparent;
+    min-height: auto;
 }
 
 .glass-surface {

--- a/src/css/produtos.css
+++ b/src/css/produtos.css
@@ -15,9 +15,10 @@
     --neutral-500: #6b7280;
 }
 
+/* Uso do background global da aplicação */
 body {
-    background: linear-gradient(135deg, var(--color-bg-deep) 0%, #1a0009 100%);
-    min-height: 100vh;
+    background: transparent;
+    min-height: auto;
 }
 
 .glass-surface {

--- a/src/css/prospeccoes.css
+++ b/src/css/prospeccoes.css
@@ -14,9 +14,10 @@
     --neutral-500: #6b7280;
 }
 
+/* Uso do background global da aplicação */
 body {
-    background: linear-gradient(135deg, var(--color-bg-deep) 0%, #1a0009 100%);
-    min-height: 100vh;
+    background: transparent;
+    min-height: auto;
 }
 
 .glass-surface {

--- a/src/css/tarefas.css
+++ b/src/css/tarefas.css
@@ -14,9 +14,10 @@
     --neutral-500: #6b7280;
 }
 
+/* Uso do background global da aplicação */
 body {
-    background: linear-gradient(135deg, var(--color-bg-deep) 0%, #1a0009 100%);
-    min-height: 100vh;
+    background: transparent;
+    min-height: auto;
 }
 
 .glass-surface {

--- a/src/css/usuarios.css
+++ b/src/css/usuarios.css
@@ -16,9 +16,10 @@
     --neutral-500: #6b7280;
 }
 
+/* Uso do background global da aplicação */
 body {
-    background: linear-gradient(135deg, var(--color-bg-deep) 0%, #1a0009 100%);
-    min-height: 100vh;
+    background: transparent;
+    min-height: auto;
 }
 
 .glass-surface {

--- a/src/html/clientes.html
+++ b/src/html/clientes.html
@@ -1,18 +1,6 @@
-<!-- Interface principal do módulo de Clientes (CRM) -->
-<!DOCTYPE html>
-<html lang="pt-BR">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Clientes - Santíssimo Decor</title>
-    <!-- Tailwind for quick layout -->
-    <script src="https://cdn.tailwindcss.com"></script>
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
-    <!-- Estilos específicos do módulo -->
-    <link rel="stylesheet" href="../css/clientes.css">
-</head>
-<body class="text-white p-6">
-    <div class="max-w-7xl mx-auto">
+<!-- Interface principal do módulo de Clientes (CRM)
+     Removido html/head/body para carregamento via menu -->
+<div class="max-w-7xl mx-auto">
         <!-- Header -->
         <div class="flex justify-between items-center mb-8 animate-fade-in-up">
             <div>
@@ -205,5 +193,3 @@
             </div>
         </div>
     </div>
-</body>
-</html>

--- a/src/html/contatos.html
+++ b/src/html/contatos.html
@@ -1,16 +1,6 @@
-<!DOCTYPE html>
-<html lang="pt-BR">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Contatos - Santíssimo Decor</title>
-    <script src="https://cdn.tailwindcss.com"></script>
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
-    <!-- Estilos exclusivos do módulo de Contatos -->
-    <link rel="stylesheet" href="../css/contatos.css">
-</head>
-<body class="text-white p-6">
-    <div class="max-w-7xl mx-auto">
+<!-- Conteúdo principal do módulo Contatos
+     Estrutura reduzida para injeção via menu -->
+<div class="max-w-7xl mx-auto">
         <!-- Header -->
         <div class="flex justify-between items-center mb-8 animate-fade-in-up">
             <div>
@@ -209,5 +199,3 @@
             </div>
         </div>
     </div>
-</body>
-</html>

--- a/src/html/materia-prima.html
+++ b/src/html/materia-prima.html
@@ -1,16 +1,6 @@
-<!DOCTYPE html>
-<html lang="pt-BR">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Matéria-Prima - Santíssimo Decor</title>
-    <script src="https://cdn.tailwindcss.com"></script>
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
-    <!-- Estilos específicos do módulo -->
-    <link rel="stylesheet" href="../css/materia-prima.css">
-</head>
-<body class="text-white p-6">
-    <div class="max-w-7xl mx-auto">
+<!-- Conteúdo do módulo Matéria-Prima
+     Removido html/head/body para uso embutido no menu -->
+<div class="max-w-7xl mx-auto">
         <!-- Matéria-Prima Header -->
         <div class="mb-8 animate-fade-in-up">
             <h1 class="text-3xl font-bold mb-2">Estoque de Matéria-Prima</h1>
@@ -91,6 +81,4 @@
         </div>
     </div>
 
-    <script src="../js/materia-prima.js"></script>
-</body>
-</html>
+

--- a/src/html/pedidos.html
+++ b/src/html/pedidos.html
@@ -1,14 +1,6 @@
-<!-- Tela de Pedidos: lista e controle de pedidos -->
-<!DOCTYPE html>
-<html lang="pt-BR">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Pedidos - Santíssimo Decor</title>
-    <!-- Tailwind e ícones carregados no documento principal -->
-</head>
-<body class="text-white p-6">
-    <div class="max-w-7xl mx-auto">
+<!-- Tela de Pedidos: lista e controle de pedidos
+     Estrutura simplificada para injeção via menu -->
+<div class="max-w-7xl mx-auto">
         <div class="mb-8 animate-fade-in-up">
             <h1 class="text-2xl font-semibold mb-2">Pedidos</h1>
             <p style="color: var(--color-violet)">Acompanhe o status de produção e entrega dos pedidos</p>
@@ -103,5 +95,3 @@
             </div>
         </div>
     </div>
-</body>
-</html>

--- a/src/html/produtos.html
+++ b/src/html/produtos.html
@@ -1,15 +1,6 @@
-<!DOCTYPE html>
-<html lang="pt-BR">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Produtos - Santíssimo Decor</title>
-    <script src="https://cdn.tailwindcss.com"></script>
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
-    <link rel="stylesheet" href="../css/produtos.css">
-</head>
-<body class="text-white p-6">
-    <div class="max-w-7xl mx-auto">
+<!-- Conteúdo do módulo Produtos
+     Estrutura reduzida para inserção via menu -->
+<div class="max-w-7xl mx-auto">
         <!-- Header -->
         <div class="mb-8 animate-fade-in-up">
             <h1 class="text-3xl font-bold mb-2">Produtos</h1>
@@ -232,5 +223,3 @@
             </div>
         </div>
     </div>
-</body>
-</html>

--- a/src/html/prospeccoes.html
+++ b/src/html/prospeccoes.html
@@ -1,16 +1,6 @@
-<!DOCTYPE html>
-<html lang="pt-BR">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Prospecções - Santíssimo Decor</title>
-    <script src="https://cdn.tailwindcss.com"></script>
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
-    <!-- Estilos exclusivos da página de Prospecções -->
-    <link rel="stylesheet" href="../css/prospeccoes.css">
-</head>
-<body class="text-white p-6">
-    <div class="max-w-7xl mx-auto">
+<!-- Conteúdo do módulo Prospecções
+     Estrutura limpa para carregamento no menu -->
+<div class="max-w-7xl mx-auto">
         <!-- Header -->
         <div class="mb-8 animate-fade-in-up">
             <h1 class="text-2xl font-semibold mb-2">Prospecções</h1>
@@ -257,5 +247,3 @@
             </div>
         </div>
     </div>
-</body>
-</html>

--- a/src/html/tarefas.html
+++ b/src/html/tarefas.html
@@ -1,17 +1,6 @@
-<!-- Página principal do módulo Tarefas (CRM) -->
-<!DOCTYPE html>
-<html lang="pt-BR">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Tarefas - Santíssimo Decor</title>
-    <script src="https://cdn.tailwindcss.com"></script>
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
-    <!-- Estilos específicos -->
-    <link rel="stylesheet" href="../css/tarefas.css">
-</head>
-<body class="text-white p-6">
-    <div class="max-w-7xl mx-auto">
+<!-- Página principal do módulo Tarefas (CRM)
+     Estrutura enxuta para carregamento via menu -->
+<div class="max-w-7xl mx-auto">
         <!-- Header -->
         <div class="mb-6 animate-fade-in-up">
             <h1 class="text-2xl font-semibold mb-2">Tarefas</h1>
@@ -224,5 +213,3 @@
             <i class="fas fa-plus w-5 h-5"></i>
         </button>
     </div>
-</body>
-</html>

--- a/src/html/usuarios.html
+++ b/src/html/usuarios.html
@@ -1,17 +1,6 @@
-<!DOCTYPE html>
-<!-- Tela principal do módulo Usuários -->
-<html lang="pt-BR">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Gestão de Usuários - Santíssimo Decor</title>
-    <script src="https://cdn.tailwindcss.com"></script>
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
-    <!-- Estilos específicos do módulo -->
-    <link rel="stylesheet" href="../css/usuarios.css">
-</head>
-<body class="text-white p-6">
-    <div class="max-w-7xl mx-auto">
+<!-- Tela principal do módulo Usuários
+     HTML enxuto para carregamento pelo menu -->
+<div class="max-w-7xl mx-auto">
         <!-- Header -->
         <div class="flex items-center justify-between mb-6 animate-fade-in-up">
             <h1 class="text-2xl font-semibold">Gestão de Usuários</h1>
@@ -138,5 +127,3 @@
             </div>
         </div>
     </div>
-</body>
-</html>


### PR DESCRIPTION
## Summary
- strip duplicate page structure from module HTML files so menu loads only inner content
- rely on main layout background for modules
- remove body backgrounds from module-specific CSS

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6887b97a6e708322b16dc64975a5cfcd