### PR TITLE
Ajusta visibilidade das barras de rolagem de tabelas e módulos

### DIFF
--- a/src/js/scroll-handler.js
+++ b/src/js/scroll-handler.js
@@ -26,20 +26,13 @@ function createScrollbar(module) {
     <div class="track"><div class="thumb"></div></div>
     <div class="arrow down">▼</div>
   `;
-  document.body.appendChild(sb);
+  module.appendChild(sb);
   currentScrollbar = sb;
 
   const up    = sb.querySelector('.arrow.up');
   const down  = sb.querySelector('.arrow.down');
   const track = sb.querySelector('.track');
   const thumb = sb.querySelector('.thumb');
-
-  // Posiciona verticalmente junto ao módulo
-  function positionBar() {
-    const r = module.getBoundingClientRect();
-    sb.style.top    = `${r.top}px`;
-    sb.style.height = `${r.height}px`;
-  }
 
   // Atualiza thumb (tamanho e posição)
   function updateThumb() {
@@ -77,13 +70,9 @@ function createScrollbar(module) {
 
   // Sincroniza thumb ao scroll e resize
   module.addEventListener('scroll', updateThumb);
-  window.addEventListener('resize', () => {
-    positionBar();
-    updateThumb();
-  });
+  window.addEventListener('resize', updateThumb);
 
   // Primeira invocação
-  positionBar();
   updateThumb();
 }
 
@@ -92,8 +81,8 @@ function refreshScrollbar() {
   // Remove barra antiga
   removeScrollbar();
 
-  // Busca todos os módulos e tabelas com scroll
-  const modules = Array.from(document.querySelectorAll('.modulo-container, .table-scroll'));
+  // Busca todos os módulos com scroll
+  const modules = Array.from(document.querySelectorAll('.modulo-container'));
   // Filtra pelos que realmente estão visíveis e precisam de scroll
   const visible = modules.filter(m => {
     const rect = m.getBoundingClientRect();

--- a/src/styles/scroll.css
+++ b/src/styles/scroll.css
@@ -33,19 +33,16 @@ html, body, #app, #mainContent, #content {
   overflow-y: auto;
   overflow-x: hidden;
   max-height: calc(var(--module-height) - 200px);
-  padding-right: var(--arrow-size);
   box-sizing: border-box;
 }
 
-.table-scroll::-webkit-scrollbar {
-  display: none;
-}
 
 /* 5) Container da scrollbar custom (injetado via JS) */
 .scrollbar-container {
-  position: fixed;
-  left: 98%;
-  transform: translateX(-50%);
+  position: absolute;
+  top: 0;
+  right: 0;
+  height: 100%;
   width: var(--arrow-size);
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- Exibe a barra de rolagem nativa das tabelas dentro do próprio espaço
- Posiciona a barra de rolagem customizada dentro do módulo e só a mostra quando há overflow

## Testing
- `npm test` (falhou: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_6893a1c8624c8322bcfa3e62353dab92