### PR TITLE
Padroniza tabelas de produtos e matéria-prima

### DIFF
--- a/src/html/materia-prima.html
+++ b/src/html/materia-prima.html
@@ -4,8 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Matéria-Prima - Santíssimo Decor</title>
-    <script src="https://cdn.tailwindcss.com"></script>
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
+    <!-- Tailwind e ícones carregados no documento principal -->
     <!-- Estilos específicos do módulo -->
     <link rel="stylesheet" href="../css/materia-prima.css">
     <!-- Estilos globais para barras de rolagem -->
@@ -57,12 +56,8 @@
                             <td class="px-6 py-4 whitespace-nowrap text-sm text-white">R$ 85,00</td>
                             <td class="px-6 py-4 whitespace-nowrap text-center">
                                 <div class="flex items-center justify-center space-x-2">
-                                    <button class="p-2 rounded-lg transition-colors duration-150 hover:bg-white/10" style="color: var(--color-primary)" title="Editar">
-                                        <i class="fas fa-edit w-4 h-4"></i>
-                                    </button>
-                                    <button class="p-2 rounded-lg transition-colors duration-150 hover:bg-white/10 hover:text-white" style="color: var(--neutral-500)" title="Excluir">
-                                        <i class="fas fa-trash w-4 h-4"></i>
-                                    </button>
+                                    <i class="fas fa-edit w-5 h-5 cursor-pointer p-1 rounded transition-colors duration-150 hover:bg-white/10" style="color: var(--color-primary)" title="Editar"></i>
+                                    <i class="fas fa-trash w-5 h-5 cursor-pointer p-1 rounded transition-colors duration-150 hover:bg-white/10 hover:text-white" style="color: var(--neutral-500)" title="Excluir"></i>
                                 </div>
                             </td>
                         </tr>
@@ -79,12 +74,8 @@
                             <td class="px-6 py-4 whitespace-nowrap text-sm" style="color: var(--color-red)">R$ 15,90</td>
                             <td class="px-6 py-4 whitespace-nowrap text-center">
                                 <div class="flex items-center justify-center space-x-2">
-                                    <button class="p-2 rounded-lg transition-colors duration-150 hover:bg-white/10" style="color: var(--color-primary)" title="Editar">
-                                        <i class="fas fa-edit w-4 h-4"></i>
-                                    </button>
-                                    <button class="p-2 rounded-lg transition-colors duration-150 hover:bg-white/10 hover:text-white" style="color: var(--neutral-500)" title="Excluir">
-                                        <i class="fas fa-trash w-4 h-4"></i>
-                                    </button>
+                                    <i class="fas fa-edit w-5 h-5 cursor-pointer p-1 rounded transition-colors duration-150 hover:bg-white/10" style="color: var(--color-primary)" title="Editar"></i>
+                                    <i class="fas fa-trash w-5 h-5 cursor-pointer p-1 rounded transition-colors duration-150 hover:bg-white/10 hover:text-white" style="color: var(--neutral-500)" title="Excluir"></i>
                                 </div>
                             </td>
                         </tr>

--- a/src/html/produtos.html
+++ b/src/html/produtos.html
@@ -4,8 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Produtos - Santíssimo Decor</title>
-    <script src="https://cdn.tailwindcss.com"></script>
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
+    <!-- Tailwind e ícones carregados no documento principal -->
     <link rel="stylesheet" href="../css/produtos.css">
     <!-- Estilos globais para barras de rolagem -->
     <link rel="stylesheet" href="../styles/scroll.css">
@@ -121,9 +120,9 @@
                             </td>
                             <td class="px-6 py-4 whitespace-nowrap text-center">
                                 <div class="flex items-center justify-center space-x-2">
