### PR TITLE
Add user metrics popover

### DIFF
--- a/src/css/usuarios.css
+++ b/src/css/usuarios.css
@@ -193,3 +193,47 @@ body {
 .filter-bar button {
     height: 48px;
 }
+
+/* Ícone de informações ao lado do título */
+.info-icon {
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    border: 1px solid var(--color-primary);
+    color: var(--color-primary);
+    font-size: 12px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    transition: all 150ms ease;
+}
+
+.info-icon::before {
+    content: 'i';
+    font-weight: bold;
+}
+
+.info-icon:hover {
+    background: var(--color-primary);
+    color: #fff;
+}
+
+/* Popover do resumo */
+.resumo-popover {
+    position: absolute;
+    z-index: 50;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+    opacity: 0;
+    visibility: hidden;
+    transform: translateY(8px);
+    transition: opacity 200ms ease, transform 200ms ease;
+    pointer-events: none;
+}
+
+.resumo-popover.show {
+    opacity: 1;
+    visibility: visible;
+    transform: translateY(0);
+    pointer-events: auto;
+}

--- a/src/html/usuarios.html
+++ b/src/html/usuarios.html
@@ -17,11 +17,36 @@
     <div class="max-w-7xl mx-auto">
         <!-- Header -->
         <div class="flex items-center justify-between mb-6 animate-fade-in-up">
-            <h1 class="text-2xl font-semibold">Gestão de Usuários</h1>
+            <div class="flex items-center gap-2">
+                <h1 class="text-2xl font-semibold">Gestão de Usuários</h1>
+                <!-- Ícone de informações -->
+                <i class="info-icon"></i>
+            </div>
             <button id="btnNovoUsuario" class="btn-primary px-4 py-2 rounded-md text-white font-medium flex items-center gap-2">
                 <i class="fas fa-plus w-4 h-4"></i>
                 Novo Usuário
             </button>
+        </div>
+
+        <!-- Popover de resumo -->
+        <div id="resumoPopover" class="resumo-popover glass-surface rounded-xl p-6 text-white">
+            <h3 class="font-medium mb-4 text-white">Resumo</h3>
+            <div class="text-3xl font-bold text-white mb-2" id="totalUsuarios">247</div>
+            <div class="text-sm text-gray-400 mb-4">Total de usuários</div>
+
+            <!-- Status Distribution -->
+            <div class="flex flex-wrap gap-2 mb-4" id="distribuicaoStatus">
+                <span class="badge-success px-3 py-1 rounded-full text-xs font-medium">189 Ativos</span>
+                <span class="badge-danger px-3 py-1 rounded-full text-xs font-medium">32 Inativos</span>
+                <span class="badge-warning px-3 py-1 rounded-full text-xs font-medium">26 Aguardando</span>
+            </div>
+
+            <!-- Profile Distribution -->
+            <div class="text-sm text-gray-400 space-y-1" id="distribuicaoPerfis">
+                <div>• 12 Administradores</div>
+                <div>• 89 Operacionais</div>
+                <div>• 146 Clientes</div>
+            </div>
         </div>
 
         <!-- Barra de filtros horizontal -->
@@ -68,27 +93,6 @@
                     <button id="aplicarFiltro" class="btn-secondary text-white rounded-md px-4 h-12 text-sm font-medium">Aplicar Filtros</button>
                     <button id="limparFiltro" class="btn-warning text-white rounded-md px-4 h-12 text-sm font-medium">Limpar</button>
                 </div>
-            </div>
-        </div>
-
-        <!-- Resumo de métricas -->
-        <div class="glass-surface rounded-xl p-6 mb-6 animate-fade-in-up">
-            <h3 class="font-medium mb-4 text-white">Resumo</h3>
-            <div class="text-3xl font-bold text-white mb-2" id="totalUsuarios">247</div>
-            <div class="text-sm text-gray-400 mb-4">Total de usuários</div>
-
-            <!-- Status Distribution -->
-            <div class="flex flex-wrap gap-2 mb-4" id="distribuicaoStatus">
-                <span class="badge-success px-3 py-1 rounded-full text-xs font-medium">189 Ativos</span>
-                <span class="badge-danger px-3 py-1 rounded-full text-xs font-medium">32 Inativos</span>
-                <span class="badge-warning px-3 py-1 rounded-full text-xs font-medium">26 Aguardando</span>
-            </div>
-
-            <!-- Profile Distribution -->
-            <div class="text-sm text-gray-400 space-y-1" id="distribuicaoPerfis">
-                <div>• 12 Administradores</div>
-                <div>• 89 Operacionais</div>
-                <div>• 146 Clientes</div>
             </div>
         </div>
 

--- a/src/js/usuarios.js
+++ b/src/js/usuarios.js
@@ -46,6 +46,31 @@ function initUsuarios() {
             console.log('Remover usuário');
         });
     });
+
+    // Controle do popover de resumo
+    const infoIcon = document.querySelector('.info-icon');
+    const resumoPopover = document.getElementById('resumoPopover');
+
+    if (infoIcon && resumoPopover) {
+        const mostrarPopover = () => {
+            const rect = infoIcon.getBoundingClientRect();
+            resumoPopover.style.left = `${rect.left + window.scrollX}px`;
+            resumoPopover.style.top = `${rect.bottom + window.scrollY}px`;
+            resumoPopover.classList.add('show');
+        };
+
+        const ocultarPopover = () => {
+            resumoPopover.classList.remove('show');
+        };
+
+        infoIcon.addEventListener('mouseenter', mostrarPopover);
+        infoIcon.addEventListener('mouseleave', () => {
+            setTimeout(() => {
+                if (!resumoPopover.matches(':hover')) ocultarPopover();
+            }, 100);
+        });
+        resumoPopover.addEventListener('mouseleave', ocultarPopover);
+    }
 }
 
 if (document.readyState === 'loading') {


### PR DESCRIPTION
## Summary
- replace fixed summary panel with hoverable info icon
- style popover with glass background and rounded info icon
- show/hide summary popover via JS

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68935e6917a083228977f45c78256206