### PR TITLE
Unify table header styling across modules

### DIFF
--- a/src/html/materia-prima.html
+++ b/src/html/materia-prima.html
@@ -34,13 +34,13 @@
         <div class="glass-surface rounded-xl overflow-hidden shadow-lg animate-fade-in-up">
             <div class="overflow-x-hidden">
                 <table class="w-full">
-                    <thead class="glass-surface sticky top-0">
+                    <thead class="bg-gray-50 sticky top-0">
                         <tr>
-                            <th class="px-6 py-4 text-left text-xs font-medium uppercase tracking-wider" style="color: var(--color-primary)">Nome</th>
-                            <th class="px-6 py-4 text-left text-xs font-medium uppercase tracking-wider" style="color: var(--color-primary)">Quantidade</th>
-                            <th class="px-6 py-4 text-left text-xs font-medium uppercase tracking-wider" style="color: var(--color-primary)">Unidade</th>
-                            <th class="px-6 py-4 text-left text-xs font-medium uppercase tracking-wider" style="color: var(--color-primary)">Preço Unitário</th>
-                            <th class="px-6 py-4 text-center text-xs font-medium uppercase tracking-wider" style="color: var(--color-primary)">Ações</th>
+                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Nome</th>
+                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Quantidade</th>
+                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Unidade</th>
+                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Preço Unitário</th>
+                            <th class="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">Ações</th>
                         </tr>
                     </thead>
                     <tbody class="divide-y divide-white/10">

--- a/src/html/menu.html
+++ b/src/html/menu.html
@@ -282,14 +282,14 @@
                         </div>
                         <div class="overflow-x-hidden">
                             <table class="w-full">
-                                <thead class="glass-surface sticky top-0">
+                                <thead class="bg-gray-50 sticky top-0">
                                     <tr>
-                                        <th class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider" style="color: var(--color-primary)">ID</th>
-                                        <th class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider" style="color: var(--color-primary)">Cliente</th>
-                                        <th class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider" style="color: var(--color-primary)">Produto</th>
-                                        <th class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider" style="color: var(--color-primary)">Valor</th>
-                                        <th class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider" style="color: var(--color-primary)">Status</th>
-                                        <th class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider" style="color: var(--color-primary)">Data</th>
+                                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">ID</th>
+                                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Cliente</th>
+                                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Produto</th>
+                                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Valor</th>
+                                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
+                                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Data</th>
                                     </tr>
                                 </thead>
                                 <tbody class="divide-y divide-white/10">

--- a/src/html/produtos.html
+++ b/src/html/produtos.html
@@ -93,17 +93,17 @@
         <div class="glass-surface rounded-xl overflow-hidden shadow-lg animate-fade-in-up mt-6">
             <div class="overflow-x-hidden">
                 <table class="w-full">
-                    <thead class="glass-surface sticky top-0">
+                    <thead class="bg-gray-50 sticky top-0">
                         <tr>
-                            <th class="px-6 py-4 text-left text-xs font-medium uppercase tracking-wider" style="color: var(--color-primary)">Código</th>
-                            <th class="px-6 py-4 text-left text-xs font-medium uppercase tracking-wider" style="color: var(--color-primary)">Nome</th>
-                            <th class="px-6 py-4 text-left text-xs font-medium uppercase tracking-wider" style="color: var(--color-primary)">Categoria</th>
-                            <th class="px-6 py-4 text-left text-xs font-medium uppercase tracking-wider" style="color: var(--color-primary)">Custo Insumos (A)</th>
-                            <th class="px-6 py-4 text-left text-xs font-medium uppercase tracking-wider" style="color: var(--color-primary)">Preço de Venda</th>
-                            <th class="px-6 py-4 text-left text-xs font-medium uppercase tracking-wider" style="color: var(--color-primary)">Margem (%)</th>
-                            <th class="px-6 py-4 text-left text-xs font-medium uppercase tracking-wider" style="color: var(--color-primary)">Estoque Atual</th>
-                            <th class="px-6 py-4 text-left text-xs font-medium uppercase tracking-wider" style="color: var(--color-primary)">Status</th>
-                            <th class="px-6 py-4 text-center text-xs font-medium uppercase tracking-wider" style="color: var(--color-primary)">Ações</th>
+                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Código</th>
+                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Nome</th>
+                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Categoria</th>
+                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Custo Insumos (A)</th>
+                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Preço de Venda</th>
+                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Margem (%)</th>
+                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Estoque Atual</th>
+                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
+                            <th class="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">Ações</th>
                         </tr>
                     </thead>
                     <tbody class="divide-y divide-white/10">


### PR DESCRIPTION
## Summary
- style tables in menu, products and raw materials modules to match orders page styling

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68926f6320e0832298576597778ddd71