### PR TITLE
Mostrar amostra de cor no popup de produtos

### DIFF
--- a/src/css/produtos.css
+++ b/src/css/produtos.css
@@ -355,7 +355,8 @@ body {
 }
 
 .popup-color-wrapper {
-  display: inline-block;
+  display: block;
+  width: 100%;
 }
 
 .popup-color-bar {

--- a/src/js/produtos.js
+++ b/src/js/produtos.js
@@ -222,10 +222,34 @@ function extrairCorDimensoes(nome) {
     return { cor, dimensoes };
 }
 
+const colorMap = {
+    branco: '#ffffff',
+    preto: '#000000',
+    vermelho: '#ff0000',
+    azul: '#0000ff',
+    verde: '#008000',
+    amarelo: '#ffff00',
+    roxo: '#800080',
+    laranja: '#ffa500',
+    rosa: '#ffc0cb',
+    marrom: '#a52a2a',
+    cinza: '#808080',
+    bege: '#f5f5dc',
+    prata: '#c0c0c0',
+    dourado: '#ffd700',
+    magenta: '#ff00ff',
+    ciano: '#00ffff'
+};
+
+function resolveColorCss(cor) {
+    const corSample = (cor.split('/')[1] || cor).trim();
+    const key = corSample.toLowerCase().replace(/\s+/g, '');
+    return colorMap[key] || corSample;
+}
+
 function createPopupContent(item) {
     const { cor, dimensoes } = extrairCorDimensoes(item.nome);
-    const corSample = (cor.split('/')[1] || cor).trim();
-    const corCss = corSample.replace(/\s+/g, '').toLowerCase();
+    const corCss = resolveColorCss(cor);
     return `
     <div class="popup-card">
       <div class="popup-header">


### PR DESCRIPTION
## Summary
- mapear nomes de cores em português para valores CSS
- exibir barra de cor abaixo do texto no popup de informações do produto

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c9d71408c8322b68dcde01f52d509