### PR TITLE
Add unit column to items table in product editor

### DIFF
--- a/src/html/modals/produtos/editar.html
+++ b/src/html/modals/produtos/editar.html
@@ -154,6 +154,7 @@
                               <tr class="border-b border-gray-200">
                                   <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">NOME DO ITEM</th>
                                   <th class="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">QUANTIDADE</th>
+                                  <th class="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">UNIDADE</th>
                                   <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">VALOR TOTAL</th>
                                   <th class="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">AÇÃO</th>
                               </tr>

--- a/src/js/modals/produto-editar.js
+++ b/src/js/modals/produto-editar.js
@@ -98,7 +98,7 @@
         console.error('[editar-produto] Sem tbody para renderizar erro:', msg);
         return;
       }
-      tableBody.innerHTML = `<tr><td colspan="4" class="py-4 text-center text-red-400">${msg}</td></tr>`;
+      tableBody.innerHTML = `<tr><td colspan="5" class="py-4 text-center text-red-400">${msg}</td></tr>`;
     }
 
     const produtoSelecionado = window.produtoSelecionado;
@@ -276,7 +276,7 @@
 
       if(itens.length === 0){
         const tr = document.createElement('tr');
-        tr.innerHTML = '<td colspan="4" class="py-4 text-center text-gray-400">Nenhum item encontrado</td>';
+        tr.innerHTML = '<td colspan="5" class="py-4 text-center text-gray-400">Nenhum item encontrado</td>';
         tableBody.appendChild(tr);
         updateTotals();
         return;
@@ -292,7 +292,7 @@
       Object.entries(grupos).forEach(([proc, arr]) => {
         const header = document.createElement('tr');
         header.className = 'process-row';
-        header.innerHTML = `<td colspan="4" class="px-6 py-2 bg-gray-50 border-t border-gray-200 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">${proc}</td>`;
+        header.innerHTML = `<td colspan="5" class="px-6 py-2 bg-gray-50 border-t border-gray-200 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">${proc}</td>`;
         tableBody.appendChild(header);
         processOrder.push(proc);
         processos[proc] = { itens: arr, total: 0 };
@@ -303,6 +303,7 @@
           tr.innerHTML = `
             <td class="py-3 px-2 text-sm text-white">${item.nome ?? '—'}</td>
             <td class="py-3 px-2 text-sm text-center quantidade-cell"><span class="quantidade-text">${formatNumber(item.quantidade)}</span></td>
+            <td class="py-3 px-2 text-sm text-center unidade-cell">${item.unidade ?? '—'}</td>
             <td class="py-3 px-2 text-sm text-right text-white item-total">${formatCurrency((item.preco_unitario || 0) * (item.quantidade || 0))}</td>
             <td class="py-3 px-2 text-sm text-center action-cell"></td>`;
           tableBody.appendChild(tr);
@@ -455,12 +456,13 @@
             if (!tableBody) {
               showError('Estrutura da tabela não encontrada (itens)');
             } else if (itensData.length === 0) {
-              tableBody.innerHTML = '<tr><td colspan="4" class="py-4 text-center text-gray-400">Nenhum item encontrado</td></tr>';
+              tableBody.innerHTML = '<tr><td colspan="5" class="py-4 text-center text-gray-400">Nenhum item encontrado</td></tr>';
             } else {
               tableBody.innerHTML = itensData.map(it => `
                 <tr class="border-b border-white/5">
                   <td class="py-3 px-2 text-white">${it.nome ?? '—'}</td>
                   <td class="py-3 px-2 text-center">${(Number.isInteger(it.quantidade)? it.quantidade : (parseFloat(it.quantidade)||0).toFixed(2))}</td>
+                  <td class="py-3 px-2 text-center">${it.unidade ?? '—'}</td>
                   <td class="py-3 px-2 text-right text-white">
                     ${(((it.preco_unitario||0)*(it.quantidade||0))).toLocaleString('pt-BR',{style:'currency',currency:'BRL'})}
                   </td>
@@ -480,7 +482,7 @@
         const msg = err && err.message ? err.message : 'Erro ao carregar dados';
         if (!tableBody) tableBody = resolveItensTbody();
         if (tableBody) {
-          tableBody.innerHTML = `<tr><td colspan="4" class="py-4 text-center text-red-400">${msg}</td></tr>`;
+          tableBody.innerHTML = `<tr><td colspan="5" class="py-4 text-center text-red-400">${msg}</td></tr>`;
         }
       }
     })();


### PR DESCRIPTION
## Summary
- show unit for each item in product edit modal
- update item rendering logic and colspans to accommodate new unit column

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689cadff3bb083229a565730ee276a36