### PR TITLE
fix: keep table headers below top bar

### DIFF
--- a/src/styles/scroll.css
+++ b/src/styles/scroll.css
@@ -102,3 +102,14 @@ select option {
   color: #000;
   background: #fff;
 }
+
+/* Correção de sobreposição entre cabeçalho fixo e tabelas */
+header {
+  z-index: 1000;
+}
+
+.table-scroll thead {
+  position: sticky;
+  top: var(--header-height);
+  z-index: 1;
+}


### PR DESCRIPTION
## Summary
- ensure top bar stays above scrolling content
- keep table headers visible below fixed bar

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6894a3e4496c832293fe756fa258911f