### PR TITLE
Implement Product Modals For Create View Edit And Delete

### DIFF
--- a/backend/produtos.js
+++ b/backend/produtos.js
@@ -23,4 +23,45 @@ async function listarProdutos() {
   }
 }
 
-module.exports = { listarProdutos };
+async function obterProduto(id) {
+  const res = await pool.query('SELECT * FROM produtos WHERE id=$1', [id]);
+  return res.rows[0];
+}
+
+async function adicionarProduto(dados) {
+  const { codigo, nome, categoria, preco_venda, pct_markup, status } = dados;
+  const res = await pool.query(
+    `INSERT INTO produtos (codigo, nome, categoria, preco_venda, pct_markup, status)
+     VALUES ($1,$2,$3,$4,$5,$6) RETURNING *`,
+    [codigo, nome, categoria, preco_venda, pct_markup, status]
+  );
+  return res.rows[0];
+}
+
+async function atualizarProduto(id, dados) {
+  const { codigo, nome, categoria, preco_venda, pct_markup, status } = dados;
+  const res = await pool.query(
+    `UPDATE produtos
+        SET codigo=$1,
+            nome=$2,
+            categoria=$3,
+            preco_venda=$4,
+            pct_markup=$5,
+            status=$6
+     WHERE id=$7 RETURNING *`,
+    [codigo, nome, categoria, preco_venda, pct_markup, status, id]
+  );
+  return res.rows[0];
+}
+
+async function excluirProduto(id) {
+  await pool.query('DELETE FROM produtos WHERE id=$1', [id]);
+}
+
+module.exports = {
+  listarProdutos,
+  obterProduto,
+  adicionarProduto,
+  atualizarProduto,
+  excluirProduto
+};

--- a/main.js
+++ b/main.js
@@ -18,7 +18,13 @@ const {
   registrarSaida,
   atualizarPreco
 } = require('./backend/materiaPrima');
-const { listarProdutos } = require('./backend/produtos');
+const {
+  listarProdutos,
+  obterProduto,
+  adicionarProduto,
+  atualizarProduto,
+  excluirProduto
+} = require('./backend/produtos');
 const apiServer = require('./backend/server');
 // Impede que múltiplas instâncias do aplicativo sejam abertas
 const gotTheLock = app.requestSingleInstanceLock();
