### PR TITLE
Add zero stock toggle to raw material filters

### DIFF
--- a/src/html/materia-prima.html
+++ b/src/html/materia-prima.html
@@ -60,6 +60,10 @@
 
                 <!-- Actions -->
                 <div id="bt-actions" class="flex items-center gap-2">
+                    <div class="filter-toggle flex flex-col items-center space-y-1">
+                        <label for="zeroStock" class="text-sm font-medium text-white">0 Estoque</label>
+                        <input type="checkbox" id="zeroStock" class="toggle" />
+                    </div>
                     <button id="btnFiltrar" class="btn-secondary text-white rounded-md px-4 py-3 text-sm font-medium">Filtrar</button>
                     <button id="btnLimpar" class="btn-warning text-white rounded-md px-4 py-3 text-sm font-medium">Limpar</button>
                 </div>

--- a/src/js/materia-prima.js
+++ b/src/js/materia-prima.js
@@ -38,6 +38,7 @@ function initMateriaPrima() {
     document.getElementById('filtroCategoria')?.addEventListener('change', aplicarFiltros);
     document.getElementById('btnFiltrar')?.addEventListener('click', aplicarFiltros);
     document.getElementById('btnLimpar')?.addEventListener('click', limparFiltros);
+    document.getElementById('zeroStock')?.addEventListener('change', aplicarFiltros);
     document.getElementById('btnNovoInsumo')?.addEventListener('click', abrirNovoInsumo);
 
     carregarMateriais();
@@ -77,8 +78,9 @@ function aplicarFiltros() {
     const termo = (document.getElementById('materiaPrimaSearch')?.value || '').toLowerCase();
     const processo = document.getElementById('filtroProcesso')?.value || '';
     const categoria = document.getElementById('filtroCategoria')?.value || '';
+    const zeroEstoque = document.getElementById('zeroStock')?.checked;
 
-    const filtrados = todosMateriais.filter(m => {
+    let filtrados = todosMateriais.filter(m => {
         const matchTermo = !termo ||
             (m.nome || '').toLowerCase().includes(termo) ||
             (m.categoria || '').toLowerCase().includes(termo) ||
@@ -89,6 +91,10 @@ function aplicarFiltros() {
         return matchTermo && matchProc && matchCat;
     });
 
+    if (zeroEstoque) {
+        filtrados = filtrados.filter(m => !m.infinito && Number(m.quantidade) === 0);
+    }
+
     renderMateriais(filtrados);
     renderTotais(filtrados);
 }
@@ -97,9 +103,11 @@ function limparFiltros() {
     const busca = document.getElementById('materiaPrimaSearch');
     const proc = document.getElementById('filtroProcesso');
     const cat = document.getElementById('filtroCategoria');
+    const zero = document.getElementById('zeroStock');
     if (busca) busca.value = '';
     if (proc) proc.value = '';
     if (cat) cat.value = '';
+    if (zero) zero.checked = false;
     aplicarFiltros();
 }
 


### PR DESCRIPTION
## Summary
- add "0 estoque" toggle beside filter button on material stock page
- filter and reset raw materials by zero quantity

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c9cb785088322bd11ca4d065024e3