### PR TITLE
Remove inner table scroll wrappers

### DIFF
--- a/src/html/clientes.html
+++ b/src/html/clientes.html
@@ -94,9 +94,8 @@
 
         <!-- Clients Table -->
         <div class="glass-surface rounded-xl overflow-hidden shadow-lg animate-fade-in-up">
-            <div class="overflow-x-hidden">
-                <table class="w-full">
-                    <thead class="bg-gray-50 sticky top-0">
+            <table class="w-full">
+                <thead class="bg-gray-50 sticky top-0">
                         <tr>
                             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Nome</th>
                             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">CNPJ</th>
@@ -193,7 +192,6 @@
                         </tr>
                     </tbody>
                 </table>
-            </div>
         </div>
     </div>
 </div>

--- a/src/html/contatos.html
+++ b/src/html/contatos.html
@@ -94,9 +94,8 @@
 
         <!-- Tabela de contatos -->
         <div class="glass-surface rounded-xl overflow-hidden shadow-lg animate-fade-in-up">
-            <div class="overflow-x-hidden">
-                <table class="w-full">
-                    <thead class="bg-gray-50 sticky top-0">
+            <table class="w-full">
+                <thead class="bg-gray-50 sticky top-0">
                         <tr>
                             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Nome</th>
                             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Tipo</th>
@@ -104,8 +103,8 @@
                             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Telefone</th>
                             <th class="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">Ações</th>
                         </tr>
-                    </thead>
-                    <tbody class="divide-y divide-white/10">
+                </thead>
+                <tbody class="divide-y divide-white/10">
                         <!-- Linha 1 -->
                         <tr class="transition-colors duration-150" style="cursor: pointer;" onmouseover="this.style.background='rgba(163, 148, 167, 0.05)'" onmouseout="this.style.background='transparent'">
                             <td class="px-6 py-4 whitespace-nowrap">
@@ -198,7 +197,6 @@
                         </tr>
                     </tbody>
                 </table>
-            </div>
         </div>
     </div>
 </div>

--- a/src/html/materia-prima.html
+++ b/src/html/materia-prima.html
@@ -31,9 +31,8 @@
 
         <!-- Materials Table -->
         <div class="glass-surface rounded-xl overflow-hidden shadow-lg animate-fade-in-up">
-            <div class="overflow-x-hidden">
-                <table class="w-full">
-                    <thead class="bg-gray-50 sticky top-0">
+            <table class="w-full">
+                <thead class="bg-gray-50 sticky top-0">
                         <tr>
                             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Nome</th>
                             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Quantidade</th>
@@ -41,12 +40,11 @@
                             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Preço Unitário</th>
                             <th class="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">Ações</th>
                         </tr>
-                    </thead>
-                    <tbody id="materiaPrimaTableBody" class="divide-y divide-white/10">
+                </thead>
+                <tbody id="materiaPrimaTableBody" class="divide-y divide-white/10">
                         <!-- Linhas geradas dinamicamente -->
                     </tbody>
                 </table>
-            </div>
         </div>
     </div>
 

--- a/src/html/menu.html
+++ b/src/html/menu.html
@@ -287,10 +287,9 @@
                         <div class="px-6 py-4 border-b border-white/10">
                             <h3 class="text-lg font-semibold" style="color: var(--color-primary)">Pedidos Recentes</h3>
                         </div>
-                        <div class="overflow-x-hidden">
-                            <table class="w-full">
-                                <thead class="bg-gray-50 sticky top-0">
-                                    <tr>
+                        <table class="w-full">
+                            <thead class="bg-gray-50 sticky top-0">
+                                <tr>
                                         <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">ID</th>
                                         <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Cliente</th>
                                         <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Produto</th>
@@ -298,9 +297,9 @@
                                         <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
                                         <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Data</th>
                                     </tr>
-                                </thead>
-                                <tbody class="divide-y divide-white/10">
-                                    <tr class="transition-colors duration-150" style="cursor: pointer;" onmouseover="this.style.background='rgba(163, 148, 167, 0.05)'" onmouseout="this.style.background='transparent'">
+                            </thead>
+                            <tbody class="divide-y divide-white/10">
+                                <tr class="transition-colors duration-150" style="cursor: pointer;" onmouseover="this.style.background='rgba(163, 148, 167, 0.05)'" onmouseout="this.style.background='transparent'">
                                         <td class="px-6 py-4 whitespace-nowrap text-sm">#001</td>
                                         <td class="px-6 py-4 whitespace-nowrap text-sm">Maria Silva</td>
                                         <td class="px-6 py-4 whitespace-nowrap text-sm">Sofá Clássico</td>
@@ -342,7 +341,6 @@
                                     </tr>
                                 </tbody>
                             </table>
-                        </div>
                     </div>
 
                     <!-- Action Buttons Demo -->

--- a/src/html/orcamentos.html
+++ b/src/html/orcamentos.html
@@ -52,10 +52,9 @@
 
     <!-- Quotes Table -->
     <div class="glass-surface rounded-xl overflow-hidden shadow-lg animate-fade-in-up">
-        <div class="overflow-x-hidden">
-            <table class="w-full">
-                <thead class="bg-gray-50 sticky top-0">
-                    <tr>
+        <table class="w-full">
+            <thead class="bg-gray-50 sticky top-0">
+                <tr>
                         <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">#</th>
                         <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Cliente</th>
                         <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Data</th>
@@ -64,8 +63,8 @@
                         <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
                         <th class="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">Ações</th>
                     </tr>
