### PR TITLE
Fix Missing Etapa Id Column - Via Codex

### DIFF
--- a/backend/produtos.js
+++ b/backend/produtos.js
@@ -76,7 +76,7 @@ async function listarItensProcessoProduto(codigo, etapaId, busca = '') {
        JOIN produtos_insumos pi ON pi.insumo_id = mp.id
        JOIN etapas_producao ep ON ep.id = $2
       WHERE pi.produto_codigo = $1
-        AND (mp.etapa_id = $2 OR (mp.etapa_id IS NULL AND mp.processo = ep.nome))
+        AND mp.processo = ep.nome
         AND mp.nome ILIKE $3
       ORDER BY mp.nome ASC`,
     [codigo, etapaId, '%' + busca + '%']


### PR DESCRIPTION
## Summary
- align item listing with production stage names instead of etapa_id

## Testing
- `npm test` *(fails: Cannot find module '/workspace/App-Gestao/backend')*

------
https://chatgpt.com/codex/tasks/task_e_689ba40f8bfc832295dfd6f6076b4922