### PR TITLE
Implement search and filter for usuarios

### DIFF
--- a/backend/usuariosController.js
+++ b/backend/usuariosController.js
@@ -4,16 +4,50 @@ const pool = require('./db');
 const router = express.Router();
 
 // GET /api/usuarios/lista
-router.get('/lista', async (_req, res) => {
+router.get('/lista', async (req, res) => {
   try {
-    const result = await pool.query(
-      'SELECT id, nome, email, verificado FROM usuarios ORDER BY nome'
-    );
+    const { busca = '', perfil = '', status = '' } = req.query;
+
+    const filtros = [];
+    const valores = [];
+
+    if (busca) {
+      valores.push(`%${busca.toLowerCase()}%`);
+      filtros.push(`(lower(nome) LIKE $${valores.length} OR lower(email) LIKE $${valores.length})`);
+    }
+
+    if (perfil) {
+      valores.push(perfil);
+      filtros.push(`perfil = $${valores.length}`);
+    }
+
+    if (status) {
+      const statuses = Array.isArray(status) ? status : status.split(',');
+      const condicoesStatus = [];
+      statuses.forEach(s => {
+        if (s === 'ativo') condicoesStatus.push('verificado = true');
+        else if (s === 'inativo') condicoesStatus.push('verificado = false');
+        else if (s === 'aguardando') condicoesStatus.push('verificado IS NULL');
+      });
+      if (condicoesStatus.length) filtros.push(`(${condicoesStatus.join(' OR ')})`);
+    }
+
+    let query = 'SELECT id, nome, email, perfil, verificado FROM usuarios';
+    if (filtros.length) query += ' WHERE ' + filtros.join(' AND ');
+    query += ' ORDER BY nome';
+
+    const result = await pool.query(query, valores);
     const usuarios = result.rows.map(u => ({
       id: u.id,
       nome: u.nome,
       email: u.email,
-      status: u.verificado ? 'Ativo' : 'Inativo'
+      perfil: u.perfil,
+      status:
+        u.verificado === true
+          ? 'Ativo'
+          : u.verificado === false
+          ? 'Inativo'
+          : 'Aguardando'
     }));
     res.json(usuarios);
   } catch (err) {

--- a/src/js/usuarios.js
+++ b/src/js/usuarios.js
@@ -31,14 +31,18 @@ function initUsuarios() {
     });
 
     document.getElementById('aplicarFiltro')?.addEventListener('click', () => {
-        console.log('Aplicar filtros', coletarFiltros());
+        carregarUsuarios(coletarFiltros());
     });
 
     document.getElementById('limparFiltro')?.addEventListener('click', () => {
         document.getElementById('filtroBusca').value = '';
         document.getElementById('filtroPerfil').value = '';
         document.querySelectorAll('.checkbox-custom').forEach(cb => cb.checked = false);
-        console.log('Filtros limpos');
+        carregarUsuarios();
+    });
+
+    document.getElementById('filtroBusca')?.addEventListener('keydown', e => {
+        if (e.key === 'Enter') carregarUsuarios(coletarFiltros());
     });
 
     document.querySelectorAll('[data-acao="editar"]').forEach(btn => {
@@ -79,9 +83,14 @@ function initUsuarios() {
     }
 }
 
-async function carregarUsuarios() {
+async function carregarUsuarios(filtros = {}) {
     try {
-        const resp = await fetch(`${API_URL}/api/usuarios/lista`);
+        const params = new URLSearchParams();
+        if (filtros.busca) params.append('busca', filtros.busca);
+        if (filtros.perfil) params.append('perfil', filtros.perfil);
+        if (filtros.status && filtros.status.length) params.append('status', filtros.status.join(','));
+
+        const resp = await fetch(`${API_URL}/api/usuarios/lista${params.toString() ? `?${params.toString()}` : ''}`);
         const usuarios = await resp.json();
         const tbody = document.getElementById('listaUsuarios');
         if (!tbody) return;
@@ -103,9 +112,9 @@ async function carregarUsuarios() {
                     <div class="text-sm font-medium text-white">${u.nome}</div>
                 </td>
                 <td class="px-6 py-4 text-sm text-white">${u.email}</td>
-                <td class="px-6 py-4"></td>
+                <td class="px-6 py-4 text-sm text-white">${u.perfil || ''}</td>
                 <td class="px-6 py-4">
-                    <span class="${u.status === 'Ativo' ? 'badge-success' : 'badge-danger'} px-2 py-1 rounded-full text-xs font-medium">${u.status}</span>
+                    <span class="${u.status === 'Ativo' ? 'badge-success' : u.status === 'Inativo' ? 'badge-danger' : 'badge-warning'} px-2 py-1 rounded-full text-xs font-medium">${u.status}</span>
                 </td>
                 <td class="px-6 py-4">
                     <div class="flex items-center gap-2">


### PR DESCRIPTION
## Summary
- add query param filtering to usuarios list API
- wire frontend to send filters and show perfil and status badges

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6899f8c84b8483228c527203433ed1df