### PR TITLE
Add client filtering by owner and status

### DIFF
--- a/src/html/clientes.html
+++ b/src/html/clientes.html
@@ -58,19 +58,23 @@
                 <!-- Search -->
                 <div class="flex-1 min-w-[250px]">
                     <label class="block text-sm font-medium mb-2 text-white">Buscar Cliente</label>
-                    <input type="text" placeholder="Razão ou Fantasia" class="input-glass text-white rounded-md px-4 py-3 w-full">
+                    <input id="searchCliente" list="clientesOptions" type="text" placeholder="Estado, CNPJ ou Razão Social" class="input-glass text-white rounded-md px-4 py-3 w-full">
+                    <datalist id="clientesOptions"></datalist>
                 </div>
 
-                <!-- Segment Select -->
+                <!-- Dono Select -->
                 <div class="flex-1 min-w-[200px]">
-                    <label class="block text-sm font-medium mb-2 text-white">Segmento</label>
-                    <select name="segmento" class="input-glass text-white rounded-md px-4 py-3 w-full">
-                        <option>Todas</option>
-                        <option>Decoração</option>
-                        <option>Arquitetura</option>
-                        <option>Construção</option>
-                        <option>Varejo</option>
-                        <option>Outros</option>
+                    <label class="block text-sm font-medium mb-2 text-white">Dono</label>
+                    <select id="donoSelect" class="input-glass text-white rounded-md px-4 py-3 w-full">
+                        <option value="">Todos</option>
+                    </select>
+                </div>
+
+                <!-- Status Select -->
+                <div class="flex-1 min-w-[200px]">
+                    <label class="block text-sm font-medium mb-2 text-white">Status</label>
+                    <select id="statusSelect" class="input-glass text-white rounded-md px-4 py-3 w-full">
+                        <option value="">Todos</option>
                     </select>
                 </div>
 
@@ -85,9 +89,9 @@
                 </div>
 
                 <!-- Actions -->
-                <div id= "bt-actions" class="flex items-center gap-2">
-                    <button class="btn-secondary text-white rounded-md px-4 py-3 text-sm font-medium">Filtrar</button>
-                    <button class="btn-warning text-white rounded-md px-4 py-3 text-sm font-medium">Limpar</button>
+                <div id="bt-actions" class="flex items-center gap-2">
+                    <button id="filtrarBtn" class="btn-secondary text-white rounded-md px-4 py-3 text-sm font-medium">Filtrar</button>
+                    <button id="limparBtn" class="btn-warning text-white rounded-md px-4 py-3 text-sm font-medium">Limpar</button>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- add search suggestions and dropdown filters for owner and status
- load unique values from clients to populate filter options
- filter client table by search text, owner or status

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_6893a87364b88322a5e0257c3d064dbe