### PR TITLE
Fix sidebar brand duplication and alignment

### DIFF
--- a/src/css/menu.css
+++ b/src/css/menu.css
@@ -219,13 +219,15 @@ header.glass-surface {
     transition: all 0.2s ease;
 }
 
-.sidebar.collapsed .brand__text {
+.sidebar-collapsed .brand__text {
+    /* Esconde texto ao recolher */
     opacity: 0;
     width: 0;
     overflow: hidden;
 }
 
-.sidebar.collapsed .brand {
+.sidebar-collapsed .brand {
+    /* Centraliza a logo na coluna de ícones */
     justify-content: center;
     padding-left: 0;
 }

--- a/src/html/menu.html
+++ b/src/html/menu.html
@@ -65,8 +65,8 @@
 
     <!-- Sidebar -->
     <aside id="sidebar" class="fixed left-0 top-14 bottom-0 sidebar-collapsed glass-deep border-r border-white/10 z-40 transition-all duration-200">
-        <!-- Bloco de marca único (duplicata removida) -->
-        <div class="brand py-4 mb-2">
+        <!-- Marca única (duplicata removida) -->
+        <div class="brand p-3 mb-2">
             <img src="../assets/Logo SideBar.png" class="brand__logo" alt="Santíssimo Decor" />
             <span class="brand__text">Santíssimo Decor</span>
         </div>


### PR DESCRIPTION
## Summary
- ensure sidebar contains single brand block with logo and name
- hide brand text and center logo when sidebar collapses

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68911713cdc0832286122f912815ac5a