### PR TITLE
Padroniza status de produtos

### DIFF
--- a/src/css/produtos.css
+++ b/src/css/produtos.css
@@ -45,6 +45,17 @@ body {
     background: rgba(138, 167, 243, 0.9);
 }
 
+/* Status badges */
+.badge-success {
+    background: rgba(162, 255, 166, 0.2);
+    color: var(--color-green);
+}
+
+.badge-danger {
+    background: rgba(255, 88, 88, 0.2);
+    color: var(--color-red);
+}
+
 .input-glass {
     background: rgba(255, 255, 255, 0.1);
     border: 1px solid rgba(255, 255, 255, 0.2);

--- a/src/html/produtos.html
+++ b/src/html/produtos.html
@@ -117,7 +117,7 @@
                             <td class="px-6 py-4 whitespace-nowrap text-sm" style="color: var(--color-green)">166,7%</td>
                             <td class="px-6 py-4 whitespace-nowrap text-sm text-white">25</td>
                             <td class="px-6 py-4 whitespace-nowrap">
-                                <span class="px-3 py-1 rounded-full text-xs font-medium" style="background: rgba(162, 255, 166, 0.2); color: var(--color-green)">Ativo</span>
+                                <span class="badge-success px-3 py-1 rounded-full text-xs font-medium">Ativo</span>
                             </td>
                             <td class="px-6 py-4 whitespace-nowrap text-center">
                                 <div class="flex items-center justify-center space-x-2">
@@ -138,7 +138,7 @@
                             <td class="px-6 py-4 whitespace-nowrap text-sm" style="color: var(--color-green)">150,0%</td>
                             <td class="px-6 py-4 whitespace-nowrap text-sm font-bold" style="color: var(--color-red)">3</td>
                             <td class="px-6 py-4 whitespace-nowrap">
-                                <span class="px-3 py-1 rounded-full text-xs font-medium" style="background: rgba(162, 255, 166, 0.2); color: var(--color-green)">Ativo</span>
+                                <span class="badge-success px-3 py-1 rounded-full text-xs font-medium">Ativo</span>
                             </td>
                             <td class="px-6 py-4 whitespace-nowrap text-center">
                                 <div class="flex items-center justify-center space-x-2">
@@ -159,7 +159,7 @@
                             <td class="px-6 py-4 whitespace-nowrap text-sm" style="color: var(--color-green)">158,8%</td>
                             <td class="px-6 py-4 whitespace-nowrap text-sm text-white">∞</td>
                             <td class="px-6 py-4 whitespace-nowrap">
-                                <span class="px-3 py-1 rounded-full text-xs font-medium" style="background: rgba(162, 255, 166, 0.2); color: var(--color-green)">Ativo</span>
+                                <span class="badge-success px-3 py-1 rounded-full text-xs font-medium">Ativo</span>
                             </td>
                             <td class="px-6 py-4 whitespace-nowrap text-center">
                                 <div class="flex items-center justify-center space-x-2">
@@ -180,7 +180,7 @@
                             <td class="px-6 py-4 whitespace-nowrap text-sm" style="color: var(--color-green)">191,7%</td>
                             <td class="px-6 py-4 whitespace-nowrap text-sm text-white">15</td>
                             <td class="px-6 py-4 whitespace-nowrap">
-                                <span class="px-3 py-1 rounded-full text-xs font-medium" style="background: rgba(255, 88, 88, 0.2); color: var(--color-red)">Inativo</span>
+                                <span class="badge-danger px-3 py-1 rounded-full text-xs font-medium">Inativo</span>
                             </td>
                             <td class="px-6 py-4 whitespace-nowrap text-center">
                                 <div class="flex items-center justify-center space-x-2">
@@ -201,7 +201,7 @@
                             <td class="px-6 py-4 whitespace-nowrap text-sm" style="color: var(--color-green)">164,7%</td>
                             <td class="px-6 py-4 whitespace-nowrap text-sm text-white">12</td>
                             <td class="px-6 py-4 whitespace-nowrap">
-                                <span class="px-3 py-1 rounded-full text-xs font-medium" style="background: rgba(162, 255, 166, 0.2); color: var(--color-green)">Ativo</span>
+                                <span class="badge-success px-3 py-1 rounded-full text-xs font-medium">Ativo</span>
                             </td>
                             <td class="px-6 py-4 whitespace-nowrap text-center">
                                 <div class="flex items-center justify-center space-x-2">
@@ -222,7 +222,7 @@
                             <td class="px-6 py-4 whitespace-nowrap text-sm" style="color: var(--color-green)">167,9%</td>
                             <td class="px-6 py-4 whitespace-nowrap text-sm font-bold" style="color: var(--color-red)">0</td>
                             <td class="px-6 py-4 whitespace-nowrap">
-                                <span class="px-3 py-1 rounded-full text-xs font-medium" style="background: rgba(162, 255, 166, 0.2); color: var(--color-green)">Ativo</span>
+                                <span class="badge-success px-3 py-1 rounded-full text-xs font-medium">Ativo</span>
                             </td>
                             <td class="px-6 py-4 whitespace-nowrap text-center">
                                 <div class="flex items-center justify-center space-x-2">


### PR DESCRIPTION
## Summary
- Adiciona classes de badge reutilizáveis para sucesso e erro no módulo de produtos
- Substitui estilos inline pelos badges padronizados na tabela de produtos

## Testing
- `npm test` *(falha: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6892717ec0d08322bad4dae74588c5e8