### PR TITLE
Limpar Processos No Início De RenderItens

### DIFF
--- a/src/js/modals/produto-editar.js
+++ b/src/js/modals/produto-editar.js
@@ -187,6 +187,7 @@
 
   function renderItens(data){
     tableBody.innerHTML = '';
+    Object.keys(processos).forEach(k => delete processos[k]);
     itens = (data || []).map(d => ({ ...d, status: 'unchanged' }));
 
     // Exibe mensagem caso não haja itens


### PR DESCRIPTION
## Summary
- clear `processos` before grouping items in `renderItens` to avoid stale process totals

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bac6beff48322baf340f931a6f069