### PR TITLE
Improve sidebar branding

### DIFF
--- a/src/css/menu.css
+++ b/src/css/menu.css
@@ -93,6 +93,44 @@ header.glass-surface {
 .sidebar-expanded { width: 240px; }
 .sidebar-collapsed { width: 64px; }
 
+/* Container for logo + brand on sidebar */
+.brand {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 64px; /* same as collapsed width for perfect centering */
+    color: #ffffff;
+    font-family: inherit;
+    transition: all 0.2s ease;
+}
+
+.brand__logo {
+    width: 40px;
+    height: 40px;
+    filter: invert(1); /* ensures white logo when using dark asset */
+    transition: all 0.2s ease;
+}
+
+.brand__text {
+    margin-left: 0.75rem; /* similar spacing as menu items */
+    white-space: nowrap;
+    transition: all 0.2s ease;
+}
+
+/* Hide brand text on collapsed sidebar */
+.sidebar-collapsed .brand__text {
+    width: 0;
+    opacity: 0;
+    overflow: hidden;
+    margin-left: 0;
+}
+
+/* Show brand text when expanded */
+.sidebar-expanded .brand__text {
+    width: auto;
+    opacity: 1;
+}
+
 .sidebar-text {
     opacity: 0;
     transform: translateX(-10px);

--- a/src/html/menu.html
+++ b/src/html/menu.html
@@ -66,6 +66,11 @@
     <!-- Sidebar -->
     <aside id="sidebar" class="fixed left-0 top-14 bottom-0 sidebar-collapsed glass-deep border-r border-white/10 z-40 transition-all duration-300">
         <nav class="p-2 space-y-1">
+            <!-- Logo + marca na sidebar -->
+            <div class="brand">
+                <img src="../assets/Logo%2040x40px.png" alt="Santíssimo Decor" class="brand__logo" />
+                <span class="brand__text">Santíssimo Decor</span>
+            </div>
             <!-- Dashboard -->
             <div class="sidebar-item active flex items-center p-3 rounded-lg" data-page="dashboard">
                 <i class="fas fa-chart-line w-5 h-5 flex-shrink-0"></i>


### PR DESCRIPTION
## Summary
- add brand container with logo and text to sidebar
- style brand elements for collapsed and expanded states

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688ba7dce2548322a4b641e8906bd837