### PR TITLE
Include user profile in user list

### DIFF
--- a/backend/usuariosController.js
+++ b/backend/usuariosController.js
@@ -7,12 +7,13 @@ const router = express.Router();
 router.get('/lista', async (_req, res) => {
   try {
     const result = await pool.query(
-      'SELECT id, nome, email, verificado FROM usuarios ORDER BY nome'
+      'SELECT id, nome, email, verificado, perfil FROM usuarios ORDER BY nome'
     );
     const usuarios = result.rows.map(u => ({
       id: u.id,
       nome: u.nome,
       email: u.email,
+      perfil: u.perfil,
       status: u.verificado ? 'Ativo' : 'Inativo'
     }));
     res.json(usuarios);

--- a/src/js/usuarios.js
+++ b/src/js/usuarios.js
@@ -103,7 +103,7 @@ async function carregarUsuarios() {
                     <div class="text-sm font-medium text-white">${u.nome}</div>
                 </td>
                 <td class="px-6 py-4 text-sm text-white">${u.email}</td>
-                <td class="px-6 py-4"></td>
+                <td class="px-6 py-4 text-sm text-white">${u.perfil || ''}</td>
                 <td class="px-6 py-4">
                     <span class="${u.status === 'Ativo' ? 'badge-success' : 'badge-danger'} px-2 py-1 rounded-full text-xs font-medium">${u.status}</span>
                 </td>


### PR DESCRIPTION
## Summary
- query `perfil` from database and return in user list
- display user profile in frontend user table

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6899f895361c8322bc1b3bd013f1e819