### PR TITLE
refactor: remove brand from sidebar

### DIFF
--- a/src/html/menu.html
+++ b/src/html/menu.html
@@ -65,11 +65,7 @@
 
     <!-- Sidebar -->
     <aside id="sidebar" class="fixed left-0 top-14 bottom-0 sidebar-collapsed glass-deep border-r border-white/10 z-40 transition-all duration-200">
-        <!-- Marca única (duplicata removida) -->
-        <div class="brand p-3 mb-2">
-            <img src="../assets/Logo SideBar.png" class="brand__logo" alt="Santíssimo Decor" />
-            <span class="brand__text">Santíssimo Decor</span>
-        </div>
+        <!-- Marca removida da sidebar -->
         <nav class="p-2 space-y-1">
             <!-- Dashboard -->
             <div class="sidebar-item active flex items-center p-3 rounded-lg" data-page="dashboard">


### PR DESCRIPTION
## Summary
- remove brand block from sidebar so logo appears only in header

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689123c9d8fc83228303b35f128511e5