### PR TITLE
Process-Based Items in Inserir Modal

### DIFF
--- a/backend/produtos.js
+++ b/backend/produtos.js
@@ -61,8 +61,34 @@ async function listarInsumosProduto(id) {
 
 async function listarEtapasProducao() {
   const res = await pool.query(
-    'SELECT id, nome FROM etapas_producao ORDER BY ordem'
+    'SELECT id, nome FROM etapas_producao ORDER BY nome'
   );
+  return res.rows;
+}
+
+async function listarItensProcessoProduto(produtoCodigo, etapaId) {
+  const baseParams = [produtoCodigo, etapaId];
+  let res = await pool.query(
+    `SELECT mp.id, mp.nome
+       FROM materia_prima mp
+       JOIN produtos_insumos pi ON pi.insumo_id = mp.id
+      WHERE pi.produto_codigo = $1
+        AND mp.etapa_id = $2
+      ORDER BY mp.nome ASC`,
+    baseParams
+  );
+  if (res.rows.length === 0) {
+    res = await pool.query(
+      `SELECT mp.id, mp.nome
+         FROM materia_prima mp
+         JOIN produtos_insumos pi ON pi.insumo_id = mp.id
+         JOIN etapas_producao ep ON ep.id = $2
+        WHERE pi.produto_codigo = $1
+          AND mp.processo = ep.nome
+        ORDER BY mp.nome ASC`,
+      baseParams
+    );
+  }
   return res.rows;
 }
 
@@ -187,6 +213,7 @@ module.exports = {
   obterProduto,
   listarInsumosProduto,
   listarEtapasProducao,
+  listarItensProcessoProduto,
   adicionarProduto,
   atualizarProduto,
   excluirProduto,

--- a/main.js
+++ b/main.js
@@ -27,6 +27,7 @@ const {
   listarDetalhesProduto,
   listarInsumosProduto,
   listarEtapasProducao,
+  listarItensProcessoProduto,
   atualizarLoteProduto,
   excluirLoteProduto,
   salvarProdutoDetalhado
@@ -396,6 +397,10 @@ ipcMain.handle('excluir-lote-produto', async (_e, id) => {
 });
 ipcMain.handle('listar-insumos-produto', async (_e, id) => {
   return listarInsumosProduto(id);
+});
+ipcMain.handle('listar-itens-processo-produto', async (_e, args) => {
+  const { produtoCodigo, etapaId } = args;
+  return listarItensProcessoProduto(produtoCodigo, etapaId);
 });
 ipcMain.handle('listar-etapas-producao', async () => {
   return listarEtapasProducao();

--- a/preload.js
+++ b/preload.js
@@ -16,6 +16,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
   excluirLoteProduto: (id) => ipcRenderer.invoke('excluir-lote-produto', id),
   listarInsumosProduto: (id) => ipcRenderer.invoke('listar-insumos-produto', id),
   listarEtapasProducao: () => ipcRenderer.invoke('listar-etapas-producao'),
+  listarItensProcessoProduto: (produtoCodigo, etapaId) =>
+    ipcRenderer.invoke('listar-itens-processo-produto', { produtoCodigo, etapaId }),
   salvarProdutoDetalhado: (id, produto, itens) =>
     ipcRenderer.invoke('salvar-produto-detalhado', { id, produto, itens }),
   adicionarMateriaPrima: (dados) => ipcRenderer.invoke('adicionar-materia-prima', dados),

--- a/src/html/modals/produtos/estoque-inserir.html
+++ b/src/html/modals/produtos/estoque-inserir.html
@@ -10,32 +10,15 @@
         <form class="space-y-6">
           <div>
             <label class="block text-sm font-medium text-gray-300 mb-2">Processos</label>
-            <select class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition select-arrow appearance-none" autofocus>
+            <select id="processoSelect" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition select-arrow appearance-none" autofocus>
               <option value="">Selecione um processo…</option>
-              <option value="marcenaria">Marcenaria</option>
-              <option value="acabamento">Acabamento</option>
-              <option value="montagem">Montagem</option>
-              <option value="embalagem">Embalagem</option>
-              <option value="pintura">Pintura</option>
-              <option value="verniz">Verniz</option>
-              <option value="estofamento">Estofamento</option>
             </select>
           </div>
           <div>
             <label class="block text-sm font-medium text-gray-300 mb-2">Último Item</label>
-            <select class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition select-arrow appearance-none">
-              <option value="">Selecione ou busque um produto…</option>
-              <option value="mesa-paris">Mesa de Jantar Modelo Paris</option>
-              <option value="cadeira-colonial">Cadeira Colonial Estofada</option>
-              <option value="armario-rustico">Armário Rústico 6 Portas</option>
-              <option value="mesa-centro">Mesa de Centro Redonda</option>
-              <option value="estante-livros">Estante para Livros 5 Prateleiras</option>
-              <option value="cama-casal">Cama de Casal com Cabeceira</option>
-              <option value="comoda-vintage">Cômoda Vintage 4 Gavetas</option>
-              <option value="banco-madeira">Banco de Madeira Maciça</option>
-              <option value="mesa-escritorio">Mesa de Escritório L</option>
-              <option value="poltrona-couro">Poltrona de Couro Marrom</option>
-            </select>
+            <input id="itemInput" type="text" list="itensList" disabled placeholder="Selecione ou busque um item…" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+            <datalist id="itensList"></datalist>
+            <p id="itemMessage" class="text-sm text-gray-400 mt-2"></p>
           </div>
           <div class="grid grid-cols-1 md:grid-cols-3 gap-4 items-end">
             <div>

--- a/src/js/modals/produto-estoque-inserir.js
+++ b/src/js/modals/produto-estoque-inserir.js
@@ -12,7 +12,82 @@
   overlay.addEventListener('click', e => { if(e.target === overlay) closeOverlay(); });
   fecharBtn.addEventListener('click', closeOverlay);
   voltarBtn.addEventListener('click', closeOverlay);
-  document.addEventListener('keydown', function esc(e){ if(e.key==='Escape'){ closeOverlay(); document.removeEventListener('keydown', esc); } });
+  document.addEventListener('keydown', function esc(e){
+    if (e.key === 'Escape') {
+      closeOverlay();
+      document.removeEventListener('keydown', esc);
+    }
+  });
+
+  const processoSelect = document.getElementById('processoSelect');
+  const itemInput = document.getElementById('itemInput');
+  const itensList = document.getElementById('itensList');
+  const itemMsg = document.getElementById('itemMessage');
+  const codigoAtual = window.produtoDetalhes?.codigo;
+
+  // carga de processos
+  (async () => {
+    try {
+      const processos = await window.electronAPI.listarEtapasProducao();
+      processoSelect.innerHTML = '<option value="">Selecione um processo…</option>';
+      processos.sort((a, b) => a.nome.localeCompare(b.nome));
+      processos.forEach(p => {
+        const opt = document.createElement('option');
+        opt.value = p.id;
+        opt.textContent = p.nome;
+        processoSelect.appendChild(opt);
+      });
+    } catch (err) {
+      console.error('Erro ao carregar processos', err);
+    }
+  })();
+
+  let itensCache = [];
+  processoSelect.addEventListener('change', async () => {
+    itemInput.value = '';
+    itemInput.disabled = true;
+    itensList.innerHTML = '';
+    itemMsg.textContent = '';
+    itensCache = [];
+    const etapaId = processoSelect.value;
+    if (!etapaId) return;
+    try {
+      // filtro por processo + produto
+      const itens = await window.electronAPI.listarItensProcessoProduto(codigoAtual, etapaId);
+      itensCache = itens;
+      if (itens.length === 0) {
+        itemMsg.textContent = 'Nenhum item disponível para este processo';
+        return;
+      }
+      renderItens(itens);
+      itemInput.disabled = false;
+    } catch (err) {
+      console.error('Erro ao carregar itens', err);
+    }
+  });
+
+  function renderItens(data) {
+    const seen = new Set();
+    itensList.innerHTML = '';
+    data.forEach(it => {
+      if (seen.has(it.id)) return;
+      seen.add(it.id);
+      const opt = document.createElement('option');
+      opt.value = it.nome;
+      opt.dataset.id = it.id;
+      itensList.appendChild(opt);
+    });
+  }
+
+  let debounceTimer;
+  itemInput.addEventListener('input', () => {
+    clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(() => {
+      const termo = itemInput.value.toLowerCase();
+      const filtrados = itensCache.filter(it => it.nome.toLowerCase().includes(termo)); // debounce de busca
+      renderItens(filtrados);
+    }, 250);
+  });
 
   const form = overlay.querySelector('form');
   if(form){


### PR DESCRIPTION
## Summary
- Load process options from database when opening the Inserir modal and fetch matching items based on selected process and current product.
- Add backend route and preload bridge to return items filtered by product code and process, with fallback when etapa_id is absent.
- Implement debounced item autocomplete with user feedback when no results exist.

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689b9608afcc832281a918584a09b6e3