### PR TITLE
Fix CRM submenu collapse behavior

### DIFF
--- a/src/js/menu.js
+++ b/src/js/menu.js
@@ -90,7 +90,8 @@ function toggleCrmSubmenu() {
     } else {
         crmSubmenu.classList.remove('open');
         chevron.classList.remove('rotated');
-        if (window.innerWidth >= 1024) setTimeout(collapseSidebar, 100);
+        // Do not auto-collapse the sidebar when closing the CRM submenu
+        // Sidebar will collapse naturally on mouse leave if needed
     }
 }
 crmToggle.addEventListener('click', toggleCrmSubmenu);


### PR DESCRIPTION
## Summary
- stop collapsing the sidebar when toggling CRM submenu

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688b96896858832294013ccb9cf64a22