### PR TITLE
Fix Missing Item Unit In Items Table

### DIFF
--- a/backend/produtos.js
+++ b/backend/produtos.js
@@ -66,6 +66,7 @@ async function listarDetalhesProduto(produtoCodigo, produtoId) {
              pi.quantidade,
              mp.nome,
              mp.preco_unitario,
+             mp.unidade,
              mp.processo
         FROM produtos_insumos pi
         JOIN materia_prima mp ON mp.id = pi.insumo_id
@@ -123,6 +124,7 @@ async function listarInsumosProduto(codigo) {
            mp.nome,
            pi.quantidade,
            mp.preco_unitario,
+           mp.unidade,
            mp.preco_unitario * pi.quantidade AS total,
            mp.processo
       FROM produtos_insumos pi


### PR DESCRIPTION
## Summary
- include material unit in product detail item queries
- expose material unit when listing product inputs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689cc574e9448322a753f2169748c6dd