-                                    <i class="fas fa-eye p-2 rounded-lg transition-colors duration-150 hover:bg-white/10 cursor-pointer" style="color: var(--color-primary)" title="Visualizar"></i>
-                                    <i class="fas fa-edit p-2 rounded-lg transition-colors duration-150 hover:bg-white/10 cursor-pointer" style="color: var(--color-primary)" title="Editar"></i>
-                                    <i class="fas fa-trash p-2 rounded-lg transition-colors duration-150 hover:bg-gray-800 hover:text-white cursor-pointer" style="color: var(--neutral-500)" title="Excluir"></i>
+                                    <i class="fas fa-eye w-5 h-5 cursor-pointer p-1 rounded transition-colors duration-150 hover:bg-white/10" style="color: var(--color-primary)" title="Visualizar"></i>
+                                    <i class="fas fa-edit w-5 h-5 cursor-pointer p-1 rounded transition-colors duration-150 hover:bg-white/10" style="color: var(--color-primary)" title="Editar"></i>
+                                    <i class="fas fa-trash w-5 h-5 cursor-pointer p-1 rounded transition-colors duration-150 hover:bg-white/10 hover:text-white" style="color: var(--neutral-500)" title="Excluir"></i>
                                 </div>
                             </td>
                         </tr>
@@ -142,9 +141,9 @@
                             </td>
                             <td class="px-6 py-4 whitespace-nowrap text-center">
                                 <div class="flex items-center justify-center space-x-2">
-                                    <i class="fas fa-eye p-2 rounded-lg transition-colors duration-150 hover:bg-white/10 cursor-pointer" style="color: var(--color-primary)" title="Visualizar"></i>
-                                    <i class="fas fa-edit p-2 rounded-lg transition-colors duration-150 hover:bg-white/10 cursor-pointer" style="color: var(--color-primary)" title="Editar"></i>
-                                    <i class="fas fa-trash p-2 rounded-lg transition-colors duration-150 hover:bg-gray-800 hover:text-white cursor-pointer" style="color: var(--neutral-500)" title="Excluir"></i>
+                                    <i class="fas fa-eye w-5 h-5 cursor-pointer p-1 rounded transition-colors duration-150 hover:bg-white/10" style="color: var(--color-primary)" title="Visualizar"></i>
+                                    <i class="fas fa-edit w-5 h-5 cursor-pointer p-1 rounded transition-colors duration-150 hover:bg-white/10" style="color: var(--color-primary)" title="Editar"></i>
+                                    <i class="fas fa-trash w-5 h-5 cursor-pointer p-1 rounded transition-colors duration-150 hover:bg-white/10 hover:text-white" style="color: var(--neutral-500)" title="Excluir"></i>
                                 </div>
                             </td>
                         </tr>
@@ -163,9 +162,9 @@
                             </td>
                             <td class="px-6 py-4 whitespace-nowrap text-center">
                                 <div class="flex items-center justify-center space-x-2">
-                                    <i class="fas fa-eye p-2 rounded-lg transition-colors duration-150 hover:bg-white/10 cursor-pointer" style="color: var(--color-primary)" title="Visualizar"></i>
-                                    <i class="fas fa-edit p-2 rounded-lg transition-colors duration-150 hover:bg-white/10 cursor-pointer" style="color: var(--color-primary)" title="Editar"></i>
-                                    <i class="fas fa-trash p-2 rounded-lg transition-colors duration-150 hover:bg-gray-800 hover:text-white cursor-pointer" style="color: var(--neutral-500)" title="Excluir"></i>
+                                    <i class="fas fa-eye w-5 h-5 cursor-pointer p-1 rounded transition-colors duration-150 hover:bg-white/10" style="color: var(--color-primary)" title="Visualizar"></i>
+                                    <i class="fas fa-edit w-5 h-5 cursor-pointer p-1 rounded transition-colors duration-150 hover:bg-white/10" style="color: var(--color-primary)" title="Editar"></i>
+                                    <i class="fas fa-trash w-5 h-5 cursor-pointer p-1 rounded transition-colors duration-150 hover:bg-white/10 hover:text-white" style="color: var(--neutral-500)" title="Excluir"></i>
                                 </div>
                             </td>
                         </tr>
@@ -184,9 +183,9 @@
                             </td>
                             <td class="px-6 py-4 whitespace-nowrap text-center">
                                 <div class="flex items-center justify-center space-x-2">
