### PR TITLE
Remove module-level width and margin restrictions

### DIFF
--- a/src/html/calendario.html
+++ b/src/html/calendario.html
@@ -1,5 +1,5 @@
 <!-- Tela de Calendário (CRM) -->
-<div class="max-w-7xl mx-auto">
+<div>
     <!-- Header -->
     <div class="mb-6 animate-fade-in-up">
         <h1 class="text-2xl font-semibold mb-2">Calendário</h1>

--- a/src/html/clientes.html
+++ b/src/html/clientes.html
@@ -13,9 +13,9 @@
     <!-- Estilos globais para barras de rolagem -->
     <link rel="stylesheet" href="../styles/scroll.css">
 </head>
-<body class="text-white p-6 ">
+<body class="text-white">
   <div class="modulo-container">
-    <div class="max-w-7xl mx-auto">
+    <div>
         <!-- Header -->
         <div class="flex justify-between items-center mb-8 animate-fade-in-up">
             <div>

--- a/src/html/contatos.html
+++ b/src/html/contatos.html
@@ -11,9 +11,9 @@
     <!-- Estilos globais para barras de rolagem -->
     <link rel="stylesheet" href="../styles/scroll.css">
 </head>
-<body class="text-white p-6 ">
+<body class="text-white">
   <div class="modulo-container">
-    <div class="max-w-7xl mx-auto">
+    <div>
         <!-- Header -->
         <div class="flex justify-between items-center mb-8 animate-fade-in-up">
             <div>

--- a/src/html/materia-prima.html
+++ b/src/html/materia-prima.html
@@ -10,9 +10,9 @@
     <!-- Estilos globais para barras de rolagem -->
     <link rel="stylesheet" href="../styles/scroll.css">
 </head>
-<body class="text-white p-6 ">
+<body class="text-white">
   <div class="modulo-container">
-    <div class="max-w-7xl mx-auto">
+    <div>
         <!-- Matéria-Prima Header -->
         <div class="mb-8 animate-fade-in-up">
             <h1 class="text-3xl font-bold mb-2">Estoque de Matéria-Prima</h1>

--- a/src/html/orcamentos.html
+++ b/src/html/orcamentos.html
@@ -1,5 +1,5 @@
 <!-- Página de orçamentos: lista e filtros -->
-<div class="max-w-7xl mx-auto">
+<div>
     <!-- Header -->
     <div class="mb-8 animate-fade-in-up">
         <h1 class="text-2xl font-semibold mb-2">Orçamentos</h1>

--- a/src/html/pedidos.html
+++ b/src/html/pedidos.html
@@ -8,9 +8,9 @@
     <!-- Tailwind e ícones carregados no documento principal -->
     <link rel="stylesheet" href="../styles/scroll.css">
 </head>
-<body class="text-white p-6 ">
+<body class="text-white">
   <div class="modulo-container">
-    <div class="max-w-7xl mx-auto">
+    <div>
         <div class="mb-8 animate-fade-in-up">
             <h1 class="text-2xl font-semibold mb-2">Pedidos</h1>
             <p style="color: var(--color-violet)">Acompanhe o status de produção e entrega dos pedidos</p>

--- a/src/html/produtos.html
+++ b/src/html/produtos.html
@@ -9,9 +9,9 @@
     <!-- Estilos globais para barras de rolagem -->
     <link rel="stylesheet" href="../styles/scroll.css">
 </head>
-<body class="text-white p-6 ">
+<body class="text-white">
   <div class="modulo-container">
-    <div class="max-w-7xl mx-auto">
+    <div>
         <!-- Header -->
         <div class="mb-8 animate-fade-in-up">
             <h1 class="text-3xl font-bold mb-2">Produtos</h1>

--- a/src/html/prospeccoes.html
+++ b/src/html/prospeccoes.html
@@ -11,9 +11,9 @@
     <!-- Estilos globais para barras de rolagem -->
     <link rel="stylesheet" href="../styles/scroll.css">
 </head>
-<body class="text-white p-6 ">
+<body class="text-white">
   <div class="modulo-container">
-    <div class="max-w-7xl mx-auto">
+    <div>
         <!-- Header -->
         <div class="mb-8 animate-fade-in-up">
             <h1 class="text-2xl font-semibold mb-2">Prospecções</h1>

--- a/src/html/tarefas.html
+++ b/src/html/tarefas.html
@@ -12,9 +12,9 @@
     <!-- Estilos globais para barras de rolagem -->
     <link rel="stylesheet" href="../styles/scroll.css">
 </head>
-<body class="text-white p-6 ">
+<body class="text-white">
   <div class="modulo-container">
-    <div class="max-w-7xl mx-auto">
+    <div>
         <!-- Header -->
         <div class="mb-6 animate-fade-in-up">
             <h1 class="text-2xl font-semibold mb-2">Tarefas</h1>

--- a/src/html/usuarios.html
+++ b/src/html/usuarios.html
@@ -12,9 +12,9 @@
     <!-- Estilos globais para barras de rolagem -->
     <link rel="stylesheet" href="../styles/scroll.css">
 </head>
-<body class="text-white p-6 ">
+<body class="text-white">
   <div class="modulo-container">
-    <div class="max-w-7xl mx-auto">
+    <div>
         <!-- Header -->
         <div class="flex items-center justify-between mb-6 animate-fade-in-up">
             <div class="flex items-center gap-2">


### PR DESCRIPTION
## Summary
- Drop hardcoded max-width and margin classes from all module HTML files so each module fills the area defined by `#content`
- Remove extra body padding in modules to rely solely on global layout rules

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6893717fb1f483228a7eb1d06baa177b