### PR TITLE
Integrate Materia Prima Modals With Backend

### DIFF
--- a/src/css/materia-prima.css
+++ b/src/css/materia-prima.css
@@ -242,3 +242,34 @@ body {
   color: #e5e5e5; /* Um cinza mais claro */
   line-height: 1.5; /* leading-relaxed */
 }
+
+/* Modals and form elements */
+.bg-input { background: var(--color-input); }
+.border-inputBorder { border-color: var(--color-inputBorder); }
+.focus\:border-primary:focus { border-color: var(--color-primary); }
+.focus\:ring-primary\/50:focus { box-shadow: 0 0 0 2px rgba(182,160,62,0.5); }
+.peer-focus\:text-primary { transition: color 150ms ease; }
+.peer:focus ~ .peer-focus\:text-primary { color: var(--color-primary); }
+.btn-danger { background: var(--color-red); transition: all 150ms ease; }
+.btn-danger:hover { background: rgba(255,88,88,0.8); transform: scale(1.1); }
+.btn-danger:active { transform: scale(0.95); }
+.btn-neutral { background: rgba(255,255,255,0.1); transition: all 150ms ease; }
+.btn-neutral:hover { background: rgba(255,255,255,0.15); transform: scale(1.05); }
+.btn-neutral:active { transform: scale(0.95); }
+.btn-success { background: var(--color-green); color:#000; transition: all 150ms ease; }
+.btn-success:hover { background: rgba(162,255,166,0.8); transform: scale(1.05); }
+.btn-success:active { transform: scale(0.95); }
+.component-toggle { appearance: none; width:48px; height:24px; background: rgba(255,255,255,0.2); border-radius:12px; position:relative; cursor:pointer; transition: all 150ms ease; }
+.component-toggle::after { content:''; position:absolute; top:2px; left:2px; width:20px; height:20px; background:white; border-radius:50%; transition: all 150ms ease; }
+.component-toggle:checked { background: var(--color-primary); }
+.component-toggle:checked::after { transform: translateX(24px); }
+.icon-only { width:32px; height:32px; display:flex; align-items:center; justify-content:center; border-radius:8px; font-size:16px; }
+.animate-modalFade { animation: modalFade 0.3s ease-out forwards; }
+.slide-in { animation: slideIn 0.3s ease-out forwards; }
+@keyframes modalFade { from { opacity:0; } to { opacity:1; } }
+@keyframes slideIn { from { transform: translateY(16px); opacity:0; } to { transform: translateY(0); opacity:1; } }
+
+/* Toast notifications */
+.toast { color: white; padding: 0.5rem 1rem; border-radius: 0.25rem; box-shadow: 0 2px 4px rgba(0,0,0,0.1); transition: opacity 0.5s ease-in-out; }
+.toast-success { background-color: #16a34a; }
+.toast-error { background-color: #dc2626; }

--- a/src/html/materia-prima.html
+++ b/src/html/materia-prima.html
@@ -20,7 +20,7 @@
                 <h1 class="text-2xl font-semibold mb-2">Estoque de Matéria-Prima</h1>
                 <p style="color: var(--color-violet)">Controle e gerenciamento de insumos para produção</p>
             </div>
-            <button class="btn-primary text-white rounded-md px-6 py-3 font-medium">
+            <button id="btnNovoInsumo" class="btn-primary text-white rounded-md px-6 py-3 font-medium">
                 <i class="fas fa-plus mr-2"></i>Novo Insumo
             </button>
         </div>
@@ -85,6 +85,5 @@
         </div>
     </div>
 
-    <script src="../js/materia-prima.js"></script>
 </body>
 </html>

--- a/src/html/menu.html
+++ b/src/html/menu.html
@@ -359,6 +359,7 @@
     <div id="exitOverlay" class="hidden fixed inset-0 bg-[#3d021f] opacity-0 flex items-center justify-center z-50"></div>
 
     <!-- Script de controle do menu -->
+    <script src="../utils/modal.js"></script>
     <script src="../js/menu.js"></script>
     <script src="../js/scroll-handler.js"></script>
     <script src="../utils/userActions.js"></script>

--- a/src/html/modals/materia-prima/editar.html
+++ b/src/html/modals/materia-prima/editar.html
@@ -1,0 +1,48 @@
+<div id="editarInsumoOverlay" class="fixed inset-0 bg-black/50 flex items-center justify-center p-6">
+  <div class="w-full max-w-2xl glass-surface backdrop-blur-xl rounded-3xl border border-white/10 ring-1 ring-white/5 shadow-2xl/40 animate-modalFade slide-in overflow-y-auto">
+    <header class="relative px-8 py-5 border-b border-white/10">
+      <h2 class="text-lg font-semibold text-center text-white">Editar Insumo</h2>
+      <button id="fecharEditarInsumo" class="btn-danger icon-only absolute right-4 top-4 text-white">✕</button>
+    </header>
+    <form id="editarInsumoForm" class="p-8 grid md:grid-cols-2 gap-6">
+      <div class="relative">
+        <input id="nome" name="nome" type="text" placeholder=" " class="peer w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-transparent focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+        <label for="nome" class="absolute left-4 top-0 -translate-y-full text-xs text-primary transition-all duration-150 pointer-events-none">Nome</label>
+      </div>
+      <div class="relative">
+        <input id="categoria" name="categoria" type="text" placeholder=" " class="peer w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-transparent focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+        <label for="categoria" class="absolute left-4 top-0 -translate-y-full text-xs text-primary transition-all duration-150 pointer-events-none">Categoria</label>
+      </div>
+      <div class="relative">
+        <input id="quantidade" name="quantidade" type="number" min="0" step="0.01" placeholder=" " class="peer w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-transparent focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+        <label for="quantidade" class="absolute left-4 top-0 -translate-y-full text-xs text-primary transition-all duration-150 pointer-events-none">Quantidade</label>
+      </div>
+      <div class="relative">
+        <input id="unidade" name="unidade" type="text" placeholder=" " class="peer w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-transparent focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+        <label for="unidade" class="absolute left-4 top-0 -translate-y-full text-xs text-primary transition-all duration-150 pointer-events-none">Unidade</label>
+      </div>
+      <div class="relative">
+        <input id="preco" name="preco" type="number" min="0" step="0.01" placeholder=" " class="peer w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-transparent focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+        <label for="preco" class="absolute left-4 top-0 -translate-y-full text-xs text-primary transition-all duration-150 pointer-events-none">Preço Unitário</label>
+      </div>
+      <div class="relative">
+        <input id="processo" name="processo" type="text" placeholder=" " class="peer w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-transparent focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+        <label for="processo" class="absolute left-4 top-0 -translate-y-full text-xs text-primary transition-all duration-150 pointer-events-none">Processo</label>
+      </div>
+      <label class="flex items-center gap-3 md:col-span-2">
+        <input id="infinito" type="checkbox" class="component-toggle" />
+        <span class="text-gray-200">Estoque infinito</span>
+      </label>
+      <div class="md:col-span-2">
+        <textarea id="descricao" name="descricao" class="w-full h-28 bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 resize-none focus:border-primary focus:ring-2 focus:ring-primary/50 transition"></textarea>
+      </div>
+      <div class="md:col-span-2">
+        <button type="button" id="abrirExcluirInsumo" class="btn-neutral border border-white/20 text-sm px-5 py-2 mt-2 text-white rounded-lg">Excluir Insumo</button>
+      </div>
+    </form>
+    <footer class="flex justify-end gap-4 px-8 py-6 border-t border-white/10">
+      <button type="button" id="cancelarEditarInsumo" class="btn-danger px-6 py-3 rounded-xl text-white font-medium active:scale-95">Cancelar</button>
+      <button type="submit" form="editarInsumoForm" class="btn-primary px-6 py-3 rounded-xl text-white font-medium active:scale-95">Salvar</button>
+    </footer>
+  </div>
+</div>

--- a/src/html/modals/materia-prima/excluir.html
+++ b/src/html/modals/materia-prima/excluir.html
@@ -1,0 +1,12 @@
+<div id="excluirInsumoOverlay" class="fixed inset-0 bg-black/50 flex items-center justify-center p-4">
+  <div class="max-w-sm w-full glass-surface backdrop-blur-xl rounded-2xl border border-white/10 ring-1 ring-white/5 shadow-2xl/40 animate-modalFade">
+    <div class="p-6 text-center">
+      <h3 class="text-lg font-semibold mb-4 text-white">Tem certeza?</h3>
+      <p class="text-sm text-gray-300">Deseja excluir este insumo? Esta ação não pode ser desfeita.</p>
+      <div class="flex justify-center gap-6 mt-8">
+        <button id="cancelarExcluirInsumo" class="btn-danger px-6 py-2 rounded-lg text-white font-medium active:scale-95">Cancelar</button>
+        <button id="confirmarExcluirInsumo" class="btn-success px-6 py-2 rounded-lg font-medium active:scale-95">Confirmar</button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/html/modals/materia-prima/novo.html
+++ b/src/html/modals/materia-prima/novo.html
@@ -1,0 +1,45 @@
+<div id="novoInsumoOverlay" class="fixed inset-0 bg-black/50 flex items-center justify-center p-6">
+  <div class="w-full max-w-2xl glass-surface backdrop-blur-xl rounded-3xl border border-white/10 ring-1 ring-white/5 shadow-2xl/40 animate-modalFade slide-in overflow-y-auto">
+    <header class="relative px-8 py-5 border-b border-white/10">
+      <h2 class="text-lg font-semibold text-center text-white">Novo Insumo</h2>
+      <button id="fecharNovoInsumo" class="btn-danger icon-only absolute right-4 top-4 text-white">✕</button>
+    </header>
+    <form id="novoInsumoForm" class="p-8 grid md:grid-cols-2 gap-6">
+      <div class="relative">
+        <input id="nome" name="nome" type="text" placeholder=" " required class="peer w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-transparent focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+        <label for="nome" class="absolute left-4 top-1/2 -translate-y-1/2 text-base text-gray-300 pointer-events-none transition-all duration-150 peer-placeholder-shown:top-1/2 peer-focus:top-0 peer-focus:-translate-y-full peer-focus:text-xs peer-focus:text-primary">Nome</label>
+      </div>
+      <div class="relative">
+        <input id="categoria" name="categoria" type="text" placeholder=" " required class="peer w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-transparent focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+        <label for="categoria" class="absolute left-4 top-1/2 -translate-y-1/2 text-base text-gray-300 pointer-events-none transition-all duration-150 peer-placeholder-shown:top-1/2 peer-focus:top-0 peer-focus:-translate-y-full peer-focus:text-xs peer-focus:text-primary">Categoria</label>
+      </div>
+      <div class="relative">
+        <input id="quantidade" name="quantidade" type="number" min="0" step="0.01" placeholder=" " required class="peer w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-transparent focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+        <label for="quantidade" class="absolute left-4 top-1/2 -translate-y-1/2 text-base text-gray-300 pointer-events-none transition-all duration-150 peer-placeholder-shown:top-1/2 peer-focus:top-0 peer-focus:-translate-y-full peer-focus:text-xs peer-focus:text-primary">Quantidade</label>
+      </div>
+      <div class="relative">
+        <input id="unidade" name="unidade" type="text" placeholder=" " required class="peer w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-transparent focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+        <label for="unidade" class="absolute left-4 top-1/2 -translate-y-1/2 text-base text-gray-300 pointer-events-none transition-all duration-150 peer-placeholder-shown:top-1/2 peer-focus:top-0 peer-focus:-translate-y-full peer-focus:text-xs peer-focus:text-primary">Unidade</label>
+      </div>
+      <div class="relative">
+        <input id="preco" name="preco" type="number" min="0" step="0.01" placeholder=" " required class="peer w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-transparent focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+        <label for="preco" class="absolute left-4 top-1/2 -translate-y-1/2 text-base text-gray-300 pointer-events-none transition-all duration-150 peer-placeholder-shown:top-1/2 peer-focus:top-0 peer-focus:-translate-y-full peer-focus:text-xs peer-focus:text-primary">Preço Unitário</label>
+      </div>
+      <div class="relative">
+        <input id="processo" name="processo" type="text" placeholder=" " required class="peer w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-transparent focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+        <label for="processo" class="absolute left-4 top-1/2 -translate-y-1/2 text-base text-gray-300 pointer-events-none transition-all duration-150 peer-placeholder-shown:top-1/2 peer-focus:top-0 peer-focus:-translate-y-full peer-focus:text-xs peer-focus:text-primary">Processo</label>
+      </div>
+      <label class="flex items-center gap-3 md:col-span-2">
+        <input id="infinito" type="checkbox" class="component-toggle" />
+        <span class="text-gray-200">Estoque infinito</span>
+      </label>
+      <div class="md:col-span-2">
+        <textarea id="descricao" name="descricao" placeholder="Descreva as especificações técnicas do insumo…" class="w-full h-28 bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 resize-none focus:border-primary focus:ring-2 focus:ring-primary/50 transition"></textarea>
+      </div>
+    </form>
+    <footer class="flex justify-end gap-4 px-8 py-6 border-t border-white/10">
+      <button type="button" id="cancelarNovoInsumo" class="btn-danger px-6 py-3 rounded-xl text-white font-medium active:scale-95">Cancelar</button>
+      <button type="submit" form="novoInsumoForm" class="btn-primary px-6 py-3 rounded-xl text-white font-medium active:scale-95">Salvar</button>
+    </footer>
+  </div>
+</div>

--- a/src/js/materia-prima.js
+++ b/src/js/materia-prima.js
@@ -1,5 +1,28 @@
 // Lógica principal do módulo Matéria Prima
 let todosMateriais = [];
+let notificationContainer;
+
+function showToast(message, type = 'success') {
+    if (!notificationContainer) {
+        notificationContainer = document.getElementById('notification');
+        if (!notificationContainer) {
+            notificationContainer = document.createElement('div');
+            notificationContainer.id = 'notification';
+            notificationContainer.className = 'fixed top-4 right-4 space-y-2 z-[10000]';
+            document.body.appendChild(notificationContainer);
+        }
+    }
+    const div = document.createElement('div');
+    div.className = `toast ${type === 'success' ? 'toast-success' : 'toast-error'}`;
+    div.textContent = message;
+    notificationContainer.appendChild(div);
+    setTimeout(() => {
+        div.classList.add('opacity-0');
+        setTimeout(() => div.remove(), 500);
+    }, 3000);
+}
+
+window.showToast = showToast;
 
 // Inicializa animações e eventos
 function initMateriaPrima() {
@@ -15,6 +38,7 @@ function initMateriaPrima() {
     document.getElementById('filtroCategoria')?.addEventListener('change', aplicarFiltros);
     document.getElementById('btnFiltrar')?.addEventListener('click', aplicarFiltros);
     document.getElementById('btnLimpar')?.addEventListener('click', limparFiltros);
+    document.getElementById('btnNovoInsumo')?.addEventListener('click', abrirNovoInsumo);
 
     carregarMateriais();
 }
@@ -273,9 +297,27 @@ function renderMateriais(listaMateriais) {
             <td class="px-6 py-4 whitespace-nowrap text-sm text-white">R$ ${preco.toFixed(2).replace('.', ',')}</td>
             <td class="px-6 py-4 whitespace-nowrap text-center">${acoes}</td>`;
         tbody.appendChild(tr);
+        const editBtn = tr.querySelector('.fa-edit');
+        const delBtn = tr.querySelector('.fa-trash');
+        if (editBtn) editBtn.addEventListener('click', e => { e.stopPropagation(); abrirEditarInsumo(item); });
+        if (delBtn) delBtn.addEventListener('click', e => { e.stopPropagation(); abrirExcluirInsumo(item); });
     });
 
     attachInfoEvents();
+}
+
+function abrirNovoInsumo() {
+    Modal.open('modals/materia-prima/novo.html', '../js/modals/materia-prima-novo.js', 'novoInsumo');
+}
+
+function abrirEditarInsumo(item) {
+    window.materiaSelecionada = item;
+    Modal.open('modals/materia-prima/editar.html', '../js/modals/materia-prima-editar.js', 'editarInsumo');
+}
+
+function abrirExcluirInsumo(item) {
+    window.materiaExcluir = item;
+    Modal.open('modals/materia-prima/excluir.html', '../js/modals/materia-prima-excluir.js', 'excluirInsumo');
 }
 
 if (document.readyState === 'loading') {

--- a/src/js/modals/materia-prima-editar.js
+++ b/src/js/modals/materia-prima-editar.js
@@ -1,0 +1,50 @@
+(function(){
+  const overlay = document.getElementById('editarInsumoOverlay');
+  const close = () => Modal.close('editarInsumo');
+  overlay.addEventListener('click', e => { if (e.target === overlay) close(); });
+  document.getElementById('fecharEditarInsumo').addEventListener('click', close);
+  document.getElementById('cancelarEditarInsumo').addEventListener('click', close);
+  document.addEventListener('keydown', function esc(e){ if(e.key==='Escape'){ close(); document.removeEventListener('keydown', esc); } });
+  const form = document.getElementById('editarInsumoForm');
+  const item = window.materiaSelecionada;
+  if(item){
+    form.nome.value = item.nome || '';
+    form.categoria.value = item.categoria || '';
+    form.quantidade.value = item.quantidade || '';
+    form.unidade.value = item.unidade || '';
+    form.preco.value = item.preco_unitario || '';
+    form.processo.value = item.processo || '';
+    form.infinito.checked = !!item.infinito;
+    form.descricao.value = item.descricao || '';
+  }
+  document.getElementById('abrirExcluirInsumo').addEventListener('click', () => {
+    window.materiaExcluir = item;
+    Modal.open('modals/materia-prima/excluir.html', '../js/modals/materia-prima-excluir.js', 'excluirInsumo');
+  });
+  form.addEventListener('submit', async e => {
+    e.preventDefault();
+    const dados = {
+      nome: form.nome.value.trim(),
+      categoria: form.categoria.value.trim(),
+      quantidade: parseFloat(form.quantidade.value),
+      unidade: form.unidade.value.trim(),
+      preco_unitario: parseFloat(form.preco.value),
+      processo: form.processo.value.trim(),
+      infinito: form.infinito.checked,
+      descricao: form.descricao.value.trim()
+    };
+    if(!dados.nome || !dados.categoria || !dados.unidade || !dados.processo || isNaN(dados.quantidade) || dados.quantidade < 0 || isNaN(dados.preco_unitario) || dados.preco_unitario < 0){
+      showToast('Verifique os campos obrigatórios.', 'error');
+      return;
+    }
+    try{
+      await window.electronAPI.atualizarMateriaPrima(item.id, dados);
+      showToast('Insumo atualizado com sucesso!', 'success');
+      close();
+      carregarMateriais();
+    }catch(err){
+      console.error(err);
+      showToast('Erro ao atualizar insumo', 'error');
+    }
+  });
+})();

--- a/src/js/modals/materia-prima-excluir.js
+++ b/src/js/modals/materia-prima-excluir.js
@@ -1,0 +1,21 @@
+(function(){
+  const overlay = document.getElementById('excluirInsumoOverlay');
+  const close = () => Modal.close('excluirInsumo');
+  overlay.addEventListener('click', e => { if (e.target === overlay) close(); });
+  document.getElementById('cancelarExcluirInsumo').addEventListener('click', close);
+  document.addEventListener('keydown', function esc(e){ if(e.key==='Escape'){ close(); document.removeEventListener('keydown', esc); } });
+  document.getElementById('confirmarExcluirInsumo').addEventListener('click', async () => {
+    const item = window.materiaExcluir;
+    if(!item) return;
+    try{
+      await window.electronAPI.excluirMateriaPrima(item.id);
+      showToast('Insumo excluído com sucesso!', 'success');
+      close();
+      Modal.close('editarInsumo');
+      carregarMateriais();
+    }catch(err){
+      console.error(err);
+      showToast('Erro ao excluir insumo', 'error');
+    }
+  });
+})();

--- a/src/js/modals/materia-prima-novo.js
+++ b/src/js/modals/materia-prima-novo.js
@@ -1,0 +1,35 @@
+(function(){
+  const overlay = document.getElementById('novoInsumoOverlay');
+  const close = () => Modal.close('novoInsumo');
+  overlay.addEventListener('click', e => { if (e.target === overlay) close(); });
+  document.getElementById('fecharNovoInsumo').addEventListener('click', close);
+  document.getElementById('cancelarNovoInsumo').addEventListener('click', close);
+  document.addEventListener('keydown', function esc(e){ if(e.key==='Escape'){ close(); document.removeEventListener('keydown', esc); } });
+  const form = document.getElementById('novoInsumoForm');
+  form.addEventListener('submit', async e => {
+    e.preventDefault();
+    const dados = {
+      nome: form.nome.value.trim(),
+      categoria: form.categoria.value.trim(),
+      quantidade: parseFloat(form.quantidade.value),
+      unidade: form.unidade.value.trim(),
+      preco_unitario: parseFloat(form.preco.value),
+      processo: form.processo.value.trim(),
+      infinito: form.infinito.checked,
+      descricao: form.descricao.value.trim()
+    };
+    if(!dados.nome || !dados.categoria || !dados.unidade || !dados.processo || isNaN(dados.quantidade) || dados.quantidade < 0 || isNaN(dados.preco_unitario) || dados.preco_unitario < 0){
+      showToast('Verifique os campos obrigatórios.', 'error');
+      return;
+    }
+    try{
+      await window.electronAPI.adicionarMateriaPrima(dados);
+      showToast('Insumo criado com sucesso!', 'success');
+      close();
+      carregarMateriais();
+    }catch(err){
+      console.error(err);
+      showToast('Erro ao criar insumo', 'error');
+    }
+  });
+})();


### PR DESCRIPTION
## Summary
- hook up Materia Prima create, edit and delete flows using new modal templates
- add toast notifications and modal manager integration
- refresh material table after operations
- load modal utilities globally in main menu so actions display corresponding dialogs

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689a10786e048322b6b955d7c3e3af33