### PR TITLE
Fix color swatch in product info popup

### DIFF
--- a/src/css/materia-prima.css
+++ b/src/css/materia-prima.css
@@ -210,6 +210,18 @@ body {
   color: white; /* Altera a cor do valor para branco */
 }
 
+.popup-color-wrapper {
+  display: block;
+  width: 100%;
+}
+
+.popup-color-bar {
+  width: 100%;
+  height: 0.25rem;
+  margin-top: 0.125rem;
+  border-radius: 0.125rem;
+}
+
 /* Badge de "Sim" ou "Não" */
 .badge {
   display: inline-flex;

--- a/src/html/menu.html
+++ b/src/html/menu.html
@@ -363,6 +363,7 @@
 
     <!-- Script de controle do menu -->
     <script src="../utils/modal.js"></script>
+    <script src="../utils/colors.js"></script>
     <script src="../js/menu.js"></script>
     <script src="../js/scroll-handler.js"></script>
     <script src="../utils/userActions.js"></script>

--- a/src/js/materia-prima.js
+++ b/src/js/materia-prima.js
@@ -146,10 +146,27 @@ let currentPopup = null;
 let infoMouseEnter;
 let infoMouseLeave;
 
+function extractCor(nome, cor) {
+    return (cor || (nome && nome.split('/')[1]) || '').trim();
+}
+
 function createPopupContent(item) {
+    const cor = extractCor(item.nome, item.cor);
+    const corCss = window.resolveColorCss ? window.resolveColorCss(cor) : cor;
     const infinitoBadge = item.infinito
         ? `<span class="badge badge-sim">✔ Sim</span>`
         : `<span class="badge badge-nao">✖ Não</span>`;
+    const corSection = cor ? `
+        <div class="popup-info-grid">
+          <div>
+            <p class="popup-info-label">Cor:</p>
+            <div class="popup-color-wrapper">
+              <p class="popup-info-value">${cor}</p>
+              <div class="popup-color-bar" style="background-color: ${corCss};"></div>
+            </div>
+          </div>
+          <div></div>
+        </div>` : '';
 
     return `
     <div class="popup-card">
@@ -178,6 +195,7 @@ function createPopupContent(item) {
             <p class="popup-info-value">${item.processo || ''}</p>
           </div>
         </div>
+        ${corSection}
         <div class="popup-description-section">
           <p class="popup-info-label">Descrição Técnica:</p>
           <p class="popup-description-text">${item.descricao || ''}</p>

--- a/src/js/produtos.js
+++ b/src/js/produtos.js
@@ -222,30 +222,7 @@ function extrairCorDimensoes(nome) {
     return { cor, dimensoes };
 }
 
-const colorMap = {
-    branco: '#ffffff',
-    preto: '#000000',
-    vermelho: '#ff0000',
-    azul: '#0000ff',
-    verde: '#008000',
-    amarelo: '#ffff00',
-    roxo: '#800080',
-    laranja: '#ffa500',
-    rosa: '#ffc0cb',
-    marrom: '#a52a2a',
-    cinza: '#808080',
-    bege: '#f5f5dc',
-    prata: '#c0c0c0',
-    dourado: '#ffd700',
-    magenta: '#ff00ff',
-    ciano: '#00ffff'
-};
-
-function resolveColorCss(cor) {
-    const corSample = (cor.split('/')[1] || cor).trim();
-    const key = corSample.toLowerCase().replace(/\s+/g, '');
-    return colorMap[key] || corSample;
-}
+const resolveColorCss = window.resolveColorCss || (c => c);
 
 function createPopupContent(item) {
     const { cor, dimensoes } = extrairCorDimensoes(item.nome);

--- a/src/utils/colors.js
+++ b/src/utils/colors.js
@@ -1,0 +1,27 @@
+const colorMap = {
+  branco: '#ffffff',
+  preto: '#000000',
+  vermelho: '#ff0000',
+  azul: '#0000ff',
+  verde: '#008000',
+  amarelo: '#ffff00',
+  roxo: '#800080',
+  laranja: '#ffa500',
+  rosa: '#ffc0cb',
+  marrom: '#a52a2a',
+  cinza: '#808080',
+  bege: '#f5f5dc',
+  prata: '#c0c0c0',
+  dourado: '#ffd700',
+  magenta: '#ff00ff',
+  ciano: '#00ffff',
+  offwhite: '#f5f5f5'
+};
+
+function resolveColorCss(cor = '') {
+  const corSample = (cor.split('/')[1] || cor).trim();
+  const key = corSample.toLowerCase().replace(/[\s-]+/g, '');
+  return colorMap[key] || corSample;
+}
+
+window.resolveColorCss = resolveColorCss;


### PR DESCRIPTION
## Summary
- move color resolution logic to shared util and load it globally so swatches render consistently
- apply color swatch display to raw material info popups
- include color utility script in main menu to support all code popups

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ca01eadf083229198706123c23946