### PR TITLE
Support Legacy Produto IDs For Insumos

### DIFF
--- a/backend/produtos.js
+++ b/backend/produtos.js
@@ -55,7 +55,9 @@ async function listarInsumosProduto(codigo) {
            mp.processo
       FROM produtos_insumos pi
       JOIN materia_prima mp ON mp.id = pi.insumo_id
+      JOIN produtos p ON p.codigo = $1
      WHERE pi.produto_codigo = $1
+        OR (pi.produto_codigo IS NULL AND pi.produto_id = p.id)
      ORDER BY mp.processo, mp.nome`;
   const res = await pool.query(query, [codigo]);
   return res.rows;

--- a/backend/scripts/populate_produto_codigo.js
+++ b/backend/scripts/populate_produto_codigo.js
@@ -1,0 +1,20 @@
+const db = require('../db');
+
+async function run() {
+  try {
+    const result = await db.query(
+      `UPDATE produtos_insumos pi
+          SET produto_codigo = p.codigo
+         FROM produtos p
+        WHERE pi.produto_codigo IS NULL
+          AND pi.produto_id = p.id`
+    );
+    console.log(`Atualizados ${result.rowCount} registros de produtos_insumos.`);
+  } catch (err) {
+    console.error('Erro ao atualizar produtos_insumos:', err);
+  } finally {
+    process.exit();
+  }
+}
+
+run();


### PR DESCRIPTION
## Summary
- handle legacy produtos_insumos entries by joining produtos and falling back to produto_id
- add script to populate produto_codigo from produtos
## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689b9a57c5d883229551e35c8eba574e