### PR TITLE
Make Product Table Editing Functional

### DIFF
--- a/backend/produtos.js
+++ b/backend/produtos.js
@@ -44,6 +44,28 @@ async function obterProduto(id) {
   return res.rows[0];
 }
 
+async function listarInsumosProduto(codigo) {
+  const query = `
+    SELECT pi.id,
+           mp.nome,
+           pi.quantidade,
+           mp.preco_unitario * pi.quantidade AS total,
+           mp.processo
+      FROM produtos_insumo pi
+      JOIN materia_prima mp ON mp.id = pi.insumo_id
+     WHERE pi.produto_codigo = $1
+     ORDER BY mp.processo, mp.nome`;
+  const res = await pool.query(query, [codigo]);
+  return res.rows;
+}
+
+async function listarEtapasProducao() {
+  const res = await pool.query(
+    'SELECT id, nome FROM etapas_producao ORDER BY ordem'
+  );
+  return res.rows;
+}
+
 async function adicionarProduto(dados) {
   const { codigo, nome, categoria, preco_venda, pct_markup, status } = dados;
   const res = await pool.query(
@@ -78,6 +100,8 @@ module.exports = {
   listarProdutos,
   listarDetalhesProduto,
   obterProduto,
+  listarInsumosProduto,
+  listarEtapasProducao,
   adicionarProduto,
   atualizarProduto,
   excluirProduto

--- a/main.js
+++ b/main.js
@@ -24,7 +24,9 @@ const {
   adicionarProduto,
   atualizarProduto,
   excluirProduto,
-  listarDetalhesProduto
+  listarDetalhesProduto,
+  listarInsumosProduto,
+  listarEtapasProducao
 } = require('./backend/produtos');
 const apiServer = require('./backend/server');
 // Impede que múltiplas instâncias do aplicativo sejam abertas
@@ -371,6 +373,12 @@ ipcMain.handle('excluir-produto', async (_e, id) => {
 });
 ipcMain.handle('listar-detalhes-produto', async (_e, id) => {
   return listarDetalhesProduto(id);
+});
+ipcMain.handle('listar-insumos-produto', async (_e, codigo) => {
+  return listarInsumosProduto(codigo);
+});
+ipcMain.handle('listar-etapas-producao', async () => {
+  return listarEtapasProducao();
 });
 
 ipcMain.handle('auto-login', async (_event, pin) => {

--- a/preload.js
+++ b/preload.js
@@ -12,6 +12,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
   atualizarProduto: (id, dados) => ipcRenderer.invoke('atualizar-produto', { id, dados }),
   excluirProduto: (id) => ipcRenderer.invoke('excluir-produto', id),
   listarDetalhesProduto: (id) => ipcRenderer.invoke('listar-detalhes-produto', id),
+  listarInsumosProduto: (codigo) => ipcRenderer.invoke('listar-insumos-produto', codigo),
+  listarEtapasProducao: () => ipcRenderer.invoke('listar-etapas-producao'),
   adicionarMateriaPrima: (dados) => ipcRenderer.invoke('adicionar-materia-prima', dados),
   atualizarMateriaPrima: (id, dados) => ipcRenderer.invoke('atualizar-materia-prima', { id, dados }),
   excluirMateriaPrima: (id) => ipcRenderer.invoke('excluir-materia-prima', id),

--- a/src/html/modals/produtos/editar.html
+++ b/src/html/modals/produtos/editar.html
@@ -57,11 +57,7 @@
         </div>
 
         <div class="flex gap-4">
-          <select class="flex-1 bg-input border border-inputBorder rounded-lg px-4 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition">
-            <option>Marcenaria</option>
-            <option>Montagem</option>
-            <option>Acabamento</option>
-          </select>
+          <select id="etapaSelect" class="flex-1 bg-input border border-inputBorder rounded-lg px-4 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition"></select>
           <button class="btn-primary px-6 py-3 rounded-lg text-white font-medium">+ Começar</button>
         </div>
       </div>
@@ -105,98 +101,63 @@
 
         <div class="space-y-6">
           <div class="glass-surface rounded-xl p-6 border border-white/10">
-            <h3 class="text-lg font-semibold mb-4 text-white">ITENS</h3>
-            <div class="overflow-x-auto">
-              <div class="max-h-64 overflow-y-auto">
-                <table id="itensTabela" class="w-full text-sm">
-                  <thead class="sticky top-0 glass-surface">
-                    <tr class="border-b border-white/10">
-                      <th class="text-left py-3 px-2 text-gray-300 font-medium">NOME DO ITEM</th>
-                      <th class="text-center py-3 px-2 text-gray-300 font-medium">QUANTIDADE</th>
-                      <th class="text-right py-3 px-2 text-gray-300 font-medium">VALOR TOTAL</th>
-                      <th class="text-center py-3 px-2 text-gray-300 font-medium">AÇÃO</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    <tr class="border-b border-white/5">
-                      <td class="py-3 px-2 text-white">Tampo de Madeira 180x90</td>
-                      <td class="py-3 px-2 text-center text-gray-300 item-qty">1</td>
-                      <td class="py-3 px-2 text-right text-white item-total">R$ 450,00</td>
-                      <td class="py-3 px-2 text-center">
-                        <div class="flex justify-center gap-2">
-                          <button class="edit-item icon-only bg-blue-600/20 text-blue-400 hover:bg-blue-600/30">✎</button>
-                          <button class="remove-item icon-only bg-red-600/20 text-red-400 hover:bg-red-600/30">🗑</button>
-                        </div>
-                      </td>
-                    </tr>
-                    <tr class="border-b border-white/5">
-                      <td class="py-3 px-2 text-white">Pé de Mesa Torneado</td>
-                      <td class="py-3 px-2 text-center text-gray-300 item-qty">4</td>
-                      <td class="py-3 px-2 text-right text-white item-total">R$ 320,00</td>
-                      <td class="py-3 px-2 text-center">
-                        <div class="flex justify-center gap-2">
-                          <button class="edit-item icon-only bg-blue-600/20 text-blue-400 hover:bg-blue-600/30">✎</button>
-                          <button class="remove-item icon-only bg-red-600/20 text-red-400 hover:bg-red-600/30">🗑</button>
-                        </div>
-                      </td>
-                    </tr>
-                    <tr class="border-b border-white/5">
-                      <td class="py-3 px-2 text-white">Parafuso Phillips 6x40</td>
-                      <td class="py-3 px-2 text-center text-gray-300 item-qty">16</td>
-                      <td class="py-3 px-2 text-right text-white item-total">R$ 24,00</td>
-                      <td class="py-3 px-2 text-center">
-                        <div class="flex justify-center gap-2">
-                          <button class="edit-item icon-only bg-blue-600/20 text-blue-400 hover:bg-blue-600/30">✎</button>
-                          <button class="remove-item icon-only bg-red-600/20 text-red-400 hover:bg-red-600/30">🗑</button>
-                        </div>
-                      </td>
-                    </tr>
-                  </tbody>
-                </table>
+            <h3 class="text-lg font-semibold mb-4 text-white">SOMAS</h3>
+            <div class="space-y-3 text-sm">
+              <div class="flex justify-between">
+                <span class="text-gray-300">Total Insumos</span>
+                <span id="totalInsumos" class="text-white font-medium">R$ 0,00</span>
+              </div>
+              <div class="flex justify-between">
+                <span class="text-gray-300">Total Mão-de-obra</span>
+                <span id="totalMaoObra" class="text-white font-medium">R$ 0,00</span>
+              </div>
+              <div class="flex justify-between">
+                <span class="text-gray-300">Sub-Total</span>
+                <span id="subTotal" class="text-white font-medium">R$ 0,00</span>
+              </div>
+              <div class="flex justify-between">
+                <span class="text-gray-300">Markup</span>
+                <span id="markupValor" class="text-white font-medium">R$ 0,00</span>
+              </div>
+              <div class="flex justify-between border-t border-white/10 pt-3">
+                <span class="text-gray-300">Custo Total</span>
+                <span id="custoTotal" class="text-white font-semibold">R$ 0,00</span>
+              </div>
+              <div class="flex justify-between">
+                <span class="text-gray-300">Comissão</span>
+                <span id="comissaoValor" class="text-white font-medium">R$ 0,00</span>
+              </div>
+              <div class="flex justify-between">
+                <span class="text-gray-300">Imposto</span>
+                <span id="impostoValor" class="text-white font-medium">R$ 0,00</span>
               </div>
             </div>
-            <p class="text-xs text-gray-400 mt-4">✎ edita quantidade; 🗑 remove o item.</p>
+          </div>
+          <div class="flex items-end justify-end">
+            <button id="salvarEditarProduto" class="btn-success px-8 py-4 rounded-xl font-semibold text-lg">Salvar</button>
           </div>
         </div>
       </div>
 
-      <div class="px-8 py-6 border-t border-white/10 grid grid-cols-1 xl:grid-cols-2 gap-8">
+      <div class="px-8 py-6 border-t border-white/10">
         <div class="glass-surface rounded-xl p-6 border border-white/10">
-          <h3 class="text-lg font-semibold mb-4 text-white">SOMAS</h3>
-          <div class="space-y-3 text-sm">
-            <div class="flex justify-between">
-              <span class="text-gray-300">Total Insumos</span>
-              <span id="totalInsumos" class="text-white font-medium">R$ 794,00</span>
-            </div>
-            <div class="flex justify-between">
-              <span class="text-gray-300">Total Mão-de-obra</span>
-              <span id="totalMaoObra" class="text-white font-medium">R$ 397,00</span>
-            </div>
-            <div class="flex justify-between">
-              <span class="text-gray-300">Sub-Total</span>
-              <span id="subTotal" class="text-white font-medium">R$ 1.191,00</span>
-            </div>
-            <div class="flex justify-between">
-              <span class="text-gray-300">Markup</span>
-              <span id="markupValor" class="text-white font-medium">R$ 357,30</span>
-            </div>
-            <div class="flex justify-between border-t border-white/10 pt-3">
-              <span class="text-gray-300">Custo Total</span>
-              <span id="custoTotal" class="text-white font-semibold">R$ 1.548,30</span>
-            </div>
-            <div class="flex justify-between">
-              <span class="text-gray-300">Comissão</span>
-              <span id="comissaoValor" class="text-white font-medium">R$ 123,86</span>
-            </div>
-            <div class="flex justify-between">
-              <span class="text-gray-300">Imposto</span>
-              <span id="impostoValor" class="text-white font-medium">R$ 185,80</span>
+          <h3 class="text-lg font-semibold mb-4 text-white">ITENS</h3>
+          <div class="overflow-x-auto">
+            <div class="max-h-64 overflow-y-auto">
+              <table id="itensTabela" class="w-full text-sm">
+                <thead class="sticky top-0 glass-surface">
+                  <tr class="border-b border-white/10">
+                    <th class="text-left py-3 px-2 text-gray-300 font-medium">NOME DO ITEM</th>
+                    <th class="text-center py-3 px-2 text-gray-300 font-medium">QUANTIDADE</th>
+                    <th class="text-right py-3 px-2 text-gray-300 font-medium">VALOR TOTAL</th>
+                    <th class="text-center py-3 px-2 text-gray-300 font-medium">AÇÃO</th>
+                  </tr>
+                </thead>
+                <tbody></tbody>
+              </table>
             </div>
           </div>
-        </div>
-
-        <div class="flex items-end justify-end">
-          <button id="salvarEditarProduto" class="btn-success px-8 py-4 rounded-xl font-semibold text-lg">Salvar</button>
+          <p class="text-xs text-gray-400 mt-4">✎ edita quantidade; 🗑 remove o item.</p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Dynamically load product percentages, insumos and production stages from database
- Rework edit modal layout so sums sit beside percentages and items fill full width below
- Add backend endpoints and IPC bridges for insumos and etapas retrieval

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689a5c1d62d48322ac9fb362cf9aaa6c