-                </thead>
-                <tbody class="divide-y divide-white/10">
+            </thead>
+            <tbody class="divide-y divide-white/10">
                     <!-- Quote 1 -->
                     <tr class="transition-colors duration-150" style="cursor: pointer;" onmouseover="this.style.background='rgba(163, 148, 167, 0.05)'" onmouseout="this.style.background='transparent'">
                         <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-white">ORC001</td>
@@ -212,6 +211,5 @@
                     </tr>
                 </tbody>
             </table>
-        </div>
     </div>
 </div>

--- a/src/html/pedidos.html
+++ b/src/html/pedidos.html
@@ -39,9 +39,8 @@
             </div>
         </div>
         <div class="glass-surface rounded-xl overflow-hidden shadow-lg animate-fade-in-up">
-            <div class="overflow-x-hidden">
-                <table class="w-full">
-                    <thead class="bg-gray-50 sticky top-0">
+            <table class="w-full">
+                <thead class="bg-gray-50 sticky top-0">
                         <tr>
                             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">#</th>
                             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Cliente</th>
@@ -50,8 +49,8 @@
                             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
                             <th class="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">Ações</th>
                         </tr>
-                    </thead>
-                    <tbody class="divide-y divide-white/10">
+                </thead>
+                <tbody class="divide-y divide-white/10">
                         <tr class="transition-colors duration-150" style="cursor: pointer;" onmouseover="this.style.background='rgba(163, 148, 167, 0.05)'" onmouseout="this.style.background='transparent'">
                             <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-white">PED001</td>
                             <td class="px-6 py-4 whitespace-nowrap text-sm text-white">Ana Carolina Mendes</td>
@@ -102,7 +101,6 @@
                         </tr>
                     </tbody>
                 </table>
-            </div>
         </div>
     </div>
     </div>

--- a/src/html/produtos.html
+++ b/src/html/produtos.html
@@ -90,9 +90,8 @@
 
         <!-- Products Table -->
         <div class="glass-surface rounded-xl overflow-hidden shadow-lg animate-fade-in-up mt-6">
-            <div class="overflow-x-hidden">
-                <table class="w-full">
-                    <thead class="bg-gray-50 sticky top-0">
+            <table class="w-full">
+                <thead class="bg-gray-50 sticky top-0">
                         <tr>
                             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Código</th>
                             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Nome</th>
@@ -197,7 +196,6 @@
                         </tr>
                     </tbody>
                 </table>
-            </div>
         </div>
     </div>
 </div>

--- a/src/html/prospeccoes.html
+++ b/src/html/prospeccoes.html
@@ -178,20 +178,19 @@
 
                 <!-- Leads Table -->
                 <div class="glass-surface shadow rounded-xl overflow-hidden">
-                    <div class="overflow-x-hidden">
-                        <table class="w-full">
-                            <thead class="bg-gray-50 sticky top-0">
-                                <tr>
+                    <table class="w-full">
+                        <thead class="bg-gray-50 sticky top-0">
+                            <tr>
                                     <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Nome do Lead</th>
                                     <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">E-mail</th>
                                     <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
                                     <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Responsável</th>
                                     <th class="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">Ações</th>
                                 </tr>
-                            </thead>
-                            <tbody class="divide-y divide-white/10">
-                                <!-- Lead 1 -->
-                                <tr class="transition-colors duration-150" style="cursor: pointer;" onmouseover="this.style.background='rgba(163, 148, 167, 0.05)'" onmouseout="this.style.background='transparent'">
+                        </thead>
+                        <tbody class="divide-y divide-white/10">
+                            <!-- Lead 1 -->
+                            <tr class="transition-colors duration-150" style="cursor: pointer;" onmouseover="this.style.background='rgba(163, 148, 167, 0.05)'" onmouseout="this.style.background='transparent'">
                                     <td class="px-6 py-4 whitespace-nowrap text-sm text-white">Ana Carolina Mendes</td>
                                     <td class="px-6 py-4 whitespace-nowrap text-sm" style="color: var(--color-violet)">ana.mendes@email.com</td>
                                     <td class="px-6 py-4 whitespace-nowrap">
@@ -255,7 +254,6 @@
                                 </tr>
                             </tbody>
                         </table>
-                    </div>
                 </div>
             </div>
         </div>

--- a/src/html/usuarios.html
+++ b/src/html/usuarios.html
@@ -98,10 +98,9 @@
 
         <!-- Users Table -->
         <div class="glass-surface rounded-xl overflow-hidden animate-fade-in-up">
-            <div class="overflow-x-hidden">
-                <table class="w-full">
-                    <thead class="sticky top-0 bg-gray-50">
-                        <tr>
+            <table class="w-full">
+                <thead class="sticky top-0 bg-gray-50">
+                    <tr>
                             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Avatar</th>
                             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Nome</th>
                             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">E-mail</th>
@@ -109,8 +108,8 @@
                             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
                             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Ações</th>
                         </tr>
-                    </thead>
-                    <tbody class="divide-y divide-white/10" id="listaUsuarios">
+                </thead>
+                <tbody class="divide-y divide-white/10" id="listaUsuarios">
                         <tr class="table-row">
                             <td class="px-6 py-4">
                                 <div class="w-9 h-9 rounded-full flex items-center justify-center text-white font-medium text-sm" style="background: var(--color-primary)">MS</div>
@@ -135,7 +134,6 @@
                         </tr>
                     </tbody>
                 </table>
-            </div>
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- remove `overflow-x-hidden` wrappers around tables so they rely on module scrollbars

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_6893814cc6e8832284cf52cda7a95523