### PR TITLE
feat: enable custom table scrolling

### DIFF
--- a/src/html/clientes.html
+++ b/src/html/clientes.html
@@ -93,7 +93,7 @@
         </div>
 
         <!-- Clients Table -->
-        <div class="glass-surface rounded-xl overflow-hidden shadow-lg animate-fade-in-up">
+        <div class="glass-surface rounded-xl shadow-lg animate-fade-in-up table-scroll">
             <table class="w-full">
                 <thead class="bg-gray-50 sticky top-0">
                         <tr>

--- a/src/html/contatos.html
+++ b/src/html/contatos.html
@@ -93,7 +93,7 @@
         </div>
 
         <!-- Tabela de contatos -->
-        <div class="glass-surface rounded-xl overflow-hidden shadow-lg animate-fade-in-up">
+        <div class="glass-surface rounded-xl shadow-lg animate-fade-in-up table-scroll">
             <table class="w-full">
                 <thead class="bg-gray-50 sticky top-0">
                         <tr>

--- a/src/html/materia-prima.html
+++ b/src/html/materia-prima.html
@@ -30,7 +30,7 @@
         </div>
 
         <!-- Materials Table -->
-        <div class="glass-surface rounded-xl overflow-hidden shadow-lg animate-fade-in-up">
+        <div class="glass-surface rounded-xl shadow-lg animate-fade-in-up table-scroll">
             <table class="w-full">
                 <thead class="bg-gray-50 sticky top-0">
                         <tr>

--- a/src/html/menu.html
+++ b/src/html/menu.html
@@ -281,7 +281,7 @@
                     </div>
 
                     <!-- Summary Table -->
-                    <div class="glass-surface rounded-xl overflow-hidden shadow-lg">
+                    <div class="glass-surface rounded-xl shadow-lg table-scroll">
                         <div class="px-6 py-4 border-b border-white/10">
                             <h3 class="text-lg font-semibold" style="color: var(--color-primary)">Pedidos Recentes</h3>
                         </div>

--- a/src/html/orcamentos.html
+++ b/src/html/orcamentos.html
@@ -51,7 +51,7 @@
     </div>
 
     <!-- Quotes Table -->
-    <div class="glass-surface rounded-xl overflow-hidden shadow-lg animate-fade-in-up">
+    <div class="glass-surface rounded-xl shadow-lg animate-fade-in-up table-scroll">
         <table class="w-full">
             <thead class="bg-gray-50 sticky top-0">
                 <tr>

--- a/src/html/pedidos.html
+++ b/src/html/pedidos.html
@@ -38,7 +38,7 @@
                 </div>
             </div>
         </div>
-        <div class="glass-surface rounded-xl overflow-hidden shadow-lg animate-fade-in-up">
+        <div class="glass-surface rounded-xl shadow-lg animate-fade-in-up table-scroll">
             <table class="w-full">
                 <thead class="bg-gray-50 sticky top-0">
                         <tr>

--- a/src/html/produtos.html
+++ b/src/html/produtos.html
@@ -89,7 +89,7 @@
         </div>
 
         <!-- Products Table -->
-        <div class="glass-surface rounded-xl overflow-hidden shadow-lg animate-fade-in-up mt-6">
+        <div class="glass-surface rounded-xl shadow-lg animate-fade-in-up mt-6 table-scroll">
             <table class="w-full">
                 <thead class="bg-gray-50 sticky top-0">
                         <tr>

--- a/src/html/prospeccoes.html
+++ b/src/html/prospeccoes.html
@@ -177,7 +177,7 @@
                 </div>
 
                 <!-- Leads Table -->
-                <div class="glass-surface shadow rounded-xl overflow-hidden">
+                <div class="glass-surface shadow rounded-xl table-scroll">
                     <table class="w-full">
                         <thead class="bg-gray-50 sticky top-0">
                             <tr>

--- a/src/html/usuarios.html
+++ b/src/html/usuarios.html
@@ -97,7 +97,7 @@
         </div>
 
         <!-- Users Table -->
-        <div class="glass-surface rounded-xl overflow-hidden animate-fade-in-up">
+        <div class="glass-surface rounded-xl animate-fade-in-up table-scroll">
             <table class="w-full">
                 <thead class="sticky top-0 bg-gray-50">
                     <tr>

--- a/src/js/scroll-handler.js
+++ b/src/js/scroll-handler.js
@@ -92,8 +92,8 @@ function refreshScrollbar() {
   // Remove barra antiga
   removeScrollbar();
 
-  // Busca todos os módulos
-  const modules = Array.from(document.querySelectorAll('.modulo-container'));
+  // Busca todos os módulos e tabelas com scroll
+  const modules = Array.from(document.querySelectorAll('.modulo-container, .table-scroll'));
   // Filtra pelos que realmente estão visíveis e precisam de scroll
   const visible = modules.filter(m => {
     const rect = m.getBoundingClientRect();

--- a/src/styles/scroll.css
+++ b/src/styles/scroll.css
@@ -28,6 +28,19 @@ html, body, #app, #mainContent, #content {
   display: none;
 }
 
+/* 3a) Scroll personalizado para tabelas */
+.table-scroll {
+  overflow-y: auto;
+  overflow-x: hidden;
+  max-height: calc(var(--module-height) - 200px);
+  padding-right: var(--arrow-size);
+  box-sizing: border-box;
+}
+
+.table-scroll::-webkit-scrollbar {
+  display: none;
+}
+
 /* 5) Container da scrollbar custom (injetado via JS) */
 .scrollbar-container {
   position: fixed;


### PR DESCRIPTION
## Summary
- add `.table-scroll` style to keep tables within the viewport and show a modern custom scrollbar when needed
- extend scroll handler to include `table-scroll` containers
- apply new scroll container to all module tables

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68938fbd2ebc8322972dee48327ece68