### PR TITLE
feat: move module scrollbars to left

### DIFF
--- a/src/js/scroll-handler.js
+++ b/src/js/scroll-handler.js
@@ -8,7 +8,9 @@ function ajustarScroll() {
   });
 }
 
-// Executa ao carregar a pagina e quando modulos sao trocados
+// Executa em eventos que podem alterar a altura
 window.addEventListener('DOMContentLoaded', ajustarScroll);
+window.addEventListener('load', ajustarScroll);
+window.addEventListener('resize', ajustarScroll);
 document.addEventListener('module-change', ajustarScroll);
 

--- a/src/styles/scroll.css
+++ b/src/styles/scroll.css
@@ -23,18 +23,24 @@ body,
 
 /* Área com rolagem individual de cada módulo */
 .modulo-container {
-  max-height: calc(100vh - var(--header-height));
+  height: calc(100vh - var(--header-height)); /* corrige altura do container */
   overflow-y: hidden;              /* scroll ativado via classe */
   overflow-x: hidden;
   scrollbar-width: none;           /* oculto até hover */
   scrollbar-color: transparent transparent;
   scrollbar-gutter: stable;        /* evita salto ao mostrar barra */
+  direction: rtl;                  /* posiciona barra à esquerda */
+  box-sizing: border-box;
+}
+
+.modulo-container > * {
+  direction: ltr;
 }
 
 /* Classe aplicada via script quando há overflow */
 .modulo-container.has-scroll {
   overflow-y: auto;
-  padding-right: 5px;              /* offset de 5px para a barra */
+  padding-left: 5px;               /* desloca a barra 5px da esquerda */
 }
 
 


### PR DESCRIPTION
## Summary
- move module scrollbars to left side with 5px offset
- ensure container height covers full viewport and recalc on load/resize

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68910f8986f8832290ce8def575c3a0b