### PR TITLE
refactor: simplify sidebar branding

### DIFF
--- a/src/css/menu.css
+++ b/src/css/menu.css
@@ -197,22 +197,33 @@ header.glass-surface {
     height: auto !important;
 }
 
-/* Logo dentro da sidebar */
-#sidebarLogo {
+/* Logo única da sidebar */
+.brand {
     display: flex;
     justify-content: center;
     align-items: center;
+    transition: all 0.2s ease;
 }
 
-#sidebarLogo img {
+.brand__logo {
     width: 48px;
     height: auto;
+    transition: all 0.2s ease;
 }
 
-.sidebar-collapsed #sidebarLogoText {
-    display: none;
+.brand__text {
+    margin-left: 0.5rem;
+    font-weight: 600;
+    color: #fff;
+    transition: all 0.2s ease;
 }
 
-.sidebar-expanded #sidebarLogoText {
-    display: inline;
+.sidebar.collapsed .brand__text {
+    opacity: 0;
+    width: 0;
+    overflow: hidden;
+}
+
+.sidebar.collapsed .brand {
+    justify-content: center;
 }

--- a/src/html/menu.html
+++ b/src/html/menu.html
@@ -23,7 +23,7 @@
                 <button id="menuToggle" class="p-2 rounded-lg transition-colors duration-150 hover:bg-white/10 lg:hidden">
                     <i class="fas fa-bars w-5 h-5" style="color: var(--color-primary)"></i>
                 </button>
-                <img src="../assets/Logo%20SideBar.png" alt="Santíssimo Decor" class="w-10 h-10" />
+                <img src="../assets/Logo SideBar.png" alt="Santíssimo Decor" class="w-10 h-10" />
                 <span id="companyName" class="text-lg font-semibold" style="color: var(--color-primary)">Santíssimo Decor</span>
             </div>
 
@@ -64,12 +64,13 @@
     </header>
 
     <!-- Sidebar -->
-    <aside id="sidebar" class="fixed left-0 top-14 bottom-0 sidebar-collapsed glass-deep border-r border-white/10 z-40 transition-all duration-300">
+    <aside id="sidebar" class="fixed left-0 top-14 bottom-0 sidebar-collapsed glass-deep border-r border-white/10 z-40 transition-all duration-200">
+        <!-- Bloco de marca único -->
+        <div class="brand py-4 mb-2">
+            <img src="../assets/Logo SideBar.png" class="brand__logo" alt="Santíssimo Decor" />
+            <span class="brand__text">Santíssimo Decor</span>
+        </div>
         <nav class="p-2 space-y-1">
-            <div id="sidebarLogo" class="flex justify-center items-center py-4 mb-2">
-                <img src="../assets/Logo%20SideBar.png" alt="Santíssimo Decor" class="w-12 h-auto" />
-                <span id="sidebarLogoText" class="ml-2 font-semibold sidebar-text whitespace-nowrap" style="color: var(--color-primary)">Santíssimo Decor</span>
-            </div>
             <!-- Dashboard -->
             <div class="sidebar-item active flex items-center p-3 rounded-lg" data-page="dashboard">
                 <i class="fas fa-chart-line w-5 h-5 flex-shrink-0"></i>


### PR DESCRIPTION
## Summary
- replace duplicated logo sections with a single brand block in sidebar header
- style brand for collapse/expand with smooth transitions and centered logo

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68910f927f2c8322b2e5949ae391a546