### PR TITLE
Atualizar Modal Editar Produto

### DIFF
--- a/src/css/produtos.css
+++ b/src/css/produtos.css
@@ -13,6 +13,7 @@
     --color-green: #a2ffa6;
     --color-red: #ff5858;
     --color-blue: #8aa7f3;
+    --color-sky: #87ceeb;
     --color-navy: #001f3f;
     --neutral-100: #f9fafb;
     --neutral-500: #6b7280;
@@ -146,8 +147,8 @@ body {
 }
 
 .badge-process {
-    background: rgba(0, 31, 63, 0.2);
-    color: var(--color-navy);
+    background: rgba(135, 206, 235, 0.2);
+    color: var(--color-sky);
 }
 
 .input-glass {

--- a/src/js/modals/produto-editar.js
+++ b/src/js/modals/produto-editar.js
@@ -292,7 +292,7 @@
       Object.entries(grupos).forEach(([proc, arr]) => {
         const header = document.createElement('tr');
         header.className = 'process-row';
-        header.innerHTML = `<td colspan="4" class="px-6 py-2 bg-gray-50 border-t border-gray-200 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">${proc}</td>`;
+        header.innerHTML = `<td colspan="4" class="px-6 py-2 bg-gray-50 border-t border-gray-200 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">${proc}</td>`;
         tableBody.appendChild(header);
         processOrder.push(proc);
         processos[proc] = { itens: arr, total: 0 };
@@ -327,6 +327,11 @@
       limparTudoBtn.addEventListener('click', () => {
         itens = [];
         if (tableBody) tableBody.innerHTML = '';
+        processOrder.length = 0;
+        Object.keys(processos).forEach(k => delete processos[k]);
+        [fabricacaoInput, acabamentoInput, montagemInput, embalagemInput, markupInput, commissionInput, taxInput]
+          .filter(Boolean)
+          .forEach(inp => inp.value = '');
         updateTotals();
       });
     }


### PR DESCRIPTION
## Summary
- refactor process totals badges to use sky-blue styling
- center process headers in items table
- extend clear all action to reset percentage fields

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c9f3025508322b7ad1052e10957eb