### PR TITLE
Ensure Gear Menu Popup Above All Layers

### DIFF
--- a/src/html/menu.html
+++ b/src/html/menu.html
@@ -16,7 +16,7 @@
 </head>
 <body class="text-white">
     <!-- Topbar -->
-    <header class="fixed top-0 left-0 right-0 z-50 h-14 glass-surface border-b border-white/10">
+    <header class="fixed top-0 left-0 right-0 z-[1001] h-14 glass-surface border-b border-white/10">
         <div class="flex items-center justify-between h-full px-4">
             <!-- Logo and Menu Toggle -->
             <div class="flex items-center">
@@ -40,7 +40,7 @@
                     <button id="user-actions-btn" class="p-2 rounded-lg transition-colors duration-150 hover:bg-white/10" style="color: var(--color-violet)" onmouseover="this.style.color='var(--color-primary-light)'" onmouseout="this.style.color='var(--color-violet)'">
                         <i class="fas fa-cog w-5 h-5"></i>
                     </button>
-                    <div id="user-actions-menu" class="hidden absolute right-0 top-full mt-2 w-40 bg-white rounded-md shadow-lg z-50 text-sm text-gray-700">
+                    <div id="user-actions-menu" class="hidden absolute right-0 top-full mt-2 w-40 bg-white rounded-md shadow-lg z-[1010] text-sm text-gray-700">
                         <button data-action="logout" class="flex items-center w-full px-3 py-2 rounded-md hover:bg-[rgba(182,160,62,0.05)] hover:text-[#b6a03e]">
                             <i class="fas fa-sign-out-alt w-5 h-5 mr-2"></i>Sair
                         </button>

--- a/src/login/login.html
+++ b/src/login/login.html
@@ -37,12 +37,12 @@
         </svg>
       </div>
     </div>
-    <div class="login-container relative w-full max-w-md sm:max-w-lg md:max-w-xl p-8 rounded-xl z-10">
-      <div class="absolute top-4 right-4">
+    <div class="login-container relative w-full max-w-md sm:max-w-lg md:max-w-xl p-8 rounded-xl">
+      <div class="absolute top-4 right-4 z-[1001]">
         <button id="user-actions-btn" class="text-[#b6a03e] hover:text-[#d4c169]">
           <i data-feather="settings" class="w-5 h-5"></i>
         </button>
-        <div id="user-actions-menu" class="hidden absolute right-0 top-full mt-2 w-40 bg-white rounded-md shadow-lg z-50 text-sm text-gray-700">
+        <div id="user-actions-menu" class="hidden absolute right-0 top-full mt-2 w-40 bg-white rounded-md shadow-lg z-[1010] text-sm text-gray-700">
           <button data-action="close" class="flex items-center w-full px-3 py-2 rounded-md hover:bg-[rgba(182,160,62,0.05)] hover:text-[#b6a03e]">
             <i data-feather="x" class="w-5 h-5 mr-2"></i>Fechar
           </button>


### PR DESCRIPTION
## Summary
- Raise z-index of topbar and options menu to keep settings popup above UI layers
- Update login page gear menu container and popup with higher z-indices to avoid being hidden

## Testing
- `npm test` (fails: missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_689a01ff72cc8322b59586891ab15a9a