### PR TITLE
Implement Modal Overlay For Editar Produto

### DIFF
--- a/src/html/modals/produtos/editar.html
+++ b/src/html/modals/produtos/editar.html
@@ -58,7 +58,7 @@
 
         <div class="flex gap-4">
           <select id="etapaSelect" class="flex-1 bg-input border border-inputBorder rounded-lg px-4 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition"></select>
-          <button class="btn-primary px-6 py-3 rounded-lg text-white font-medium">+ Começar</button>
+          <button id="comecarEditarProduto" class="btn-primary px-6 py-3 rounded-lg text-white font-medium">+ Começar</button>
         </div>
       </div>
 

--- a/src/html/modals/produtos/proxima-etapa.html
+++ b/src/html/modals/produtos/proxima-etapa.html
@@ -1,0 +1,14 @@
+<div id="proximaEtapaOverlay" class="fixed inset-0 bg-black/60 flex items-center justify-center p-4">
+  <div role="dialog" aria-modal="true" tabindex="0" class="w-full max-w-lg bg-surface/60 backdrop-blur-xl rounded-3xl border border-white/10 ring-1 ring-white/5 shadow-2xl/40 animate-modalFade slide-in overflow-hidden flex flex-col">
+    <header class="flex items-center justify-between px-8 py-5 border-b border-white/10">
+      <h2 class="text-lg font-semibold text-white">PRÓXIMA ETAPA</h2>
+      <button id="fecharProximaEtapa" class="btn-danger icon-only text-white">✕</button>
+    </header>
+    <div class="flex-1 overflow-y-auto px-8 py-6">
+      <p class="text-gray-300">Conteúdo da próxima etapa...</p>
+    </div>
+    <footer class="flex items-center justify-end gap-3 px-8 py-5 border-t border-white/10">
+      <button id="voltarProximaEtapa" class="btn-neutral px-4 py-2 rounded-lg text-white font-medium">Fechar</button>
+    </footer>
+  </div>
+</div>

--- a/src/js/modals/produto-editar.js
+++ b/src/js/modals/produto-editar.js
@@ -14,6 +14,7 @@
   const taxInput = document.getElementById('taxInput');
   const etapaSelect = document.getElementById('etapaSelect');
   const editarRegistroToggle = document.getElementById('editarRegistroToggle');
+  const comecarBtn = document.getElementById('comecarEditarProduto');
 
   const nomeInput = document.getElementById('nomeInput');
   const codigoInput = document.getElementById('codigoInput');
@@ -32,6 +33,15 @@
   const impostoValorEl = document.getElementById('impostoValor');
   const valorVendaEl = document.getElementById('valorVenda');
   let registroOriginal = {};
+
+  // Abre a etapa seguinte em um novo modal sobreposto,
+  // mantendo o modal atual aberto porém inativo ao fundo.
+  comecarBtn.addEventListener('click', () => {
+    // Bloqueia interação com o modal base e aplica leve desfoque
+    overlay.classList.add('pointer-events-none', 'blur-sm');
+    // keepExisting=true mantém o modal original aberto
+    Modal.open('modals/produtos/proxima-etapa.html', '../js/modals/produto-proxima-etapa.js', 'proximaEtapa', true);
+  });
 
   // toggle on/off
   function updateRegistroEditState(){

--- a/src/js/modals/produto-proxima-etapa.js
+++ b/src/js/modals/produto-proxima-etapa.js
@@ -1,0 +1,18 @@
+(function(){
+  const overlay = document.getElementById('proximaEtapaOverlay');
+  const fecharBtn = document.getElementById('fecharProximaEtapa');
+  const voltarBtn = document.getElementById('voltarProximaEtapa');
+
+  // Helper function to close this overlay and restore the underlying modal
+  function closeOverlay(){
+    Modal.close('proximaEtapa');
+    // Reativa o modal principal removendo efeitos de bloqueio
+    const baseOverlay = document.getElementById('editarProdutoOverlay');
+    baseOverlay.classList.remove('pointer-events-none', 'blur-sm');
+  }
+
+  // Fecha ao clicar fora do conteúdo
+  overlay.addEventListener('click', (e) => { if(e.target === overlay) closeOverlay(); });
+  fecharBtn.addEventListener('click', closeOverlay);
+  voltarBtn.addEventListener('click', closeOverlay);
+})();


### PR DESCRIPTION
## Summary
- enable 'Começar' button to open overlay modal atop Editar Produto
- add new Proxima Etapa modal with standard layout and close behavior

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_689b8994080c8322a8f89b29c3e228c2