### PR TITLE
Compacta barra de filtros de produtos e adiciona toggle de estoque

### DIFF
--- a/src/css/produtos.css
+++ b/src/css/produtos.css
@@ -79,7 +79,7 @@ body {
     display: flex;
     flex-wrap: wrap;
     gap: 1rem;
-    align-items: center;
+    align-items: flex-start;
 }
 .filter-field {
     display: flex;
@@ -89,11 +89,21 @@ body {
 .filter-field select {
     height: 3rem;
 }
-.filter-checkbox {
+.price-group {
     display: flex;
-    align-items: center;
+    flex-direction: column;
     gap: 0.5rem;
-    height: 3rem;
+}
+.price-row {
+    display: flex;
+    gap: 1rem;
+    align-items: flex-start;
+}
+.price-field {
+    width: 180px;
+}
+.filter-toggle {
+    margin-top: 1.75rem;
 }
 .filter-actions {
     display: flex;
@@ -102,6 +112,41 @@ body {
 .filter-actions button {
     height: 3rem;
 }
-.max-price input {
-    min-width: 8rem;
+.toggle {
+    appearance: none;
+    width: 3rem;
+    height: 1.5rem;
+    background: var(--color-bordeaux);
+    border-radius: 9999px;
+    position: relative;
+    cursor: pointer;
+    transition: background 150ms ease;
+}
+.toggle::before {
+    content: "";
+    position: absolute;
+    top: 0.125rem;
+    left: 0.125rem;
+    width: 1.25rem;
+    height: 1.25rem;
+    background: white;
+    border-radius: 9999px;
+    transition: transform 150ms ease;
+}
+.toggle:checked {
+    background: var(--color-primary);
+}
+.toggle:checked::before {
+    transform: translateX(1.5rem);
+}
+@media (max-width: 960px) {
+    .filter-bar {
+        flex-direction: column;
+    }
+    .price-row {
+        flex-direction: column;
+    }
+    .price-field {
+        width: 100%;
+    }
 }

--- a/src/html/produtos.html
+++ b/src/html/produtos.html
@@ -49,34 +49,39 @@
                     </select>
                 </div>
 
-                <!-- Price Min -->
-                <div class="filter-field">
-                    <label class="block text-sm font-medium mb-2 text-white">Preço Min.</label>
-                    <div class="relative">
-                        <span class="absolute left-3 top-1/2 transform -translate-y-1/2 text-white/70">R$</span>
-                        <input type="number" class="input-glass text-white rounded-md pl-10 pr-4 h-12 w-full placeholder-white/50">
+                <!-- Price + Actions -->
+                <div class="price-group">
+                    <div class="price-row">
+                        <!-- Price Min -->
+                        <div class="filter-field price-field">
+                            <label class="block text-sm font-medium mb-2 text-white">Preço Min.</label>
+                            <div class="relative">
+                                <span class="absolute left-3 top-1/2 transform -translate-y-1/2 text-white/70">R$</span>
+                                <input type="number" class="input-glass text-white rounded-md pl-10 pr-4 h-12 w-full placeholder-white/50">
+                            </div>
+                        </div>
+
+                        <!-- Price Max -->
+                        <div class="filter-field price-field">
+                            <label class="block text-sm font-medium mb-2 text-white">Preço Máx.</label>
+                            <div class="relative">
+                                <span class="absolute left-3 top-1/2 transform -translate-y-1/2 text-white/70">R$</span>
+                                <input type="number" class="input-glass text-white rounded-md pl-10 pr-4 h-12 w-full placeholder-white/50">
+                            </div>
+                        </div>
+
+                        <!-- Zero Stock Toggle -->
+                        <div class="filter-toggle">
+                            <label for="zeroStock" class="sr-only">0 Estoque</label>
+                            <input type="checkbox" id="zeroStock" class="toggle">
+                        </div>
                     </div>
-                </div>
 
-                <!-- Price Max -->
-                <div class="filter-field max-price">
-                    <label class="block text-sm font-medium mb-2 text-white">Preço Máx.</label>
-                    <div class="relative">
-                        <span class="absolute left-3 top-1/2 transform -translate-y-1/2 text-white/70">R$</span>
-                        <input type="number" class="input-glass text-white rounded-md pl-10 pr-4 h-12 w-full placeholder-white/50">
+                    <!-- Action Buttons -->
+                    <div class="filter-actions">
+                        <button class="btn-secondary text-white rounded-md px-4 font-medium whitespace-nowrap"><i class="fas fa-filter mr-2"></i>Filtrar</button>
+                        <button class="btn-primary text-white rounded-md px-4 font-medium whitespace-nowrap"><i class="fas fa-plus mr-2"></i>Novo</button>
                     </div>
-                </div>
-
-                <!-- Zero Stock Checkbox -->
-                <div class="filter-checkbox">
-                    <input type="checkbox" id="zeroStock" class="rounded border-white/30 text-primary focus:ring-primary">
-                    <label for="zeroStock" class="text-sm text-white">0 Estoque</label>
-                </div>
-
-                <!-- Action Buttons -->
-                <div class="filter-actions">
-                    <button class="btn-secondary text-white rounded-md px-4 font-medium whitespace-nowrap"><i class="fas fa-filter mr-2"></i>Filtrar</button>
-                    <button class="btn-primary text-white rounded-md px-4 font-medium whitespace-nowrap"><i class="fas fa-plus mr-2"></i>Novo</button>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Resumo
- Reduz largura e reorganiza campos de preço em grupo com ações alinhadas abaixo
- Substitui checkbox de estoque por toggle switch com cores do projeto
- Ajusta responsividade da barra de filtros para manter uma linha em telas largas e empilhar abaixo de 960px

## Testes
- `npm test` *(falhou: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68911419fcc88322a09e3b0dde67a0a5