### PR TITLE
feat: ajustar padding dos botões de produtos conforme sidebar

### DIFF
--- a/src/js/produtos.js
+++ b/src/js/produtos.js
@@ -19,6 +19,30 @@ function initProdutos() {
             cell.appendChild(template.content.cloneNode(true));
         });
     }
+
+    // Ajusta os botões de ação conforme o estado da sidebar
+    ajustarBotoes();
+
+    const sidebar = document.getElementById('sidebar');
+    if (sidebar) {
+        const observer = new MutationObserver(ajustarBotoes);
+        observer.observe(sidebar, { attributes: true, attributeFilter: ['class'] });
+    }
+}
+
+// Reduz ou amplia o padding dos botões "Filtrar" e "Novo"
+function ajustarBotoes() {
+    const sidebar = document.getElementById('sidebar');
+    const expandida = sidebar?.classList.contains('sidebar-expanded');
+    document.querySelectorAll('#bt-actions button').forEach(btn => {
+        if (expandida) {
+            btn.classList.remove('px-4');
+            btn.classList.add('px-2');
+        } else {
+            btn.classList.remove('px-2');
+            btn.classList.add('px-4');
+        }
+    });
 }
 
 if (document.readyState === 'loading') {


### PR DESCRIPTION
## Summary
- Ajusta dinamicamente o padding dos botões Filtrar e Novo para evitar quebra de linha quando a sidebar está expandida.
- Observa mudanças no estado da sidebar para manter o layout responsivo.

## Testing
- `npm test` *(falha: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_6895108002d48322b5b6ae8b7f729062