### PR TITLE
Update sidebar logo behavior

### DIFF
--- a/src/css/menu.css
+++ b/src/css/menu.css
@@ -185,7 +185,7 @@ header.glass-surface {
     opacity: 1;
 }
 
-/* Ajuste do tamanho da Logo SideBar */
+/* Ajuste do tamanho da Logo no topo */
 #logoContainer {
     display: flex;
     justify-content: center;
@@ -195,4 +195,24 @@ header.glass-surface {
 #logoContainer img {
     width: 48px !important;
     height: auto !important;
+}
+
+/* Logo dentro da sidebar */
+#sidebarLogo {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+#sidebarLogo img {
+    width: 48px;
+    height: auto;
+}
+
+.sidebar-collapsed #sidebarLogoText {
+    display: none;
+}
+
+.sidebar-expanded #sidebarLogoText {
+    display: inline;
 }

--- a/src/html/menu.html
+++ b/src/html/menu.html
@@ -23,7 +23,7 @@
                 <button id="menuToggle" class="p-2 rounded-lg transition-colors duration-150 hover:bg-white/10 lg:hidden">
                     <i class="fas fa-bars w-5 h-5" style="color: var(--color-primary)"></i>
                 </button>
-                <img src="../assets/Logo%2040x40px.png" alt="Santíssimo Decor" class="w-10 h-10" />
+                <img src="../assets/Logo%20SideBar.png" alt="Santíssimo Decor" class="w-10 h-10" />
                 <span id="companyName" class="text-lg font-semibold" style="color: var(--color-primary)">Santíssimo Decor</span>
             </div>
 
@@ -66,6 +66,10 @@
     <!-- Sidebar -->
     <aside id="sidebar" class="fixed left-0 top-14 bottom-0 sidebar-collapsed glass-deep border-r border-white/10 z-40 transition-all duration-300">
         <nav class="p-2 space-y-1">
+            <div id="sidebarLogo" class="flex justify-center items-center py-4 mb-2">
+                <img src="../assets/Logo%20SideBar.png" alt="Santíssimo Decor" class="w-12 h-auto" />
+                <span id="sidebarLogoText" class="ml-2 font-semibold sidebar-text whitespace-nowrap" style="color: var(--color-primary)">Santíssimo Decor</span>
+            </div>
             <!-- Dashboard -->
             <div class="sidebar-item active flex items-center p-3 rounded-lg" data-page="dashboard">
                 <i class="fas fa-chart-line w-5 h-5 flex-shrink-0"></i>

--- a/src/js/menu.js
+++ b/src/js/menu.js
@@ -58,7 +58,6 @@ function expandSidebar() {
         mainContent.style.marginLeft = window.innerWidth >= 1024 ? '240px' : '200px';
         if (companyName) companyName.style.display = 'inline';
         if (logoContainer) {
-            logoContainer.classList.remove('justify-center');
             logoContainer.style.width = '';
         }
         sidebarExpanded = true;


### PR DESCRIPTION
## Summary
- show 'Logo SideBar.png' everywhere
- add a sidebar logo container for expanded/collapsed states
- keep logo centered when expanding the sidebar

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688bb2befd0c8322b37d55b8fa29e35b