### PR TITLE
Improve popover positioning

### DIFF
--- a/src/css/usuarios.css
+++ b/src/css/usuarios.css
@@ -221,8 +221,10 @@ body {
 
 /* Popover do resumo */
 .resumo-popover {
-    position: absolute;
-    z-index: 50;
+    position: fixed;
+    top: 0;
+    left: 0;
+    z-index: 9999;
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.555);
     opacity: 0;
     visibility: hidden;

--- a/src/js/materia-prima.js
+++ b/src/js/materia-prima.js
@@ -95,21 +95,25 @@ function renderMateriais(lista) {
             const mostrarPopover = () => {
                 const iconRect = infoIcon.getBoundingClientRect();
                 const popRect = popover.getBoundingClientRect();
+                const container = infoIcon.closest('.table-scroll') || infoIcon.closest('.modulo-container') || document.body;
+                const containerRect = container.getBoundingClientRect();
 
-                let top = iconRect.bottom + 8;
-                let left = iconRect.left + iconRect.width / 2 - popRect.width / 2;
+                let left = iconRect.right + 8;
+                let top = iconRect.top + iconRect.height / 2 - popRect.height / 2;
 
-                if (top + popRect.height > window.innerHeight) {
-                    top = iconRect.top - popRect.height - 8;
-                    if (top < 0) {
-                        top = window.innerHeight / 2 - popRect.height / 2;
-                    }
+                if (left + popRect.width > containerRect.right) {
+                    left = iconRect.left - popRect.width - 8;
+                }
+                if (left < containerRect.left) {
+                    left = containerRect.left;
                 }
 
-                if (left + popRect.width > window.innerWidth) {
-                    left = window.innerWidth - popRect.width - 8;
+                if (top < containerRect.top) {
+                    top = containerRect.top;
                 }
-                if (left < 8) left = 8;
+                if (top + popRect.height > containerRect.bottom) {
+                    top = containerRect.bottom - popRect.height;
+                }
 
                 popover.style.left = `${left}px`;
                 popover.style.top = `${top}px`;

--- a/src/js/usuarios.js
+++ b/src/js/usuarios.js
@@ -53,9 +53,30 @@ function initUsuarios() {
 
     if (infoIcon && resumoPopover) {
         const mostrarPopover = () => {
-            const rect = infoIcon.getBoundingClientRect();
-            resumoPopover.style.left = '1vw';
-            resumoPopover.style.top = '2.5vw';
+            const iconRect = infoIcon.getBoundingClientRect();
+            const popRect = resumoPopover.getBoundingClientRect();
+            const container = infoIcon.closest('.table-scroll') || infoIcon.closest('.modulo-container') || document.body;
+            const containerRect = container.getBoundingClientRect();
+
+            let left = iconRect.right + 8;
+            let top = iconRect.top + iconRect.height / 2 - popRect.height / 2;
+
+            if (left + popRect.width > containerRect.right) {
+                left = iconRect.left - popRect.width - 8;
+            }
+            if (left < containerRect.left) {
+                left = containerRect.left;
+            }
+
+            if (top < containerRect.top) {
+                top = containerRect.top;
+            }
+            if (top + popRect.height > containerRect.bottom) {
+                top = containerRect.bottom - popRect.height;
+            }
+
+            resumoPopover.style.left = `${left}px`;
+            resumoPopover.style.top = `${top}px`;
             resumoPopover.classList.add('show');
         };
 


### PR DESCRIPTION
## Summary
- keep material popovers within table bounds and near their info icons
- ensure user summary popover appears beside the info icon and stays in view
- make user summary popover use fixed positioning

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6893aecd11ac8322ad285e82c7e486ba