### PR TITLE
Implement Process Totals Popover And Critical Search

### DIFF
--- a/src/css/materia-prima.css
+++ b/src/css/materia-prima.css
@@ -81,6 +81,26 @@ body {
     color: var(--color-violet);
 }
 
+.badge-acabamento {
+    background: rgba(182, 160, 62, 0.2);
+    color: var(--color-primary);
+}
+
+.badge-embalagem {
+    background: rgba(138, 167, 243, 0.2);
+    color: var(--color-blue);
+}
+
+.badge-marcenaria {
+    background: rgba(162, 255, 166, 0.2);
+    color: var(--color-green);
+}
+
+.badge-montagem {
+    background: rgba(106, 21, 44, 0.2);
+    color: var(--color-bordeaux);
+}
+
 .animate-fade-in-up {
     animation: fadeInUp 0.6s ease-out forwards;
     opacity: 0;
@@ -145,6 +165,25 @@ body {
 .info-icon:hover {
     background: rgba(255, 255, 255, 0.445);
     transform: scale(1.1);
+}
+
+.resumo-popover {
+    position: absolute;
+    z-index: 50;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.555);
+    opacity: 0;
+    visibility: hidden;
+    transform: translateY(8px);
+    transition: opacity 200ms ease, transform 200ms ease;
+    pointer-events: none;
+    background: #310017c5;
+}
+
+.resumo-popover.show {
+    opacity: 1;
+    visibility: visible;
+    transform: translateY(0);
+    pointer-events: auto;
 }
 
 /* Card principal do popup */

--- a/src/html/materia-prima.html
+++ b/src/html/materia-prima.html
@@ -52,7 +52,7 @@
 
                 <!-- Totais -->
                 <div class="flex flex-col">
-                    <label class="block text-sm font-medium mb-1 text-white">Totais por Tipo</label>
+                    <label class="block text-sm font-medium mb-1 text-white flex items-center gap-2">Totais por Tipo <i id="totaisInfoIcon" class="info-icon"></i></label>
                     <div id="totaisTags" class="flex flex-wrap gap-2">
                         <!-- Tags geradas dinamicamente -->
                     </div>
@@ -68,6 +68,11 @@
                     <button id="btnLimpar" class="btn-warning text-white rounded-md px-4 py-3 text-sm font-medium">Limpar</button>
                 </div>
             </div>
+        </div>
+
+        <div id="totaisPopover" class="resumo-popover glass-surface rounded-xl p-4 text-white">
+            <h3 class="font-medium mb-4 text-white">Totais por Processo</h3>
+            <div id="processTags" class="flex flex-wrap gap-2"></div>
         </div>
 
         <!-- Materials Table -->


### PR DESCRIPTION
## Summary
- Display an info popover for raw material process totals and color-coded tags.
- Highlight only infinite and low-stock totals while enabling search for critical items.
- Style process badges and popovers for consistent visual feedback.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ca20bbcc48322a59ef064888e1698