### PR TITLE
Fix Delete Confirmation And Refresh Product Table

### DIFF
--- a/src/js/modals/produto-detalhes.js
+++ b/src/js/modals/produto-detalhes.js
@@ -73,6 +73,7 @@
         await window.electronAPI.atualizarLoteProduto({ id: dados.id, quantidade: novaQtd });
         showToast('Quantidade atualizada', 'success');
         carregarDetalhes(item.id);
+        carregarProdutos();
       } catch (err) {
         console.error(err);
         showToast('Erro ao atualizar quantidade', 'error');
@@ -82,8 +83,14 @@
   }
 
   function excluirLote(id) {
-    window.loteExcluir = { id, reload: () => carregarDetalhes(item.id) };
-    Modal.open('modals/produtos/excluir-lote.html', '../js/modals/produto-lote-excluir.js', 'excluirLote');
+    window.loteExcluir = {
+      id,
+      reload: () => {
+        carregarDetalhes(item.id);
+        carregarProdutos();
+      }
+    };
+    Modal.open('modals/produtos/excluir-lote.html', '../js/modals/produto-lote-excluir.js', 'excluirLote', true);
   }
 
   function formatDateTime(value){

--- a/src/utils/modal.js
+++ b/src/utils/modal.js
@@ -6,7 +6,7 @@ const ModalManager = (() => {
   const modalConfigs = {
   };
 
-  async function open(htmlPath, scriptPath, overlayId) {
+  async function open(htmlPath, scriptPath, overlayId, keepExisting = false) {
     if (arguments.length === 1) {
       const cfg = modalConfigs[htmlPath];
       if (!cfg) return;
@@ -16,7 +16,7 @@ const ModalManager = (() => {
     }
 
     // Closing existing modals invalidates older open() calls via openToken.
-    closeAll();
+    if (!keepExisting) closeAll();
     // Increment and store token so async steps know if they should continue.
     const token = ++openToken;
 


### PR DESCRIPTION
## Summary
- allow nested modals without closing existing ones
- refresh main product table after lot edits or deletions

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689a65e5888883228dd9030c704e1bca