### PR TITLE
Remove X Buttons from Product Modals

### DIFF
--- a/src/html/modals/produtos/detalhes.html
+++ b/src/html/modals/produtos/detalhes.html
@@ -1,10 +1,9 @@
 <div id="detalhesProdutoOverlay" class="fixed inset-0 bg-black/50 flex items-center justify-center p-4">
   <div class="w-full max-w-6xl max-h-[90vh] glass-surface backdrop-blur-xl rounded-3xl border border-white/10 ring-1 ring-white/5 shadow-2xl/40 animate-modalFade slide-in overflow-hidden flex flex-col">
     <header class="px-8 py-5 border-b border-white/10 flex-shrink-0">
-      <div class="flex items-center justify-between mb-3">
+      <div class="flex items-center mb-3">
         <button id="voltarDetalhesProduto" class="btn-neutral px-4 py-2 rounded-lg text-white font-medium flex items-center gap-2">← Voltar</button>
         <h2 id="detalheTitulo" class="text-lg font-semibold text-white text-center flex-1 mx-4">DETALHE DE ESTOQUE – Produto</h2>
-        <button id="fecharDetalhesProduto" class="btn-danger icon-only text-white">✕</button>
       </div>
       <p class="text-sm text-gray-400 text-center">Último Lote Adicionado #12345 — Data: 26/06/2025</p>
     </header>

--- a/src/html/modals/produtos/editar.html
+++ b/src/html/modals/produtos/editar.html
@@ -5,7 +5,6 @@
       <h2 class="text-lg font-semibold text-white">EDITAR PRODUTO</h2>
       <div class="flex items-center gap-3">
         <button id="limparTudo" class="btn-danger px-4 py-2 rounded-lg text-white font-medium flex items-center gap-2">🗑️ Limpar Tudo</button>
-        <button id="fecharEditarProduto" class="btn-danger icon-only text-white">✕</button>
       </div>
     </header>
 

--- a/src/js/modals/produto-detalhes.js
+++ b/src/js/modals/produto-detalhes.js
@@ -2,7 +2,6 @@
   const overlay = document.getElementById('detalhesProdutoOverlay');
   const close = () => Modal.close('detalhesProduto');
   overlay.addEventListener('click', e => { if(e.target === overlay) close(); });
-  document.getElementById('fecharDetalhesProduto').addEventListener('click', close);
   const voltar = document.getElementById('voltarDetalhesProduto');
   if (voltar) voltar.addEventListener('click', close);
   document.addEventListener('keydown', function esc(e){ if(e.key==='Escape'){ close(); document.removeEventListener('keydown', esc); } });

--- a/src/js/modals/produto-editar.js
+++ b/src/js/modals/produto-editar.js
@@ -2,7 +2,6 @@
   const overlay = document.getElementById('editarProdutoOverlay');
   const close = () => Modal.close('editarProduto');
   overlay.addEventListener('click', e => { if (e.target === overlay) close(); });
-  document.getElementById('fecharEditarProduto').addEventListener('click', close);
   document.getElementById('voltarEditarProduto').addEventListener('click', close);
 
   const tableBody = document.querySelector('#itensTabela tbody');


### PR DESCRIPTION
## Summary
- Remove close (X) buttons from product detail and edit modals, leaving only the back button
- Remove unused event listeners tied to the deleted buttons

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689b7b33091c8322a0ec4e69b13b1cdb