### PR TITLE
Produtos: botão de filtro dinâmico e busca automática

### DIFF
--- a/src/css/produtos.css
+++ b/src/css/produtos.css
@@ -50,6 +50,16 @@ body {
     background: rgba(138, 167, 243, 0.9);
 }
 
+.btn-warning {
+    background: var(--color-bordeaux);
+    transition: all 150ms ease;
+}
+
+.btn-warning:hover {
+    background: rgba(106, 21, 44, 0.8);
+    transform: scale(1.05);
+}
+
 .btn-danger {
     background: var(--color-red);
     transition: all 150ms ease;


### PR DESCRIPTION
## Summary
- Alterna o botão de filtro para modo limpar após aplicar filtros
- Limpa filtros e restaura botão ao padrão
- Busca por texto atualiza resultados automaticamente

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689b9c4acfd08322af51464b0846b14f