### PR TITLE
Fix sidebar active style

### DIFF
--- a/src/css/menu.css
+++ b/src/css/menu.css
@@ -54,20 +54,29 @@ body {
     }
 }
 
-.sidebar-item {
-    transition: all 150ms ease;
+.sidebar-item,
+.submenu-item {
+    /* Default menu color and smooth transition */
+    color: var(--color-violet);
+    transition: color 0.2s ease, background 150ms ease;
     cursor: pointer;
 }
 
+/* Icons and text follow parent color */
+.sidebar-item i, .submenu-item i,
+.sidebar-item span, .submenu-item span {
+    color: inherit;
+    transition: color 0.2s ease;
+}
+/* Highlight item on hover */
 .sidebar-item:hover { background: rgba(182, 160, 62, 0.1); }
+
+/* Active/selected state */
 .sidebar-item.active,
 .submenu-item.active {
     background: rgba(182, 160, 62, 0.15);
-}
-
-.sidebar-item.active span,
-.submenu-item.active span {
-    color: var(--color-primary);
+    color: #ffffff;
+    font-weight: 600;
 }
 
 .sidebar-expanded { width: 240px; }

--- a/src/html/menu.html
+++ b/src/html/menu.html
@@ -73,31 +73,31 @@
             </div>
 
             <!-- Matéria Prima -->
-            <div class="sidebar-item flex items-center p-3 rounded-lg" style="color: var(--color-violet)" data-page="materia-prima">
+            <div class="sidebar-item flex items-center p-3 rounded-lg" data-page="materia-prima">
                 <i class="fas fa-boxes w-5 h-5 flex-shrink-0"></i>
                 <span class="sidebar-text ml-3 whitespace-nowrap">Matéria Prima</span>
             </div>
 
             <!-- Produtos -->
-            <div class="sidebar-item flex items-center p-3 rounded-lg" style="color: var(--color-violet)" data-page="produtos">
+            <div class="sidebar-item flex items-center p-3 rounded-lg" data-page="produtos">
                 <i class="fas fa-cube w-5 h-5 flex-shrink-0"></i>
                 <span class="sidebar-text ml-3 whitespace-nowrap">Produtos</span>
             </div>
 
             <!-- Orçamentos -->
-            <div class="sidebar-item flex items-center p-3 rounded-lg" style="color: var(--color-violet)" data-page="orcamentos">
+            <div class="sidebar-item flex items-center p-3 rounded-lg" data-page="orcamentos">
                 <i class="fas fa-file-invoice-dollar w-5 h-5 flex-shrink-0"></i>
                 <span class="sidebar-text ml-3 whitespace-nowrap">Orçamentos</span>
             </div>
 
             <!-- Pedidos -->
-            <div class="sidebar-item flex items-center p-3 rounded-lg" style="color: var(--color-violet)" data-page="pedidos">
+            <div class="sidebar-item flex items-center p-3 rounded-lg" data-page="pedidos">
                 <i class="fas fa-shopping-cart w-5 h-5 flex-shrink-0"></i>
                 <span class="sidebar-text ml-3 whitespace-nowrap">Pedidos</span>
             </div>
 
             <!-- CRM -->
-            <div class="sidebar-item flex items-center justify-between p-3 rounded-lg" style="color: var(--color-violet)" id="crmToggle">
+            <div class="sidebar-item flex items-center justify-between p-3 rounded-lg" id="crmToggle">
                 <div class="flex items-center">
                     <i class="fas fa-users w-5 h-5 flex-shrink-0"></i>
                     <span class="sidebar-text ml-3 whitespace-nowrap">CRM</span>
@@ -107,48 +107,48 @@
 
             <!-- CRM Submenu -->
             <div class="submenu" id="crmSubmenu">
-                <div class="submenu-item flex items-center py-2 px-3 rounded-lg" style="color: var(--color-violet)" data-page="clientes">
+                <div class="submenu-item flex items-center py-2 px-3 rounded-lg" data-page="clientes">
                     <i class="fas fa-user-friends w-4 h-4 flex-shrink-0"></i>
                     <span class="sidebar-text ml-3 whitespace-nowrap">Clientes</span>
                 </div>
-                <div class="submenu-item flex items-center py-2 px-3 rounded-lg" style="color: var(--color-violet)" data-page="prospeccoes">
+                <div class="submenu-item flex items-center py-2 px-3 rounded-lg" data-page="prospeccoes">
                     <i class="fas fa-user-plus w-4 h-4 flex-shrink-0"></i>
                     <span class="sidebar-text ml-3 whitespace-nowrap">Prospecções</span>
                 </div>
-                <div class="submenu-item flex items-center py-2 px-3 rounded-lg" style="color: var(--color-violet)" data-page="contatos">
+                <div class="submenu-item flex items-center py-2 px-3 rounded-lg" data-page="contatos">
                     <i class="fas fa-address-book w-4 h-4 flex-shrink-0"></i>
                     <span class="sidebar-text ml-3 whitespace-nowrap">Contatos</span>
                 </div>
-                <div class="submenu-item flex items-center py-2 px-3 rounded-lg" style="color: var(--color-violet)" data-page="calendario">
+                <div class="submenu-item flex items-center py-2 px-3 rounded-lg" data-page="calendario">
                     <i class="fas fa-calendar-alt w-4 h-4 flex-shrink-0"></i>
                     <span class="sidebar-text ml-3 whitespace-nowrap">Calendário</span>
                 </div>
-                <div class="submenu-item flex items-center py-2 px-3 rounded-lg" style="color: var(--color-violet)" data-page="tarefas">
+                <div class="submenu-item flex items-center py-2 px-3 rounded-lg" data-page="tarefas">
                     <i class="fas fa-tasks w-4 h-4 flex-shrink-0"></i>
                     <span class="sidebar-text ml-3 whitespace-nowrap">Tarefas</span>
                 </div>
             </div>
 
             <!-- IA -->
-            <div class="sidebar-item flex items-center p-3 rounded-lg" style="color: var(--color-violet)" data-page="ia">
+            <div class="sidebar-item flex items-center p-3 rounded-lg" data-page="ia">
                 <i class="fas fa-robot w-5 h-5 flex-shrink-0"></i>
                 <span class="sidebar-text ml-3 whitespace-nowrap">IA</span>
             </div>
 
             <!-- Usuários -->
-            <div class="sidebar-item flex items-center p-3 rounded-lg" style="color: var(--color-violet)" data-page="usuarios">
+            <div class="sidebar-item flex items-center p-3 rounded-lg" data-page="usuarios">
                 <i class="fas fa-user-shield w-5 h-5 flex-shrink-0"></i>
                 <span class="sidebar-text ml-3 whitespace-nowrap">Usuários</span>
             </div>
 
             <!-- Relatórios -->
-            <div class="sidebar-item flex items-center p-3 rounded-lg" style="color: var(--color-violet)" data-page="relatorios">
+            <div class="sidebar-item flex items-center p-3 rounded-lg" data-page="relatorios">
                 <i class="fas fa-chart-bar w-5 h-5 flex-shrink-0"></i>
                 <span class="sidebar-text ml-3 whitespace-nowrap">Relatórios</span>
             </div>
 
             <!-- Configurações -->
-            <div class="sidebar-item flex items-center p-3 rounded-lg" style="color: var(--color-violet)" data-page="configuracoes">
+            <div class="sidebar-item flex items-center p-3 rounded-lg" data-page="configuracoes">
                 <i class="fas fa-cogs w-5 h-5 flex-shrink-0"></i>
                 <span class="sidebar-text ml-3 whitespace-nowrap">Configurações</span>
             </div>

--- a/src/js/menu.js
+++ b/src/js/menu.js
@@ -143,7 +143,10 @@ document.querySelectorAll('.sidebar-item[data-page], .submenu-item[data-page]').
     item.addEventListener('click', function (e) {
         e.stopPropagation();
         // Remove destaque de todos os itens antes de aplicar ao clicado
+
         document.querySelectorAll('.sidebar-item, .submenu-item').forEach(i => i.classList.remove('active'));
+        // Marca item clicado como ativo para aplicar o estilo de destaque
+
         this.classList.add('active');
 
         // Fecha submenu do CRM ao navegar para outros módulos


### PR DESCRIPTION
## Summary
- style sidebar links via CSS instead of inline style
- highlight icons and text in white on active item
- ensure icon color inherits from parent
- show JS comment for active handling

## Testing
- `npm install`
- `npm run verify-smtp` *(fails: connect ECONNREFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_6887bb00b04883229133ac209b6e7a97