### PR TITLE
Add Insert Button To Stock Details Modal

### DIFF
--- a/src/html/modals/produtos/detalhes.html
+++ b/src/html/modals/produtos/detalhes.html
@@ -1,9 +1,10 @@
 <div id="detalhesProdutoOverlay" class="fixed inset-0 bg-black/50 flex items-center justify-center p-4">
   <div class="w-full max-w-6xl max-h-[90vh] glass-surface backdrop-blur-xl rounded-3xl border border-white/10 ring-1 ring-white/5 shadow-2xl/40 animate-modalFade slide-in overflow-hidden flex flex-col">
     <header class="px-8 py-5 border-b border-white/10 flex-shrink-0">
-      <div class="flex items-center mb-3">
+      <div class="flex items-center justify-between mb-3">
         <button id="voltarDetalhesProduto" class="btn-neutral px-4 py-2 rounded-lg text-white font-medium flex items-center gap-2">← Voltar</button>
         <h2 id="detalheTitulo" class="text-lg font-semibold text-white text-center flex-1 mx-4">DETALHE DE ESTOQUE – Produto</h2>
+        <button id="abrirInserirEstoque" class="btn-primary px-4 py-2 rounded-lg text-white font-medium flex items-center gap-2"><i class="fas fa-plus"></i>Inserir</button>
       </div>
       <!-- Subtítulo exibe código da peça -->
       <p id="codigoPeca" class="text-sm text-gray-400 text-center"></p>

--- a/src/html/modals/produtos/estoque-inserir.html
+++ b/src/html/modals/produtos/estoque-inserir.html
@@ -1,0 +1,56 @@
+<div id="inserirEstoqueOverlay" class="fixed inset-0 bg-black/50 flex items-center justify-center p-4">
+  <div role="dialog" aria-modal="true" tabindex="0" class="w-full max-w-3xl bg-surface/60 backdrop-blur-xl rounded-3xl border border-white/10 ring-1 ring-white/5 shadow-2xl/40 animate-modalFade slide-in overflow-hidden flex flex-col">
+    <header class="flex items-center justify-between px-8 py-5 border-b border-white/10">
+      <button id="voltarInserirEstoque" class="btn-neutral px-4 py-2 rounded-lg text-white font-medium flex items-center gap-2">← Voltar</button>
+      <h2 class="text-lg font-semibold text-white">ADICIONAR PRODUTO AO ESTOQUE</h2>
+      <button id="fecharInserirEstoque" class="btn-danger icon-only text-white">✕</button>
+    </header>
+    <div class="flex-1 overflow-y-auto">
+      <div class="px-8 py-8">
+        <form class="space-y-6">
+          <div>
+            <label class="block text-sm font-medium text-gray-300 mb-2">Processos</label>
+            <select class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition select-arrow appearance-none" autofocus>
+              <option value="">Selecione um processo…</option>
+              <option value="marcenaria">Marcenaria</option>
+              <option value="acabamento">Acabamento</option>
+              <option value="montagem">Montagem</option>
+              <option value="embalagem">Embalagem</option>
+              <option value="pintura">Pintura</option>
+              <option value="verniz">Verniz</option>
+              <option value="estofamento">Estofamento</option>
+            </select>
+          </div>
+          <div>
+            <label class="block text-sm font-medium text-gray-300 mb-2">Último Item</label>
+            <select class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition select-arrow appearance-none">
+              <option value="">Selecione ou busque um produto…</option>
+              <option value="mesa-paris">Mesa de Jantar Modelo Paris</option>
+              <option value="cadeira-colonial">Cadeira Colonial Estofada</option>
+              <option value="armario-rustico">Armário Rústico 6 Portas</option>
+              <option value="mesa-centro">Mesa de Centro Redonda</option>
+              <option value="estante-livros">Estante para Livros 5 Prateleiras</option>
+              <option value="cama-casal">Cama de Casal com Cabeceira</option>
+              <option value="comoda-vintage">Cômoda Vintage 4 Gavetas</option>
+              <option value="banco-madeira">Banco de Madeira Maciça</option>
+              <option value="mesa-escritorio">Mesa de Escritório L</option>
+              <option value="poltrona-couro">Poltrona de Couro Marrom</option>
+            </select>
+          </div>
+          <div class="grid grid-cols-1 md:grid-cols-3 gap-4 items-end">
+            <div>
+              <label class="block text-sm font-medium text-gray-300 mb-2">Quantidade em Estoque</label>
+              <input type="number" placeholder="0" min="1" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+            </div>
+            <div class="md:col-span-2 flex justify-end">
+              <button type="submit" class="btn-primary px-8 py-3 rounded-lg text-white font-medium">+ Inserir</button>
+            </div>
+          </div>
+        </form>
+        <div class="mt-8 pt-6 border-t border-white/10">
+          <p class="text-xs text-gray-400 text-center">Informe o processo, selecione o item e adicione a quantidade ao estoque.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/js/modals/produto-detalhes.js
+++ b/src/js/modals/produto-detalhes.js
@@ -6,6 +6,12 @@
   if (voltar) voltar.addEventListener('click', close);
   document.addEventListener('keydown', function esc(e){ if(e.key==='Escape'){ close(); document.removeEventListener('keydown', esc); } });
 
+  const inserirBtn = document.getElementById('abrirInserirEstoque');
+  if (inserirBtn) inserirBtn.addEventListener('click', () => {
+    overlay.classList.add('pointer-events-none', 'blur-sm');
+    Modal.open('modals/produtos/estoque-inserir.html', '../js/modals/produto-estoque-inserir.js', 'inserirEstoque', true);
+  });
+
   const item = window.produtoDetalhes;
   if(item){
     const titulo = document.getElementById('detalheTitulo');

--- a/src/js/modals/produto-estoque-inserir.js
+++ b/src/js/modals/produto-estoque-inserir.js
@@ -1,0 +1,24 @@
+(function(){
+  const overlay = document.getElementById('inserirEstoqueOverlay');
+  const fecharBtn = document.getElementById('fecharInserirEstoque');
+  const voltarBtn = document.getElementById('voltarInserirEstoque');
+
+  function closeOverlay(){
+    Modal.close('inserirEstoque');
+    const baseOverlay = document.getElementById('detalhesProdutoOverlay');
+    baseOverlay.classList.remove('pointer-events-none', 'blur-sm');
+  }
+
+  overlay.addEventListener('click', e => { if(e.target === overlay) closeOverlay(); });
+  fecharBtn.addEventListener('click', closeOverlay);
+  voltarBtn.addEventListener('click', closeOverlay);
+  document.addEventListener('keydown', function esc(e){ if(e.key==='Escape'){ closeOverlay(); document.removeEventListener('keydown', esc); } });
+
+  const form = overlay.querySelector('form');
+  if(form){
+    form.addEventListener('submit', e => {
+      e.preventDefault();
+      showToast('Funcionalidade em desenvolvimento', 'info');
+    });
+  }
+})();


### PR DESCRIPTION
## Summary
- add "+ Inserir" action beside Voltar in stock detail modal
- open dedicated insert modal overlay to add stock without closing details
- disable background modal while insert modal active and restore on close

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689b91a00fe8832286711619e294a3e8