### PR TITLE
Fix Listar Detalhes Produto Query

### DIFF
--- a/backend/produtos.js
+++ b/backend/produtos.js
@@ -26,12 +26,11 @@ async function listarProdutos() {
 async function listarDetalhesProduto(produtoId) {
   const query = `
     SELECT pe.id,
-           e.nome AS etapa_nome,
+           pe.etapa_id AS etapa_nome,
            mp.nome AS ultimo_item,
            pe.quantidade,
            pe.data_hora_completa
       FROM produtos_em_cada_ponto pe
-      LEFT JOIN etapas e ON e.id = pe.etapa_id
       LEFT JOIN materia_prima mp ON mp.id = pe.ultimo_insumo_id
      WHERE pe.produto_id = $1
      ORDER BY pe.data_hora_completa DESC`;


### PR DESCRIPTION
## Summary
- read stage name directly from produtos_em_cada_ponto when listing product details

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689a5a3273a88322b6519e56823295b0