### PR TITLE
Improve Materia Prima Popup And Button Styling

### DIFF
--- a/src/css/materia-prima.css
+++ b/src/css/materia-prima.css
@@ -97,8 +97,8 @@ body {
 }
 
 .badge-montagem {
-    background: rgba(106, 21, 44, 0.2);
-    color: var(--color-bordeaux);
+    background: rgba(245, 158, 11, 0.2);
+    color: #F59E0B;
 }
 
 .animate-fade-in-up {
@@ -140,6 +140,12 @@ body {
     margin-top: 1vw;
 }
 
+.filter-bar input:not([type="checkbox"]),
+.filter-bar select,
+.filter-bar button {
+    height: 48px;
+}
+
 /* Ícone de informações e popover */
 .info-icon {
     width: 20px;
@@ -173,7 +179,7 @@ body {
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.555);
     opacity: 0;
     visibility: hidden;
-    transform: translateY(8px);
+    transform: translateY(-8px);
     transition: opacity 200ms ease, transform 200ms ease;
     pointer-events: none;
     background: #310017c5;

--- a/src/html/materia-prima.html
+++ b/src/html/materia-prima.html
@@ -64,8 +64,8 @@
                         <label for="zeroStock" class="text-sm font-medium text-white">0 Estoque</label>
                         <input type="checkbox" id="zeroStock" class="toggle" />
                     </div>
-                    <button id="btnFiltrar" class="btn-secondary text-white rounded-md px-4 py-3 text-sm font-medium">Filtrar</button>
-                    <button id="btnLimpar" class="btn-warning text-white rounded-md px-4 py-3 text-sm font-medium">Limpar</button>
+                    <button id="btnFiltrar" class="btn-secondary text-white rounded-md px-4 h-12 text-sm font-medium">Filtrar</button>
+                    <button id="btnLimpar" class="btn-warning text-white rounded-md px-4 h-12 text-sm font-medium">Limpar</button>
                 </div>
             </div>
         </div>

--- a/src/js/materia-prima.js
+++ b/src/js/materia-prima.js
@@ -45,10 +45,11 @@ function initMateriaPrima() {
     const popover = document.getElementById('totaisPopover');
     if (infoIcon && popover) {
         const mostrar = () => {
-            const rect = infoIcon.getBoundingClientRect();
-            popover.style.left = `${rect.left}px`;
-            popover.style.top = `${rect.bottom + 8}px`;
             popover.classList.add('show');
+            const rect = infoIcon.getBoundingClientRect();
+            const popRect = popover.getBoundingClientRect();
+            popover.style.left = `${rect.left + rect.width / 2 - popRect.width / 2}px`;
+            popover.style.top = `${rect.top - popRect.height - 4}px`;
         };
         const ocultar = () => popover.classList.remove('show');
         infoIcon.addEventListener('mouseenter', mostrar);


### PR DESCRIPTION
## Summary
- Position Materia Prima totals popover above info icon for better visibility
- Adjust Montagem badge color for clearer contrast
- Standardize filter bar control heights to avoid line wrapping

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ca87a2f408322869bef42b622572d