### PR TITLE
feat: improve material popover positioning

### DIFF
--- a/src/js/materia-prima.js
+++ b/src/js/materia-prima.js
@@ -95,21 +95,29 @@ function renderMateriais(lista) {
             const mostrarPopover = () => {
                 const iconRect = infoIcon.getBoundingClientRect();
                 const popRect = popover.getBoundingClientRect();
+                const viewportWidth = window.innerWidth;
+                const viewportHeight = window.innerHeight;
+                const margin = 8; // margem mínima na viewport
 
-                let top = iconRect.bottom + 8;
+                // Posição padrão: abaixo do ícone
+                let top = iconRect.bottom + margin;
+                // Se não couber abaixo, abre acima
+                if (top + popRect.height > viewportHeight - margin) {
+                    top = iconRect.top - popRect.height - margin;
+                }
+                // Garante que o popup permaneça visível na vertical
+                if (top < margin) top = margin;
+                if (top + popRect.height > viewportHeight - margin) {
+                    top = viewportHeight - popRect.height - margin;
+                }
+
+                // Centraliza horizontalmente relativo ao ícone
                 let left = iconRect.left + iconRect.width / 2 - popRect.width / 2;
-
-                if (top + popRect.height > window.innerHeight) {
-                    top = iconRect.top - popRect.height - 8;
-                    if (top < 0) {
-                        top = window.innerHeight / 2 - popRect.height / 2;
-                    }
+                // Ajusta se ultrapassar as bordas laterais
+                if (left + popRect.width > viewportWidth - margin) {
+                    left = viewportWidth - popRect.width - margin;
                 }
-
-                if (left + popRect.width > window.innerWidth) {
-                    left = window.innerWidth - popRect.width - 8;
-                }
-                if (left < 8) left = 8;
+                if (left < margin) left = margin;
 
                 popover.style.left = `${left}px`;
                 popover.style.top = `${top}px`;


### PR DESCRIPTION
## Summary
- position material info popover intelligently within viewport
- ensure popup stays visible with 8px margins and flips above when needed

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6894a0dac0488322aa34747d80ce6f88