### PR TITLE
Corrigir Carregamento Da Tabela De Itens No Modal De Editar Produtos

### DIFF
--- a/src/js/modals/produto-editar.js
+++ b/src/js/modals/produto-editar.js
@@ -306,8 +306,13 @@
       const etapas = await window.electronAPI.listarEtapasProducao();
       etapaSelect.innerHTML = etapas.map(e => `<option value="${e.id}">${e.nome}</option>`).join('');
       const codigoProduto = (dados && dados.codigo) || produto.codigo;
-      const itens = await window.electronAPI.listarInsumosProduto(codigoProduto);
-      renderItens(itens);
+      let itensData = [];
+      try {
+        itensData = await window.electronAPI.listarInsumosProduto(codigoProduto);
+      } catch(err) {
+        console.error('Erro ao listar insumos do produto', err);
+      }
+      renderItens(itensData);
       updateTotals();
     } catch(err){
       console.error('Erro ao carregar dados do produto', err);


### PR DESCRIPTION
## Summary
- handle failures when fetching product items so the edit modal renders gracefully

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689b8d3c197083229167ad3971152fa0