### PR TITLE
feat: enable user search and filters

### DIFF
--- a/src/js/usuarios.js
+++ b/src/js/usuarios.js
@@ -5,6 +5,9 @@
 // precisamos apontar explicitamente para o servidor HTTP.
 const API_URL = 'http://localhost:3000';
 
+// Cache local dos usuários carregados
+let usuariosCache = [];
+
 function coletarFiltros() {
     const status = [];
     document.querySelectorAll('.checkbox-custom:checked').forEach(cb => status.push(cb.value));
@@ -30,27 +33,14 @@ function initUsuarios() {
         console.log('Criar novo usuário');
     });
 
-    document.getElementById('aplicarFiltro')?.addEventListener('click', () => {
-        console.log('Aplicar filtros', coletarFiltros());
-    });
+    document.getElementById('aplicarFiltro')?.addEventListener('click', aplicarFiltros);
+    document.getElementById('filtroBusca')?.addEventListener('input', aplicarFiltros);
 
     document.getElementById('limparFiltro')?.addEventListener('click', () => {
         document.getElementById('filtroBusca').value = '';
         document.getElementById('filtroPerfil').value = '';
         document.querySelectorAll('.checkbox-custom').forEach(cb => cb.checked = false);
-        console.log('Filtros limpos');
-    });
-
-    document.querySelectorAll('[data-acao="editar"]').forEach(btn => {
-        btn.addEventListener('click', () => {
-            console.log('Editar usuário');
-        });
-    });
-
-    document.querySelectorAll('[data-acao="remover"]').forEach(btn => {
-        btn.addEventListener('click', () => {
-            console.log('Remover usuário');
-        });
+        renderUsuarios(usuariosCache);
     });
 
     // Controle do popover de resumo
@@ -79,54 +69,76 @@ function initUsuarios() {
     }
 }
 
+function aplicarFiltros() {
+    const filtros = coletarFiltros();
+    const busca = filtros.busca.toLowerCase();
+    const filtrados = usuariosCache.filter(u => {
+        if (busca && !u.nome.toLowerCase().includes(busca) && !u.email.toLowerCase().includes(busca)) {
+            return false;
+        }
+        if (filtros.perfil && u.perfil !== filtros.perfil) {
+            return false;
+        }
+        if (filtros.status.length > 0 && !filtros.status.includes(u.status.toLowerCase())) {
+            return false;
+        }
+        return true;
+    });
+    renderUsuarios(filtrados);
+}
+
+function renderUsuarios(lista) {
+    const tbody = document.getElementById('listaUsuarios');
+    if (!tbody) return;
+    tbody.innerHTML = '';
+    lista.forEach(u => {
+        const tr = document.createElement('tr');
+        tr.classList.add('table-row');
+        const iniciais = u.nome
+            .split(' ')
+            .map(p => p[0])
+            .join('')
+            .substring(0, 2)
+            .toUpperCase();
+        tr.innerHTML = `
+            <td class="px-6 py-4">
+                <div class="w-9 h-9 rounded-full flex items-center justify-center text-white font-medium text-sm" style="background: var(--color-primary)">${iniciais}</div>
+            </td>
+            <td class="px-6 py-4">
+                <div class="text-sm font-medium text-white">${u.nome}</div>
+            </td>
+            <td class="px-6 py-4 text-sm text-white">${u.email}</td>
+            <td class="px-6 py-4 text-sm text-white">${u.perfil || ''}</td>
+            <td class="px-6 py-4">
+                <span class="${u.status === 'Ativo' ? 'badge-success' : 'badge-danger'} px-2 py-1 rounded-full text-xs font-medium">${u.status}</span>
+            </td>
+            <td class="px-6 py-4">
+                <div class="flex items-center gap-2">
+                    <i class="fas fa-edit w-5 h-5 cursor-pointer p-1 rounded transition-colors duration-150 hover:bg-white/10" data-acao="editar" style="color: var(--color-primary)" title="Editar"></i>
+                    <i class="fas fa-trash w-5 h-5 cursor-pointer p-1 rounded transition-colors duration-150 hover:bg-white/10" data-acao="remover" style="color: var(--color-red)" title="Excluir"></i>
+                </div>
+            </td>`;
+        tbody.appendChild(tr);
+    });
+
+    document.querySelectorAll('[data-acao="editar"]').forEach(btn => {
+        btn.addEventListener('click', () => {
+            console.log('Editar usuário');
+        });
+    });
+
+    document.querySelectorAll('[data-acao="remover"]').forEach(btn => {
+        btn.addEventListener('click', () => {
+            console.log('Remover usuário');
+        });
+    });
+}
+
 async function carregarUsuarios() {
     try {
         const resp = await fetch(`${API_URL}/api/usuarios/lista`);
-        const usuarios = await resp.json();
-        const tbody = document.getElementById('listaUsuarios');
-        if (!tbody) return;
-        tbody.innerHTML = '';
-        usuarios.forEach(u => {
-            const tr = document.createElement('tr');
-            tr.classList.add('table-row');
-            const iniciais = u.nome
-                .split(' ')
-                .map(p => p[0])
-                .join('')
-                .substring(0, 2)
-                .toUpperCase();
-            tr.innerHTML = `
-                <td class="px-6 py-4">
-                    <div class="w-9 h-9 rounded-full flex items-center justify-center text-white font-medium text-sm" style="background: var(--color-primary)">${iniciais}</div>
-                </td>
-                <td class="px-6 py-4">
-                    <div class="text-sm font-medium text-white">${u.nome}</div>
-                </td>
-                <td class="px-6 py-4 text-sm text-white">${u.email}</td>
-                <td class="px-6 py-4 text-sm text-white">${u.perfil || ''}</td>
-                <td class="px-6 py-4">
-                    <span class="${u.status === 'Ativo' ? 'badge-success' : 'badge-danger'} px-2 py-1 rounded-full text-xs font-medium">${u.status}</span>
-                </td>
-                <td class="px-6 py-4">
-                    <div class="flex items-center gap-2">
-                        <i class="fas fa-edit w-5 h-5 cursor-pointer p-1 rounded transition-colors duration-150 hover:bg-white/10" data-acao="editar" style="color: var(--color-primary)" title="Editar"></i>
-                        <i class="fas fa-trash w-5 h-5 cursor-pointer p-1 rounded transition-colors duration-150 hover:bg-white/10" data-acao="remover" style="color: var(--color-red)" title="Excluir"></i>
-                    </div>
-                </td>`;
-            tbody.appendChild(tr);
-        });
-
-        document.querySelectorAll('[data-acao="editar"]').forEach(btn => {
-            btn.addEventListener('click', () => {
-                console.log('Editar usuário');
-            });
-        });
-
-        document.querySelectorAll('[data-acao="remover"]').forEach(btn => {
-            btn.addEventListener('click', () => {
-                console.log('Remover usuário');
-            });
-        });
+        usuariosCache = await resp.json();
+        renderUsuarios(usuariosCache);
     } catch (err) {
         console.error('Erro ao carregar usuários:', err);
     }


### PR DESCRIPTION
## Summary
- cache user list on client and render filtered results
- wire up search bar, profile and status filters for users

## Testing
- `node --check src/js/usuarios.js`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6899fb944fd88322bd586946a860102f