### PR TITLE
Fix sidebar not collapsing on mouse leave

### DIFF
--- a/src/js/menu.js
+++ b/src/js/menu.js
@@ -80,10 +80,10 @@ function collapseSidebar() {
     // Submenu CRM permanece aberto; fechamento apenas via clique
 }
 
-// Comportamento desktop: expande ao passar o mouse
-// Mouseleave removido para evitar fechamento automático do submenu
+// Comportamento desktop: expande ao passar o mouse e recolhe ao sair
 if (window.innerWidth >= 1024) {
     sidebar.addEventListener('mouseenter', expandSidebar);
+    sidebar.addEventListener('mouseleave', collapseSidebar);
 }
 
 // Alterna sidebar no mobile


### PR DESCRIPTION
## Summary
- Collapse sidebar when mouse leaves the sidebar area on desktop.

## Testing
- `npm test` *(fails: Missing script 'test')*


------
https://chatgpt.com/codex/tasks/task_e_689117aa8a748322b36fdeeb983aa3b7