### PR TITLE
feat: toggle sidebar via button

### DIFF
--- a/src/html/menu.html
+++ b/src/html/menu.html
@@ -25,7 +25,7 @@
                       { margin-left: -1vw; /* Exemplo: 5% da largura da tela */ }
 
                     </style>
-                <button id="menuToggle" class="p-2 rounded-lg transition-colors duration-150 hover:bg-white/10 lg:hidden">
+                <button id="menuToggle" class="p-2 rounded-lg transition-colors duration-150 hover:bg-white/10">
                     <i class="fas fa-bars w-5 h-5" style="color: var(--color-primary)"></i>
                 </button>
                 <img src="../assets/Logo SideBar.png" alt="Santíssimo Decor" class="w-10 h-10" />

--- a/src/js/menu.js
+++ b/src/js/menu.js
@@ -7,7 +7,6 @@ const menuToggle = document.getElementById('menuToggle');
 const crmToggle = document.getElementById('crmToggle');
 const crmSubmenu = document.getElementById('crmSubmenu');
 const chevron = crmToggle.querySelector('.chevron');
-const logoContainer = document.getElementById('logoContainer');
 const companyName = document.getElementById('companyName');
 
 // Ajusta logo e nome conforme estado inicial da sidebar
@@ -69,13 +68,7 @@ function collapseSidebar() {
     // Submenu CRM permanece aberto; fechamento apenas via clique
 }
 
-// Comportamento desktop: expande ao passar o mouse e recolhe ao sair
-if (window.innerWidth >= 1024) {
-    sidebar.addEventListener('mouseenter', expandSidebar);
-    sidebar.addEventListener('mouseleave', collapseSidebar);
-}
-
-// Alterna sidebar no mobile
+// Alterna a sidebar através do botão de menu
 menuToggle?.addEventListener('click', () => {
     if (sidebarExpanded) {
         collapseSidebar();


### PR DESCRIPTION
## Summary
- replace responsive sidebar hover with hamburger toggle button
- keep module navigation accessible when sidebar collapsed

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689506834368832280199da1d661f7c9