### PR TITLE
Fix custom scrollbar visibility within modules

### DIFF
--- a/src/js/scroll-handler.js
+++ b/src/js/scroll-handler.js
@@ -26,20 +26,13 @@ function createScrollbar(module) {
     <div class="track"><div class="thumb"></div></div>
     <div class="arrow down">▼</div>
   `;
-  document.body.appendChild(sb);
+  module.appendChild(sb);
   currentScrollbar = sb;
 
   const up    = sb.querySelector('.arrow.up');
   const down  = sb.querySelector('.arrow.down');
   const track = sb.querySelector('.track');
   const thumb = sb.querySelector('.thumb');
-
-  // Posiciona verticalmente junto ao módulo
-  function positionBar() {
-    const r = module.getBoundingClientRect();
-    sb.style.top    = `${r.top}px`;
-    sb.style.height = `${r.height}px`;
-  }
 
   // Atualiza thumb (tamanho e posição)
   function updateThumb() {
@@ -77,13 +70,9 @@ function createScrollbar(module) {
 
   // Sincroniza thumb ao scroll e resize
   module.addEventListener('scroll', updateThumb);
-  window.addEventListener('resize', () => {
-    positionBar();
-    updateThumb();
-  });
+  window.addEventListener('resize', updateThumb);
 
   // Primeira invocação
-  positionBar();
   updateThumb();
 }
 

--- a/src/styles/scroll.css
+++ b/src/styles/scroll.css
@@ -30,6 +30,7 @@ html, body, #app, #mainContent, #content {
 
 /* 3a) Scroll personalizado para tabelas */
 .table-scroll {
+  position: relative;
   overflow-y: auto;
   overflow-x: hidden;
   max-height: calc(var(--module-height) - 200px);
@@ -43,9 +44,10 @@ html, body, #app, #mainContent, #content {
 
 /* 5) Container da scrollbar custom (injetado via JS) */
 .scrollbar-container {
-  position: fixed;
-  left: 98%;
-  transform: translateX(-50%);
+  position: absolute;
+  top: 0;
+  right: 0;
+  height: 100%;
   width: var(--arrow-size);
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- Ensure table containers reserve space for the custom scrollbar
- Position custom scrollbar inside modules/tables so it appears only when content overflows

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6893a3f1f1f883228925cf6cfac0e54c