### PR TITLE
Fix Item Loading In Edit Product Modal

### DIFF
--- a/backend/produtos.js
+++ b/backend/produtos.js
@@ -43,7 +43,7 @@ async function obterProduto(id) {
   return res.rows[0];
 }
 
-async function listarInsumosProduto(codigo) {
+async function listarInsumosProduto(id) {
   const query = `
     SELECT pi.id,
            mp.nome,
@@ -53,9 +53,9 @@ async function listarInsumosProduto(codigo) {
            mp.processo
       FROM produtos_insumos pi
       JOIN materia_prima mp ON mp.id = pi.insumo_id
-     WHERE pi.produto_codigo = $1
+     WHERE pi.produto_id = $1
      ORDER BY mp.processo, mp.nome`;
-  const res = await pool.query(query, [codigo]);
+  const res = await pool.query(query, [id]);
   return res.rows;
 }
 
@@ -112,7 +112,7 @@ async function excluirLoteProduto(id) {
 }
 
 // Atualiza percentuais e insumos do produto em uma única transação
-async function salvarProdutoDetalhado(codigo, produto, itens) {
+async function salvarProdutoDetalhado(id, produto, itens) {
   const client = await pool.connect();
   try {
     await client.query('BEGIN');
@@ -140,7 +140,7 @@ async function salvarProdutoDetalhado(codigo, produto, itens) {
               preco_base=$8,
               preco_venda=$9,
               data=NOW()
-       WHERE codigo=$10`,
+       WHERE id=$10`,
       [
         pct_fabricacao,
         pct_acabamento,
@@ -151,7 +151,7 @@ async function salvarProdutoDetalhado(codigo, produto, itens) {
         pct_imposto,
         preco_base,
         preco_venda,
-        codigo
+        id
       ]
     );
 
@@ -166,8 +166,8 @@ async function salvarProdutoDetalhado(codigo, produto, itens) {
     // Processa inserções
     for (const ins of itens.inseridos || []) {
       await client.query(
-        'INSERT INTO produtos_insumos (produto_codigo, insumo_id, quantidade) VALUES ($1,$2,$3)',
-        [codigo, ins.insumo_id, ins.quantidade]
+        'INSERT INTO produtos_insumos (produto_id, insumo_id, quantidade) VALUES ($1,$2,$3)',
+        [id, ins.insumo_id, ins.quantidade]
       );
     }
 

--- a/main.js
+++ b/main.js
@@ -394,14 +394,14 @@ ipcMain.handle('excluir-lote-produto', async (_e, id) => {
   await excluirLoteProduto(id);
   return true;
 });
-ipcMain.handle('listar-insumos-produto', async (_e, codigo) => {
-  return listarInsumosProduto(codigo);
+ipcMain.handle('listar-insumos-produto', async (_e, id) => {
+  return listarInsumosProduto(id);
 });
 ipcMain.handle('listar-etapas-producao', async () => {
   return listarEtapasProducao();
 });
-ipcMain.handle('salvar-produto-detalhado', async (_e, { codigo, produto, itens }) => {
-  return salvarProdutoDetalhado(codigo, produto, itens);
+ipcMain.handle('salvar-produto-detalhado', async (_e, { id, produto, itens }) => {
+  return salvarProdutoDetalhado(id, produto, itens);
 });
 
 ipcMain.handle('auto-login', async (_event, pin) => {

--- a/preload.js
+++ b/preload.js
@@ -14,10 +14,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
   listarDetalhesProduto: (id) => ipcRenderer.invoke('listar-detalhes-produto', id),
   atualizarLoteProduto: (dados) => ipcRenderer.invoke('atualizar-lote-produto', dados),
   excluirLoteProduto: (id) => ipcRenderer.invoke('excluir-lote-produto', id),
-  listarInsumosProduto: (codigo) => ipcRenderer.invoke('listar-insumos-produto', codigo),
+  listarInsumosProduto: (id) => ipcRenderer.invoke('listar-insumos-produto', id),
   listarEtapasProducao: () => ipcRenderer.invoke('listar-etapas-producao'),
-  salvarProdutoDetalhado: (codigo, produto, itens) =>
-    ipcRenderer.invoke('salvar-produto-detalhado', { codigo, produto, itens }),
+  salvarProdutoDetalhado: (id, produto, itens) =>
+    ipcRenderer.invoke('salvar-produto-detalhado', { id, produto, itens }),
   adicionarMateriaPrima: (dados) => ipcRenderer.invoke('adicionar-materia-prima', dados),
   atualizarMateriaPrima: (id, dados) => ipcRenderer.invoke('atualizar-materia-prima', { id, dados }),
   excluirMateriaPrima: (id) => ipcRenderer.invoke('excluir-materia-prima', id),

--- a/src/js/modals/produto-editar.js
+++ b/src/js/modals/produto-editar.js
@@ -262,7 +262,7 @@
       deletados: itens.filter(i => i.status === 'deleted').map(i => ({ id: i.id }))
     };
     try{
-      await window.electronAPI.salvarProdutoDetalhado(produtoSelecionado.codigo, produto, itensPayload);
+      await window.electronAPI.salvarProdutoDetalhado(produtoSelecionado.id, produto, itensPayload);
       const now = new Date();
       ultimaDataEl.textContent = now.toLocaleDateString('pt-BR');
       ultimaHoraEl.textContent = now.toLocaleTimeString('pt-BR', { hour: '2-digit', minute: '2-digit' });
@@ -305,10 +305,10 @@
       }
       const etapas = await window.electronAPI.listarEtapasProducao();
       etapaSelect.innerHTML = etapas.map(e => `<option value="${e.id}">${e.nome}</option>`).join('');
-      const codigoProduto = (dados && dados.codigo) || produto.codigo;
+      const produtoId = (dados && dados.id) || produto.id;
       let itensData = [];
       try {
-        itensData = await window.electronAPI.listarInsumosProduto(codigoProduto);
+        itensData = await window.electronAPI.listarInsumosProduto(produtoId);
       } catch(err) {
         console.error('Erro ao listar insumos do produto', err);
       }


### PR DESCRIPTION
## Summary
- Query and save product insumos using product IDs instead of codes
- Expose updated APIs in preload and main processes
- Request and persist product details with IDs in edit modal

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689b90c0e388832281fe91dc4d1d978b