### PR TITLE
Improve materia-prima info popover responsiveness

### DIFF
--- a/src/css/materia-prima.css
+++ b/src/css/materia-prima.css
@@ -108,8 +108,10 @@ body {
 }
 
 .resumo-popover {
-    position: absolute;
-    z-index: 50;
+    position: fixed;
+    top: 0;
+    left: 0;
+    z-index: 9999;
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.555);
     opacity: 0;
     visibility: hidden;

--- a/src/js/materia-prima.js
+++ b/src/js/materia-prima.js
@@ -93,10 +93,26 @@ function renderMateriais(lista) {
         const popover = tr.querySelector(`#popover_${index}`);
         if (infoIcon && popover) {
             const mostrarPopover = () => {
-                const rect = infoIcon.getBoundingClientRect();
-                popover.style.position = 'fixed';
-                popover.style.left = `${rect.left}px`;
-                popover.style.top = `${rect.bottom}px`;
+                const iconRect = infoIcon.getBoundingClientRect();
+                const popRect = popover.getBoundingClientRect();
+
+                let top = iconRect.bottom + 8;
+                let left = iconRect.left + iconRect.width / 2 - popRect.width / 2;
+
+                if (top + popRect.height > window.innerHeight) {
+                    top = iconRect.top - popRect.height - 8;
+                    if (top < 0) {
+                        top = window.innerHeight / 2 - popRect.height / 2;
+                    }
+                }
+
+                if (left + popRect.width > window.innerWidth) {
+                    left = window.innerWidth - popRect.width - 8;
+                }
+                if (left < 8) left = 8;
+
+                popover.style.left = `${left}px`;
+                popover.style.top = `${top}px`;
                 popover.classList.add('show');
             };
 


### PR DESCRIPTION
## Summary
- adapt matéria-prima detail popover to appear near the info icon and stay within viewport bounds
- move popover to top layer, preventing leftover space at bottom of the table

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6893aa5d80588322a49f758e7a17813a