### PR TITLE
Improve dynamic scrollbar detection

### DIFF
--- a/src/js/menu.js
+++ b/src/js/menu.js
@@ -42,6 +42,7 @@ function loadPage(page) {
             const script = document.createElement('script');
             script.id = 'page-script';
             script.src = `../js/${page}.js`;
+            script.onload = () => document.dispatchEvent(new Event('module-change'));
             document.body.appendChild(script);
         });
 }
@@ -141,6 +142,7 @@ async function loadPage(page) {
     try {
         const resp = await fetch(`../html/${page}.html`);
         container.innerHTML = await resp.text();
+        document.dispatchEvent(new Event('module-change'));
 
         document.getElementById('page-style')?.remove();
         document.getElementById('page-script')?.remove();
@@ -153,6 +155,7 @@ async function loadPage(page) {
         const script = document.createElement('script');
         script.id = 'page-script';
         script.src = `../js/${page}.js`;
+        script.onload = () => document.dispatchEvent(new Event('module-change'));
         document.body.appendChild(script);
     } catch (err) {
         console.error('Erro ao carregar página', page, err);

--- a/src/styles/scroll.css
+++ b/src/styles/scroll.css
@@ -34,6 +34,7 @@ body,
 /* Classe aplicada via script quando há overflow */
 .modulo-container.has-scroll {
   overflow-y: auto;
+  padding-right: 5px;              /* offset de 5px para a barra */
 }
 
 
@@ -46,7 +47,7 @@ body,
 
 /* Largura da barra durante hover */
 .modulo-container:hover::-webkit-scrollbar {
-  width: 4px;                     /* ultrafina */
+  width: 3px;                     /* ultrafina de 3px */
 }
 
 /* Trilha transparente */
@@ -73,7 +74,17 @@ body,
   scrollbar-color: #f0c94c transparent;
 }
 
-/* Oculta botões de seta da scrollbar */
+/* Botões de seta visíveis */
 .modulo-container::-webkit-scrollbar-button {
-  display: none;
+  width: 3px;
+  height: 12px;
+  background-color: transparent;
+}
+.modulo-container::-webkit-scrollbar-button:vertical:decrement {
+  background: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMCA2Ij48cG9seWdvbiBwb2ludHM9IjUsMCAxMCw2IDAsNiIgZmlsbD0iI2YwYzk0YyIvPjwvc3ZnPg==') no-repeat center;
+  border-radius: 6px;               /* setas arredondadas */
+}
+.modulo-container::-webkit-scrollbar-button:vertical:increment {
+  background: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMCA2Ij48cG9seWdvbiBwb2ludHM9IjAsMCAxMCwwIDUsNiIgZmlsbD0iI2YwYzk0YyIvPjwvc3ZnPg==') no-repeat center;
+  border-radius: 6px;               /* setas arredondadas */
 }


### PR DESCRIPTION
## Summary
- adjust `.modulo-container` scroll style for a 3px wide bar with 5px offset
- display yellow arrow buttons for scrolling
- trigger overflow check whenever `loadPage()` finishes loading a module

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688bb5587b98832281ca611511a859d3