### PR TITLE
Padronizar Mensagem De Exclusão No Detalhe De Estoque

### DIFF
--- a/src/html/modals/produtos/excluir-lote.html
+++ b/src/html/modals/produtos/excluir-lote.html
@@ -1,0 +1,12 @@
+<div id="excluirLoteOverlay" class="fixed inset-0 bg-black/50 flex items-center justify-center p-4">
+  <div class="max-w-sm w-full glass-surface backdrop-blur-xl rounded-2xl border border-white/10 ring-1 ring-white/5 shadow-2xl/40 animate-modalFade">
+    <div class="p-6 text-center">
+      <h3 class="text-lg font-semibold mb-4 text-white">Tem certeza?</h3>
+      <p class="text-sm text-gray-300">Deseja excluir este lote? Esta ação não pode ser desfeita.</p>
+      <div class="flex justify-center gap-6 mt-8">
+        <button id="cancelarExcluirLote" class="btn-danger px-6 py-2 rounded-lg text-white font-medium active:scale-95">Cancelar</button>
+        <button id="confirmarExcluirLote" class="btn-success px-6 py-2 rounded-lg font-medium active:scale-95">Confirmar</button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/js/modals/produto-detalhes.js
+++ b/src/js/modals/produto-detalhes.js
@@ -81,16 +81,9 @@
     cancelBtn.addEventListener('click', () => carregarDetalhes(item.id));
   }
 
-  async function excluirLote(id) {
-    if (!confirm('Deseja excluir este lote?')) return;
-    try {
-      await window.electronAPI.excluirLoteProduto(id);
-      showToast('Lote excluído', 'success');
-      carregarDetalhes(item.id);
-    } catch (err) {
-      console.error(err);
-      showToast('Erro ao excluir lote', 'error');
-    }
+  function excluirLote(id) {
+    window.loteExcluir = { id, reload: () => carregarDetalhes(item.id) };
+    Modal.open('modals/produtos/excluir-lote.html', '../js/modals/produto-lote-excluir.js', 'excluirLote');
   }
 
   function formatDateTime(value){

--- a/src/js/modals/produto-lote-excluir.js
+++ b/src/js/modals/produto-lote-excluir.js
@@ -1,0 +1,21 @@
+(function(){
+  const overlay = document.getElementById('excluirLoteOverlay');
+  const close = () => Modal.close('excluirLote');
+  overlay.addEventListener('click', e => { if (e.target === overlay) close(); });
+  document.getElementById('cancelarExcluirLote').addEventListener('click', close);
+  document.addEventListener('keydown', function esc(e){ if(e.key==='Escape'){ close(); document.removeEventListener('keydown', esc); } });
+  document.getElementById('confirmarExcluirLote').addEventListener('click', async () => {
+    const item = window.loteExcluir;
+    if(!item) return;
+    try {
+      await window.electronAPI.excluirLoteProduto(item.id);
+      showToast('Lote excluído', 'success');
+      close();
+      item.reload?.();
+      window.loteExcluir = null;
+    } catch (err) {
+      console.error(err);
+      showToast('Erro ao excluir lote', 'error');
+    }
+  });
+})();


### PR DESCRIPTION
## Summary
- alinhar exclusão de lotes de estoque ao padrão visual dos modais

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689a63a53d708322909750719bd96d92