@@ -348,6 +354,19 @@ ipcMain.handle('atualizar-preco-materia-prima', async (_e, { id, preco }) => {
 });
 ipcMain.handle('listar-produtos', async () => {
   return listarProdutos();
+});
+ipcMain.handle('obter-produto', async (_e, id) => {
+  return obterProduto(id);
+});
+ipcMain.handle('adicionar-produto', async (_e, dados) => {
+  return adicionarProduto(dados);
+});
+ipcMain.handle('atualizar-produto', async (_e, { id, dados }) => {
+  return atualizarProduto(id, dados);
+});
+ipcMain.handle('excluir-produto', async (_e, id) => {
+  await excluirProduto(id);
+  return true;
 });
 
 ipcMain.handle('auto-login', async (_event, pin) => {

--- a/preload.js
+++ b/preload.js
@@ -7,6 +7,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
   // Módulo de Matéria-Prima
   listarMateriaPrima: (filtro) => ipcRenderer.invoke('listar-materia-prima', { filtro }),
   listarProdutos: () => ipcRenderer.invoke('listar-produtos'),
+  obterProduto: (id) => ipcRenderer.invoke('obter-produto', id),
+  adicionarProduto: (dados) => ipcRenderer.invoke('adicionar-produto', dados),
+  atualizarProduto: (id, dados) => ipcRenderer.invoke('atualizar-produto', { id, dados }),
+  excluirProduto: (id) => ipcRenderer.invoke('excluir-produto', id),
   adicionarMateriaPrima: (dados) => ipcRenderer.invoke('adicionar-materia-prima', dados),
   atualizarMateriaPrima: (id, dados) => ipcRenderer.invoke('atualizar-materia-prima', { id, dados }),
   excluirMateriaPrima: (id) => ipcRenderer.invoke('excluir-materia-prima', id),

--- a/src/html/modals/produtos/detalhes.html
+++ b/src/html/modals/produtos/detalhes.html
@@ -1,0 +1,17 @@
+<div id="detalhesProdutoOverlay" class="fixed inset-0 bg-black/50 flex items-center justify-center p-6">
+  <div class="w-full max-w-md glass-surface backdrop-blur-xl rounded-3xl border border-white/10 ring-1 ring-white/5 shadow-2xl/40 animate-modalFade slide-in overflow-y-auto">
+    <header class="relative px-8 py-5 border-b border-white/10">
+      <h2 class="text-lg font-semibold text-center text-white">Detalhes do Produto</h2>
+      <button id="fecharDetalhesProduto" class="btn-danger icon-only absolute right-4 top-4 text-white">✕</button>
+    </header>
+    <div class="p-8 space-y-3 text-sm text-white">
+      <p><span class="text-gray-300">Código:</span> <span id="detCodigo"></span></p>
+      <p><span class="text-gray-300">Nome:</span> <span id="detNome"></span></p>
+      <p><span class="text-gray-300">Categoria:</span> <span id="detCategoria"></span></p>
+      <p><span class="text-gray-300">Preço de Venda:</span> <span id="detPreco"></span></p>
+      <p><span class="text-gray-300">Markup %:</span> <span id="detMarkup"></span></p>
+      <p><span class="text-gray-300">Status:</span> <span id="detStatus"></span></p>
+      <p><span class="text-gray-300">Quantidade:</span> <span id="detQuantidade"></span></p>
+    </div>
+  </div>
+</div>

--- a/src/html/modals/produtos/editar.html
+++ b/src/html/modals/produtos/editar.html
@@ -1,0 +1,40 @@
+<div id="editarProdutoOverlay" class="fixed inset-0 bg-black/50 flex items-center justify-center p-6">
+  <div class="w-full max-w-2xl glass-surface backdrop-blur-xl rounded-3xl border border-white/10 ring-1 ring-white/5 shadow-2xl/40 animate-modalFade slide-in overflow-y-auto">
+    <header class="relative px-8 py-5 border-b border-white/10">
+      <h2 class="text-lg font-semibold text-center text-white">Editar Produto</h2>
+      <button id="fecharEditarProduto" class="btn-danger icon-only absolute right-4 top-4 text-white">✕</button>
+    </header>
+    <form id="editarProdutoForm" class="p-8 grid md:grid-cols-2 gap-6">
+      <div class="relative">
+        <input id="codigo" name="codigo" type="text" placeholder=" " required class="peer w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-transparent focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+        <label for="codigo" class="absolute left-4 top-1/2 -translate-y-1/2 text-base text-gray-300 pointer-events-none transition-all duration-150 peer-placeholder-shown:top-1/2 peer-focus:top-0 peer-focus:-translate-y-full peer-focus:text-xs peer-focus:text-primary">Código</label>
+      </div>
+      <div class="relative md:col-span-2">
+        <input id="nome" name="nome" type="text" placeholder=" " required class="peer w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-transparent focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+        <label for="nome" class="absolute left-4 top-1/2 -translate-y-1/2 text-base text-gray-300 pointer-events-none transition-all duration-150 peer-placeholder-shown:top-1/2 peer-focus:top-0 peer-focus:-translate-y-full peer-focus:text-xs peer-focus:text-primary">Nome</label>
+      </div>
+      <div class="relative">
+        <input id="categoria" name="categoria" type="text" placeholder=" " class="peer w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-transparent focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+        <label for="categoria" class="absolute left-4 top-1/2 -translate-y-1/2 text-base text-gray-300 pointer-events-none transition-all duration-150 peer-placeholder-shown:top-1/2 peer-focus:top-0 peer-focus:-translate-y-full peer-focus:text-xs peer-focus:text-primary">Categoria</label>
+      </div>
+      <div class="relative">
+        <input id="preco" name="preco" type="number" min="0" step="0.01" placeholder=" " required class="peer w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-transparent focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+        <label for="preco" class="absolute left-4 top-1/2 -translate-y-1/2 text-base text-gray-300 pointer-events-none transition-all duration-150 peer-placeholder-shown:top-1/2 peer-focus:top-0 peer-focus:-translate-y-full peer-focus:text-xs peer-focus:text-primary">Preço de Venda</label>
+      </div>
+      <div class="relative">
+        <input id="markup" name="markup" type="number" min="0" step="0.1" placeholder=" " class="peer w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-transparent focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+        <label for="markup" class="absolute left-4 top-1/2 -translate-y-1/2 text-base text-gray-300 pointer-events-none transition-all duration-150 peer-placeholder-shown:top-1/2 peer-focus:top-0 peer-focus:-translate-y-full peer-focus:text-xs peer-focus:text-primary">Markup %</label>
+      </div>
+      <div class="relative">
+        <select id="status" name="status" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition">
+          <option value="Em linha">Em linha</option>
+          <option value="Inativo">Inativo</option>
+        </select>
+      </div>
+    </form>
+    <footer class="flex justify-end gap-4 px-8 py-6 border-t border-white/10">
+      <button type="button" id="cancelarEditarProduto" class="btn-danger px-6 py-3 rounded-xl text-white font-medium active:scale-95">Cancelar</button>
+      <button type="submit" form="editarProdutoForm" class="btn-primary px-6 py-3 rounded-xl text-white font-medium active:scale-95">Salvar</button>
+    </footer>
+  </div>
+</div>

--- a/src/html/modals/produtos/excluir.html
+++ b/src/html/modals/produtos/excluir.html
@@ -1,0 +1,12 @@
+<div id="excluirProdutoOverlay" class="fixed inset-0 bg-black/50 flex items-center justify-center p-4">
+  <div class="max-w-sm w-full glass-surface backdrop-blur-xl rounded-2xl border border-white/10 ring-1 ring-white/5 shadow-2xl/40 animate-modalFade">
+    <div class="p-6 text-center">
+      <h3 class="text-lg font-semibold mb-4 text-white">Tem certeza?</h3>
+      <p class="text-sm text-gray-300">Deseja excluir este produto? Esta ação não pode ser desfeita.</p>
+      <div class="flex justify-center gap-6 mt-8">
+        <button id="cancelarExcluirProduto" class="btn-danger px-6 py-2 rounded-lg text-white font-medium active:scale-95">Cancelar</button>
+        <button id="confirmarExcluirProduto" class="btn-success px-6 py-2 rounded-lg font-medium active:scale-95">Confirmar</button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/html/modals/produtos/novo.html
+++ b/src/html/modals/produtos/novo.html
@@ -1,0 +1,41 @@
+<div id="novoProdutoOverlay" class="fixed inset-0 bg-black/50 flex items-center justify-center p-6">
+  <div class="w-full max-w-2xl glass-surface backdrop-blur-xl rounded-3xl border border-white/10 ring-1 ring-white/5 shadow-2xl/40 animate-modalFade slide-in overflow-y-auto">
+    <header class="relative px-8 py-5 border-b border-white/10">
+      <h2 class="text-lg font-semibold text-center text-white">Novo Produto</h2>
+      <button id="fecharNovoProduto" class="btn-danger icon-only absolute right-4 top-4 text-white">✕</button>
+    </header>
+    <form id="novoProdutoForm" class="p-8 grid md:grid-cols-2 gap-6">
+      <div class="relative">
+        <input id="codigo" name="codigo" type="text" placeholder=" " required class="peer w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-transparent focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+        <label for="codigo" class="absolute left-4 top-1/2 -translate-y-1/2 text-base text-gray-300 pointer-events-none transition-all duration-150 peer-placeholder-shown:top-1/2 peer-focus:top-0 peer-focus:-translate-y-full peer-focus:text-xs peer-focus:text-primary">Código</label>
+      </div>
+      <div class="relative md:col-span-2">
+        <input id="nome" name="nome" type="text" placeholder=" " required class="peer w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-transparent focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+        <label for="nome" class="absolute left-4 top-1/2 -translate-y-1/2 text-base text-gray-300 pointer-events-none transition-all duration-150 peer-placeholder-shown:top-1/2 peer-focus:top-0 peer-focus:-translate-y-full peer-focus:text-xs peer-focus:text-primary">Nome</label>
+      </div>
+      <div class="relative">
+        <input id="categoria" name="categoria" type="text" placeholder=" " class="peer w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-transparent focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+        <label for="categoria" class="absolute left-4 top-1/2 -translate-y-1/2 text-base text-gray-300 pointer-events-none transition-all duration-150 peer-placeholder-shown:top-1/2 peer-focus:top-0 peer-focus:-translate-y-full peer-focus:text-xs peer-focus:text-primary">Categoria</label>
+      </div>
+      <div class="relative">
+        <input id="preco" name="preco" type="number" min="0" step="0.01" placeholder=" " required class="peer w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-transparent focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+        <label for="preco" class="absolute left-4 top-1/2 -translate-y-1/2 text-base text-gray-300 pointer-events-none transition-all duration-150 peer-placeholder-shown:top-1/2 peer-focus:top-0 peer-focus:-translate-y-full peer-focus:text-xs peer-focus:text-primary">Preço de Venda</label>
+      </div>
+      <div class="relative">
+        <input id="markup" name="markup" type="number" min="0" step="0.1" placeholder=" " class="peer w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-transparent focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+        <label for="markup" class="absolute left-4 top-1/2 -translate-y-1/2 text-base text-gray-300 pointer-events-none transition-all duration-150 peer-placeholder-shown:top-1/2 peer-focus:top-0 peer-focus:-translate-y-full peer-focus:text-xs peer-focus:text-primary">Markup %</label>
+      </div>
+      <div class="relative">
+        <select id="status" name="status" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition">
+          <option value="">Status</option>
+          <option value="Em linha">Em linha</option>
+          <option value="Inativo">Inativo</option>
+        </select>
+      </div>
+    </form>
+    <footer class="flex justify-end gap-4 px-8 py-6 border-t border-white/10">
+      <button type="button" id="cancelarNovoProduto" class="btn-danger px-6 py-3 rounded-xl text-white font-medium active:scale-95">Cancelar</button>
+      <button type="submit" form="novoProdutoForm" class="btn-primary px-6 py-3 rounded-xl text-white font-medium active:scale-95">Salvar</button>
+    </footer>
+  </div>
+</div>

--- a/src/html/produtos.html
+++ b/src/html/produtos.html
@@ -80,7 +80,7 @@
                         <button class="btn-secondary flex-1 text-white rounded-md h-12 font-medium whitespace-nowrap">
                             <i class="fas fa-filter mr-2"></i>Filtrar
                         </button>
-                        <button class="btn-primary flex-1 text-white rounded-md h-12 font-medium whitespace-nowrap">
+                        <button id="btnNovoProduto" class="btn-primary flex-1 text-white rounded-md h-12 font-medium whitespace-nowrap">
                             <i class="fas fa-plus mr-2"></i>Novo
                         </button>
                     </div>

--- a/src/js/modals/produto-detalhes.js
+++ b/src/js/modals/produto-detalhes.js
@@ -1,0 +1,25 @@
+(function(){
+  const overlay = document.getElementById('detalhesProdutoOverlay');
+  const close = () => Modal.close('detalhesProduto');
+  overlay.addEventListener('click', e => { if(e.target === overlay) close(); });
+  document.getElementById('fecharDetalhesProduto').addEventListener('click', close);
+  document.addEventListener('keydown', function esc(e){ if(e.key==='Escape'){ close(); document.removeEventListener('keydown', esc); } });
+  (async () => {
+    const item = window.produtoDetalhes;
+    if(!item) return;
+    try{
+      const dados = await window.electronAPI.obterProduto(item.id);
+      const info = { ...item, ...dados };
+      document.getElementById('detCodigo').textContent = info.codigo || '';
+      document.getElementById('detNome').textContent = info.nome || '';
+      document.getElementById('detCategoria').textContent = info.categoria || '';
+      document.getElementById('detPreco').textContent = info.preco_venda != null ? `R$ ${Number(info.preco_venda).toFixed(2).replace('.', ',')}` : '';
+      document.getElementById('detMarkup').textContent = info.pct_markup != null ? `${Number(info.pct_markup).toFixed(1)}%` : '';
+      document.getElementById('detStatus').textContent = info.status || '';
+      document.getElementById('detQuantidade').textContent = info.quantidade_total ?? 0;
+    }catch(err){
+      console.error(err);
+      showToast('Erro ao carregar detalhes', 'error');
+    }
+  })();
+})();

--- a/src/js/modals/produto-editar.js
+++ b/src/js/modals/produto-editar.js
@@ -1,0 +1,44 @@
+(function(){
+  const overlay = document.getElementById('editarProdutoOverlay');
+  const close = () => Modal.close('editarProduto');
+  overlay.addEventListener('click', e => { if (e.target === overlay) close(); });
+  document.getElementById('fecharEditarProduto').addEventListener('click', close);
+  document.getElementById('cancelarEditarProduto').addEventListener('click', close);
+  document.addEventListener('keydown', function esc(e){ if(e.key==='Escape'){ close(); document.removeEventListener('keydown', esc); } });
+  const form = document.getElementById('editarProdutoForm');
+  const item = window.produtoSelecionado;
+  if(item){
+    form.codigo.value = item.codigo || '';
+    form.nome.value = item.nome || '';
+    form.categoria.value = item.categoria || '';
+    form.preco.value = item.preco_venda || '';
+    form.markup.value = item.pct_markup || '';
+    form.status.value = item.status || '';
+  }
+  form.codigo.focus();
+  form.addEventListener('submit', async e => {
+    e.preventDefault();
+    if(!item) return;
+    const dados = {
+      codigo: form.codigo.value.trim(),
+      nome: form.nome.value.trim(),
+      categoria: form.categoria.value.trim(),
+      preco_venda: parseFloat(form.preco.value),
+      pct_markup: form.markup.value ? parseFloat(form.markup.value) : null,
+      status: form.status.value.trim()
+    };
+    if(!dados.codigo || !dados.nome || isNaN(dados.preco_venda)){
+      showToast('Preencha os campos obrigatórios.', 'error');
+      return;
+    }
+    try{
+      await window.electronAPI.atualizarProduto(item.id, dados);
+      showToast('Produto atualizado com sucesso!', 'success');
+      close();
+      carregarProdutos();
+    }catch(err){
+      console.error(err);
+      showToast('Erro ao atualizar produto', 'error');
+    }
+  });
+})();

--- a/src/js/modals/produto-excluir.js
+++ b/src/js/modals/produto-excluir.js
@@ -1,0 +1,20 @@
+(function(){
+  const overlay = document.getElementById('excluirProdutoOverlay');
+  const close = () => Modal.close('excluirProduto');
+  overlay.addEventListener('click', e => { if (e.target === overlay) close(); });
+  document.getElementById('cancelarExcluirProduto').addEventListener('click', close);
+  document.addEventListener('keydown', function esc(e){ if(e.key==='Escape'){ close(); document.removeEventListener('keydown', esc); } });
+  document.getElementById('confirmarExcluirProduto').addEventListener('click', async () => {
+    const item = window.produtoExcluir;
+    if(!item) return;
+    try{
+      await window.electronAPI.excluirProduto(item.id);
+      showToast('Produto excluído com sucesso!', 'success');
+      close();
+      carregarProdutos();
+    }catch(err){
+      console.error(err);
+      showToast('Erro ao excluir produto', 'error');
+    }
+  });
+})();

--- a/src/js/modals/produto-novo.js
+++ b/src/js/modals/produto-novo.js
@@ -1,0 +1,34 @@
+(function(){
+  const overlay = document.getElementById('novoProdutoOverlay');
+  const close = () => Modal.close('novoProduto');
+  overlay.addEventListener('click', e => { if (e.target === overlay) close(); });
+  document.getElementById('fecharNovoProduto').addEventListener('click', close);
+  document.getElementById('cancelarNovoProduto').addEventListener('click', close);
+  document.addEventListener('keydown', function esc(e){ if(e.key==='Escape'){ close(); document.removeEventListener('keydown', esc); } });
+  const form = document.getElementById('novoProdutoForm');
+  document.getElementById('codigo').focus();
+  form.addEventListener('submit', async e => {
+    e.preventDefault();
+    const dados = {
+      codigo: form.codigo.value.trim(),
+      nome: form.nome.value.trim(),
+      categoria: form.categoria.value.trim(),
+      preco_venda: parseFloat(form.preco.value),
+      pct_markup: form.markup.value ? parseFloat(form.markup.value) : null,
+      status: form.status.value.trim()
+    };
+    if(!dados.codigo || !dados.nome || isNaN(dados.preco_venda)){
+      showToast('Preencha os campos obrigatórios.', 'error');
+      return;
+    }
+    try{
+      await window.electronAPI.adicionarProduto(dados);
+      showToast('Produto criado com sucesso!', 'success');
+      close();
+      carregarProdutos();
+    }catch(err){
+      console.error(err);
+      showToast('Erro ao criar produto', 'error');
+    }
+  });
+})();


### PR DESCRIPTION
## Summary
- add complete CRUD support for products with backend handlers and IPC wiring
- implement frontend modals for creating, viewing, editing, and deleting products
- wire product page actions to open modals, validate data, and refresh table

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_689a4ec0cd408322a72acab98b78b655