### PR TITLE
fix: update sidebar collapse triggers

### DIFF
--- a/src/js/menu.js
+++ b/src/js/menu.js
@@ -86,11 +86,8 @@ menuToggle?.addEventListener('click', () => {
     }
 });
 
-// Recolhe a sidebar ao interagir com o conteúdo principal
-mainContent?.addEventListener('click', collapseSidebar);
-
-// Recolhe automaticamente ao carregar módulos
-document.addEventListener('module-change', () => collapseSidebar());
+// Recolhe a sidebar apenas quando o usuário entra no conteúdo principal
+mainContent?.addEventListener('mouseenter', collapseSidebar);
 
 // Mostra ou esconde submenu do CRM
 function toggleCrmSubmenu() {


### PR DESCRIPTION
## Summary
- update menu to only collapse sidebar when entering main content or clicking menu button
- remove automatic collapse on module changes

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689517086f048322a5dd3ebb4a74b7c3