### PR TITLE
Atualizar pop-up de usuários com dados reais

### DIFF
--- a/src/html/usuarios.html
+++ b/src/html/usuarios.html
@@ -31,22 +31,14 @@
         <!-- Popover de resumo -->
         <div id="resumoPopover" class="resumo-popover glass-surface rounded-xl p-6 text-white">
             <h3 class="font-medium mb-4 text-white">Resumo</h3>
-            <div class="text-3xl font-bold text-white mb-2" id="totalUsuarios">247</div>
+            <div class="text-3xl font-bold text-white mb-2" id="totalUsuarios">0</div>
             <div class="text-sm text-gray-400 mb-4">Total de usuários</div>
 
             <!-- Status Distribution -->
-            <div class="flex flex-wrap gap-2 mb-4" id="distribuicaoStatus">
-                <span class="badge-success px-3 py-1 rounded-full text-xs font-medium">189 Ativos</span>
-                <span class="badge-danger px-3 py-1 rounded-full text-xs font-medium">32 Inativos</span>
-                <span class="badge-warning px-3 py-1 rounded-full text-xs font-medium">26 Aguardando</span>
-            </div>
+            <div class="flex flex-wrap gap-2 mb-4" id="distribuicaoStatus"></div>
 
             <!-- Profile Distribution -->
-            <div class="text-sm text-gray-400 space-y-1" id="distribuicaoPerfis">
-                <div>• 12 Administradores</div>
-                <div>• 89 Operacionais</div>
-                <div>• 146 Clientes</div>
-            </div>
+            <div class="text-sm text-gray-400 space-y-1" id="distribuicaoPerfis"></div>
         </div>
 
         <!-- Barra de filtros horizontal -->

--- a/src/js/usuarios.js
+++ b/src/js/usuarios.js
@@ -134,11 +134,59 @@ function renderUsuarios(lista) {
     });
 }
 
+function atualizarResumo() {
+    const totalEl = document.getElementById('totalUsuarios');
+    const statusEl = document.getElementById('distribuicaoStatus');
+    const perfisEl = document.getElementById('distribuicaoPerfis');
+    if (!totalEl || !statusEl || !perfisEl) return;
+
+    totalEl.textContent = usuariosCache.length;
+
+    const statusCounts = usuariosCache.reduce((acc, u) => {
+        const key = (u.status || 'Aguardando').toLowerCase();
+        acc[key] = (acc[key] || 0) + 1;
+        return acc;
+    }, {});
+    statusEl.innerHTML = '';
+    const statusConfig = {
+        ativo: { class: 'badge-success', label: 'Ativos' },
+        inativo: { class: 'badge-danger', label: 'Inativos' },
+        aguardando: { class: 'badge-warning', label: 'Aguardando' }
+    };
+    Object.entries(statusCounts).forEach(([status, count]) => {
+        const cfg = statusConfig[status] || { class: 'badge-secondary', label: status };
+        const span = document.createElement('span');
+        span.className = `${cfg.class} px-3 py-1 rounded-full text-xs font-medium`;
+        span.textContent = `${count} ${cfg.label}`;
+        statusEl.appendChild(span);
+    });
+
+    const perfilCounts = usuariosCache.reduce((acc, u) => {
+        const perfil = u.perfil || 'Sem Perfil';
+        acc[perfil] = (acc[perfil] || 0) + 1;
+        return acc;
+    }, {});
+    perfisEl.innerHTML = '';
+    const perfilLabels = {
+        admin: 'Administradores',
+        operacional: 'Operacionais',
+        cliente: 'Clientes',
+        'Sem Perfil': 'Sem Perfil'
+    };
+    Object.entries(perfilCounts).forEach(([perfil, count]) => {
+        const div = document.createElement('div');
+        const label = perfilLabels[perfil] || perfil;
+        div.textContent = `• ${count} ${label}`;
+        perfisEl.appendChild(div);
+    });
+}
+
 async function carregarUsuarios() {
     try {
         const resp = await fetch(`${API_URL}/api/usuarios/lista`);
         usuariosCache = await resp.json();
         renderUsuarios(usuariosCache);
+        atualizarResumo();
     } catch (err) {
         console.error('Erro ao carregar usuários:', err);
     }


### PR DESCRIPTION
## Summary
- exibir total de usuários e distribuições de status e perfis
- popular popover de usuários com dados retornados da API

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689b9af8a98c8322ba5836c15ed7a45c