### PR TITLE
Ajustar Fontes E Totais Do Modal Editar Produto

### DIFF
--- a/src/css/produtos.css
+++ b/src/css/produtos.css
@@ -13,6 +13,7 @@
     --color-green: #a2ffa6;
     --color-red: #ff5858;
     --color-blue: #8aa7f3;
+    --color-navy: #001f3f;
     --neutral-100: #f9fafb;
     --neutral-500: #6b7280;
     --color-input: rgba(0,0,0,0.3);
@@ -142,6 +143,11 @@ body {
 .badge-danger {
     background: rgba(255, 88, 88, 0.2);
     color: var(--color-red);
+}
+
+.badge-process {
+    background: rgba(0, 31, 63, 0.2);
+    color: var(--color-navy);
 }
 
 .input-glass {

--- a/src/html/modals/produtos/editar.html
+++ b/src/html/modals/produtos/editar.html
@@ -144,12 +144,12 @@
         <div class="glass-surface rounded-xl p-6 border border-white/10">
           <div class="flex items-center justify-between mb-4">
             <h3 class="text-lg font-semibold text-white">ITENS</h3>
-            <span id="totalInsumosTitulo" class="text-sm text-gray-300"></span>
+            <span id="totalInsumosTitulo" class="flex flex-wrap justify-end gap-2"></span>
           </div>
           <div class="glass-surface rounded-xl shadow-lg animate-fade-in-up mt-6 overflow-hidden">
               <div class="overflow-x-auto">
                   <div class="max-h-64 overflow-y-auto">
-                      <table id="itensTabela" class="w-full">
+                      <table id="itensTabela" class="w-full text-sm">
                           <thead class="bg-gray-50 sticky top-0">
                               <tr class="border-b border-gray-200">
                                   <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">NOME DO ITEM</th>


### PR DESCRIPTION
## Summary
- Redimensionar fontes de itens e exibir totais por processo
- Adicionar badges estilizadas em azul marinho e verde para totais
- Arredondar quantidades para cima com duas casas decimais

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c9a63e9e48322bc20d1b6744a35ed