### PR TITLE
Remove manual check click

### DIFF
--- a/src/js/checking.js
+++ b/src/js/checking.js
@@ -67,6 +67,5 @@ async function verifyConnection() {
 
 // verifica ao iniciar e a cada 10s
 verifyConnection();
-if (checkBtn) checkBtn.addEventListener('click', verifyConnection);
 intervalId = setInterval(verifyConnection, 10000);
 window.stopServerCheck = () => clearInterval(intervalId);


### PR DESCRIPTION
## Summary
- network status indicator shouldn't be clickable
- drop event listener that triggered manual checks

## Testing
- `npm test` *(fails: Missing script)*
- `npm run verify-smtp` *(fails: connect ECONNREFUSED 127.0.0.1:465)*

------
https://chatgpt.com/codex/tasks/task_e_688b95f827f883228a5a11b986f5fda9