### PR TITLE
Fix color swatch in product info popup

### DIFF
--- a/src/js/produtos.js
+++ b/src/js/produtos.js
@@ -238,12 +238,13 @@ const colorMap = {
     prata: '#c0c0c0',
     dourado: '#ffd700',
     magenta: '#ff00ff',
-    ciano: '#00ffff'
+    ciano: '#00ffff',
+    offwhite: '#f5f5f5'
 };
 
 function resolveColorCss(cor) {
     const corSample = (cor.split('/')[1] || cor).trim();
-    const key = corSample.toLowerCase().replace(/\s+/g, '');
+    const key = corSample.toLowerCase().replace(/[\s-]+/g, '');
     return colorMap[key] || corSample;
 }
 


### PR DESCRIPTION
## Summary
- normalize color tokens and add offwhite hex mapping to show color swatch under color text in product info popup

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ca01eadf083229198706123c23946