### PR TITLE
Sync menu toggle with sidebar and auto-collapse

### DIFF
--- a/src/css/menu.css
+++ b/src/css/menu.css
@@ -198,6 +198,7 @@ header.glass-surface {
     align-items: center;
     width: 64px;
     position: relative;
+    transition: margin-left 0.2s ease;
 }
 
 #companyName {

--- a/src/js/menu.js
+++ b/src/js/menu.js
@@ -8,6 +8,8 @@ const crmToggle = document.getElementById('crmToggle');
 const crmSubmenu = document.getElementById('crmSubmenu');
 const chevron = crmToggle.querySelector('.chevron');
 const companyName = document.getElementById('companyName');
+const logoContainer = document.getElementById('logoContainer');
+const initialLogoMarginLeft = logoContainer ? getComputedStyle(logoContainer).marginLeft : '0';
 
 // Ajusta logo e nome conforme estado inicial da sidebar
 if (sidebar && !sidebar.classList.contains('sidebar-expanded')) {
@@ -55,7 +57,9 @@ function expandSidebar() {
     if (!sidebarExpanded) {
         sidebar.classList.remove('sidebar-collapsed');
         sidebar.classList.add('sidebar-expanded');
-        mainContent.style.marginLeft = window.innerWidth >= 1024 ? '240px' : '200px';
+        const offset = window.innerWidth >= 1024 ? '240px' : '200px';
+        mainContent.style.marginLeft = offset;
+        if (logoContainer) logoContainer.style.marginLeft = offset;
         if (companyName) companyName.style.display = 'inline';
         sidebarExpanded = true;
     }
@@ -66,6 +70,7 @@ function collapseSidebar() {
         sidebar.classList.remove('sidebar-expanded');
         sidebar.classList.add('sidebar-collapsed');
         mainContent.style.marginLeft = '64px';
+        if (logoContainer) logoContainer.style.marginLeft = initialLogoMarginLeft;
         if (companyName) companyName.style.display = 'none';
         sidebarExpanded = false;
     }
@@ -80,6 +85,12 @@ menuToggle?.addEventListener('click', () => {
         expandSidebar();
     }
 });
+
+// Recolhe a sidebar ao interagir com o conteúdo principal
+mainContent?.addEventListener('click', collapseSidebar);
+
+// Recolhe automaticamente ao carregar módulos
+document.addEventListener('module-change', () => collapseSidebar());
 
 // Mostra ou esconde submenu do CRM
 function toggleCrmSubmenu() {


### PR DESCRIPTION
## Summary
- Move hamburger toggle with the sidebar by offsetting logo container
- Auto-collapse sidebar when interacting with page content or after module load
- Add transition for smooth logo container movement

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68950c909c188322811713e8ba92fe2e