-                                    <i class="fas fa-eye p-2 rounded-lg transition-colors duration-150 hover:bg-white/10 cursor-pointer" style="color: var(--color-primary)" title="Visualizar"></i>
-                                    <i class="fas fa-edit p-2 rounded-lg transition-colors duration-150 hover:bg-white/10 cursor-pointer" style="color: var(--color-primary)" title="Editar"></i>
-                                    <i class="fas fa-trash p-2 rounded-lg transition-colors duration-150 hover:bg-gray-800 hover:text-white cursor-pointer" style="color: var(--neutral-500)" title="Excluir"></i>
+                                    <i class="fas fa-eye w-5 h-5 cursor-pointer p-1 rounded transition-colors duration-150 hover:bg-white/10" style="color: var(--color-primary)" title="Visualizar"></i>
+                                    <i class="fas fa-edit w-5 h-5 cursor-pointer p-1 rounded transition-colors duration-150 hover:bg-white/10" style="color: var(--color-primary)" title="Editar"></i>
+                                    <i class="fas fa-trash w-5 h-5 cursor-pointer p-1 rounded transition-colors duration-150 hover:bg-white/10 hover:text-white" style="color: var(--neutral-500)" title="Excluir"></i>
                                 </div>
                             </td>
                         </tr>
@@ -205,9 +204,9 @@
                             </td>
                             <td class="px-6 py-4 whitespace-nowrap text-center">
                                 <div class="flex items-center justify-center space-x-2">
-                                    <i class="fas fa-eye p-2 rounded-lg transition-colors duration-150 hover:bg-white/10 cursor-pointer" style="color: var(--color-primary)" title="Visualizar"></i>
-                                    <i class="fas fa-edit p-2 rounded-lg transition-colors duration-150 hover:bg-white/10 cursor-pointer" style="color: var(--color-primary)" title="Editar"></i>
-                                    <i class="fas fa-trash p-2 rounded-lg transition-colors duration-150 hover:bg-gray-800 hover:text-white cursor-pointer" style="color: var(--neutral-500)" title="Excluir"></i>
+                                    <i class="fas fa-eye w-5 h-5 cursor-pointer p-1 rounded transition-colors duration-150 hover:bg-white/10" style="color: var(--color-primary)" title="Visualizar"></i>
+                                    <i class="fas fa-edit w-5 h-5 cursor-pointer p-1 rounded transition-colors duration-150 hover:bg-white/10" style="color: var(--color-primary)" title="Editar"></i>
+                                    <i class="fas fa-trash w-5 h-5 cursor-pointer p-1 rounded transition-colors duration-150 hover:bg-white/10 hover:text-white" style="color: var(--neutral-500)" title="Excluir"></i>
                                 </div>
                             </td>
                         </tr>
@@ -226,9 +225,9 @@
                             </td>
                             <td class="px-6 py-4 whitespace-nowrap text-center">
                                 <div class="flex items-center justify-center space-x-2">
-                                    <i class="fas fa-eye p-2 rounded-lg transition-colors duration-150 hover:bg-white/10 cursor-pointer" style="color: var(--color-primary)" title="Visualizar"></i>
-                                    <i class="fas fa-edit p-2 rounded-lg transition-colors duration-150 hover:bg-white/10 cursor-pointer" style="color: var(--color-primary)" title="Editar"></i>
-                                    <i class="fas fa-trash p-2 rounded-lg transition-colors duration-150 hover:bg-gray-800 hover:text-white cursor-pointer" style="color: var(--neutral-500)" title="Excluir"></i>
+                                    <i class="fas fa-eye w-5 h-5 cursor-pointer p-1 rounded transition-colors duration-150 hover:bg-white/10" style="color: var(--color-primary)" title="Visualizar"></i>
+                                    <i class="fas fa-edit w-5 h-5 cursor-pointer p-1 rounded transition-colors duration-150 hover:bg-white/10" style="color: var(--color-primary)" title="Editar"></i>
+                                    <i class="fas fa-trash w-5 h-5 cursor-pointer p-1 rounded transition-colors duration-150 hover:bg-white/10 hover:text-white" style="color: var(--neutral-500)" title="Excluir"></i>
                                 </div>
                             </td>
                         </tr>


### PR DESCRIPTION
## Summary
- Unify products and raw materials tables with orders layout
- Remove duplicate Tailwind and icon includes from module pages

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68934d7d68648322bed0d530704d3bfb