### PR TITLE
Adapt Product Popup Width And Data

### DIFF
--- a/backend/produtos.js
+++ b/backend/produtos.js
@@ -17,14 +17,18 @@ async function listarProdutos() {
       SELECT p.id,
              p.codigo,
              p.nome,
+             p.descricao,
              p.categoria,
              p.preco_venda,
              p.pct_markup,
              p.status,
+             p.criado_em,
+             p.data,
              COALESCE(SUM(pe.quantidade), 0) AS quantidade_total
         FROM produtos p
    LEFT JOIN produtos_em_cada_ponto pe ON pe.produto_id = p.id
-    GROUP BY p.id, p.codigo, p.nome, p.categoria, p.preco_venda, p.pct_markup, p.status
+    GROUP BY p.id, p.codigo, p.nome, p.descricao, p.categoria, p.preco_venda,
+             p.pct_markup, p.status, p.criado_em, p.data
     ORDER BY p.nome`;
     const res = await pool.query(sql);
     return res.rows;

--- a/src/css/produtos.css
+++ b/src/css/produtos.css
@@ -297,7 +297,9 @@ body {
   color: white;
   border-radius: 0.5rem;
   overflow: hidden;
-  width: 16rem;
+  display: inline-block;
+  width: auto;
+  min-width: 16rem;
 }
 
 /* Cabeçalho do popup */
@@ -327,7 +329,7 @@ body {
 /* Seções de informações do corpo */
 .popup-info-grid {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-columns: auto auto;
   gap: 1rem;
   margin-bottom: 1rem;
 }
@@ -343,6 +345,18 @@ body {
   font-size: 0.875rem;
   font-weight: 500;
   color: white;
+  white-space: nowrap;
+}
+
+.popup-color-wrapper {
+  display: inline-block;
+}
+
+.popup-color-bar {
+  width: 100%;
+  height: 0.25rem;
+  margin-top: 0.125rem;
+  border-radius: 0.125rem;
 }
 
 /* Seção de descrição técnica */

--- a/src/js/produtos.js
+++ b/src/js/produtos.js
@@ -224,6 +224,8 @@ function extrairCorDimensoes(nome) {
 
 function createPopupContent(item) {
     const { cor, dimensoes } = extrairCorDimensoes(item.nome);
+    const corSample = (cor.split('/')[1] || cor).trim();
+    const corCss = corSample.replace(/\s+/g, '').toLowerCase();
     return `
     <div class="popup-card">
       <div class="popup-header">
@@ -233,7 +235,7 @@ function createPopupContent(item) {
       <div class="popup-body">
         <div class="popup-info-grid">
           <div>
-            <p class="popup-info-label">Data de Entrada:</p>
+            <p class="popup-info-label">Data de Criação:</p>
             <p class="popup-info-value">${formatDate(item.criado_em)}</p>
           </div>
           <div>
@@ -244,7 +246,10 @@ function createPopupContent(item) {
         <div class="popup-info-grid">
           <div>
             <p class="popup-info-label">Cor:</p>
-            <p class="popup-info-value">${cor}</p>
+            <div class="popup-color-wrapper">
+              <p class="popup-info-value">${cor}</p>
+              <div class="popup-color-bar" style="background-color: ${corCss};"></div>
+            </div>
           </div>
           <div>
             <p class="popup-info-label">Dimensões:</p>
@@ -252,7 +257,7 @@ function createPopupContent(item) {
           </div>
         </div>
         <div class="popup-description-section">
-          <p class="popup-info-label">Descrição Técnica:</p>
+          <p class="popup-info-label">Descrição:</p>
           <p class="popup-description-text">${item.descricao || ''}</p>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- fetch creation date, last update, and description fields for product popups
- expand product code popup width with no line breaks and show a color sample bar
- relabel popup fields for creation date and description

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c968c8cf88322a6ed79fe9454ce73