### PR TITLE
Remove Observações E Ícones De Limpar Tudo

### DIFF
--- a/src/html/modals/produtos/detalhes.html
+++ b/src/html/modals/produtos/detalhes.html
@@ -27,9 +27,7 @@
               </table>
             </div>
           </div>
-          <div class="px-4 py-3 border-t border-white/10 bg-surface/20">
-            <p class="text-xs text-gray-400">✎ edita quantidade; 🗑 remove o lote.</p>
-          </div>
+          <!-- Observações removidas -->
         </div>
       </div>
 

--- a/src/html/modals/produtos/editar.html
+++ b/src/html/modals/produtos/editar.html
@@ -5,7 +5,7 @@
       <h2 class="text-lg font-semibold text-white">EDITAR PRODUTO</h2>
       <div class="flex items-center gap-3">
         <button id="salvarEditarProduto" class="btn-success px-4 py-2 rounded-lg text-white font-medium flex items-center gap-2">Salvar</button>
-        <button id="limparTudo" class="btn-danger px-4 py-2 rounded-lg text-white font-medium flex items-center gap-2">🗑️ Limpar Tudo</button>
+          <button id="limparTudo" class="btn-danger px-4 py-2 rounded-lg text-white font-medium">Limpar Tudo</button>
       </div>
     </header>
 
@@ -158,7 +158,7 @@
               </table>
             </div>
           </div>
-          <p class="text-xs text-gray-400 mt-4">✎ edita quantidade; 🗑 remove o item.</p>
+          <!-- Observações removidas -->
         </div>
       </div>
     </div>

--- a/src/html/modals/produtos/novo.html
+++ b/src/html/modals/produtos/novo.html
@@ -5,8 +5,8 @@
         ← Voltar
       </button>
       <h2 class="text-lg font-semibold text-white">INSERIR NOVO PRODUTO</h2>
-      <button id="limparNovoProduto" class="btn-danger px-4 py-2 rounded-lg text-white font-medium flex items-center gap-2">
-        🗑️ Limpar Tudo
+      <button id="limparNovoProduto" class="btn-danger px-4 py-2 rounded-lg text-white font-medium">
+        Limpar Tudo
       </button>
     </header>
     <div class="flex-1 overflow-y-auto">
@@ -162,7 +162,7 @@
               </table>
             </div>
           </div>
-          <p class="text-xs text-gray-400 mt-4">✎ edita quantidade; 🗑 remove o item.</p>
+          <!-- Observações removidas -->
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- remove trash icons from Limpar Tudo buttons in product modals
- drop explanatory footnotes about editing/removing items or lots

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689b7dbb0cb883228e96a08d3d1cd948