### PR TITLE
Fix Product Table Display And Quantity

### DIFF
--- a/backend/produtos.js
+++ b/backend/produtos.js
@@ -2,7 +2,20 @@ const pool = require('./db');
 
 async function listarProdutos() {
   try {
-    const res = await pool.query('SELECT * FROM produtos ORDER BY nome');
+    const res = await pool.query(
+      `SELECT p.id,
+              p.codigo,
+              p.nome,
+              p.categoria,
+              p.preco_venda,
+              p.pct_markup,
+              p.status,
+              COALESCE(SUM(pe.quantidade), 0) AS quantidade_total
+         FROM produtos p
+    LEFT JOIN produtos_em_cada_ponto pe ON pe.id_produto = p.id
+     GROUP BY p.id, p.codigo, p.nome, p.categoria, p.preco_venda, p.pct_markup, p.status
+     ORDER BY p.nome`
+    );
     return res.rows;
   } catch (err) {
     console.error('Erro ao listar produtos:', err.message);

--- a/src/html/produtos.html
+++ b/src/html/produtos.html
@@ -96,10 +96,9 @@
                             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Código</th>
                             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Nome</th>
                             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Categoria</th>
-                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Custo Insumos (A)</th>
                             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Preço de Venda</th>
                             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Margem (%)</th>
-                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Estoque Atual</th>
+                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Quantidade</th>
                             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
                             <th class="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">Ações</th>
                         </tr>

--- a/src/js/produtos.js
+++ b/src/js/produtos.js
@@ -17,12 +17,11 @@ async function carregarProdutos() {
 
             tr.innerHTML = `
                 <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-white">${p.codigo || ''}</td>
-                <td class="px-6 py-4 whitespace-nowrap text-sm text-white">${p.nome || ''}</td>
+                <td class="px-6 py-4 whitespace-nowrap text-sm text-white">${reduzirNome(p.nome) || ''}</td>
                 <td class="px-6 py-4 whitespace-nowrap text-sm" style="color: var(--color-violet)">${p.categoria || ''}</td>
-                <td class="px-6 py-4 whitespace-nowrap text-sm text-white">${formatCurrency(p.custo_insumos)}</td>
                 <td class="px-6 py-4 whitespace-nowrap text-sm text-white">${formatCurrency(p.preco_venda)}</td>
-                <td class="px-6 py-4 whitespace-nowrap text-sm" style="color: var(--color-green)">${formatPercent(p.margem)}</td>
-                <td class="px-6 py-4 whitespace-nowrap text-sm text-white">${p.estoque_atual ?? ''}</td>
+                <td class="px-6 py-4 whitespace-nowrap text-sm" style="color: var(--color-green)">${formatPercent(p.pct_markup)}</td>
+                <td class="px-6 py-4 whitespace-nowrap text-sm text-white">${p.quantidade_total ?? 0}</td>
                 <td class="px-6 py-4 whitespace-nowrap">
                     <span class="${p.status === 'ativo' ? 'badge-success' : 'badge-danger'} px-3 py-1 rounded-full text-xs font-medium">
                         ${p.status === 'ativo' ? 'Ativo' : 'Inativo'}
@@ -52,6 +51,14 @@ function formatCurrency(value) {
 function formatPercent(value) {
     if (value == null) return '';
     return `${Number(value).toFixed(1)}%`;
+}
+
+function reduzirNome(nome) {
+    if (!nome) return '';
+    const partes = nome.split(' - ');
+    if (partes.length < 2) return partes[0];
+    const medida = partes[1].split(' (')[0].trim();
+    return `${partes[0]} - ${medida}`;
 }
 
 function initProdutos() {


### PR DESCRIPTION
## Summary
- show only product name and size in table
- aggregate total quantity for each product across locations
- streamline product table headers and display

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689a41cd599c832287250bb189530805