### PR TITLE
Make Materia Prima Fields Responsive to Sidebar

### DIFF
--- a/src/css/materia-prima.css
+++ b/src/css/materia-prima.css
@@ -121,12 +121,7 @@ body {
 /* Barra de filtros responsiva */
 .filter-bar {
     gap: 24px;
-}
-
-@media (min-width: 1280px) {
-    .filter-bar {
-        flex-wrap: nowrap;
-    }
+    flex-wrap: wrap;
 }
 
 @media (max-width: 767px) {
@@ -138,6 +133,16 @@ body {
 
 #bt-actions {
     margin-top: 1vw;
+    width: 100%;
+    justify-content: flex-start;
+}
+
+@media (min-width: 768px) {
+    #bt-actions {
+        width: auto;
+        margin-top: 0;
+        justify-content: flex-end;
+    }
 }
 
 .filter-bar input:not([type="checkbox"]),

--- a/src/html/materia-prima.html
+++ b/src/html/materia-prima.html
@@ -27,7 +27,7 @@
 
         <!-- Filters & Totals -->
         <div class="glass-surface rounded-xl p-6 mb-6 animate-fade-in-up">
-            <div class="filter-bar flex flex-col md:flex-row md:flex-wrap xl:flex-nowrap items-center">
+            <div class="filter-bar flex flex-col md:flex-row md:flex-wrap items-center w-full">
                 <!-- Search -->
                 <div class="flex-1 min-w-[250px]">
                     <label class="block text-sm font-medium mb-2 text-white">Buscar Insumo</label>
@@ -51,7 +51,7 @@
                 </div>
 
                 <!-- Totais -->
-                <div class="flex flex-col">
+                <div class="flex flex-col flex-1 min-w-[200px]">
                     <label class="block text-sm font-medium mb-1 text-white flex items-center gap-2">Totais por Tipo <i id="totaisInfoIcon" class="info-icon"></i></label>
                     <div id="totaisTags" class="flex flex-wrap gap-2">
                         <!-- Tags geradas dinamicamente -->
@@ -59,7 +59,7 @@
                 </div>
 
                 <!-- Actions -->
-                <div id="bt-actions" class="flex items-center gap-2">
+                <div id="bt-actions" class="flex items-center gap-2 w-full justify-center md:w-auto md:justify-end">
                     <div class="filter-toggle flex flex-col items-center space-y-1">
                         <label for="zeroStock" class="text-sm font-medium text-white">0 Estoque</label>
                         <input type="checkbox" id="zeroStock" class="toggle" />


### PR DESCRIPTION
## Summary
- ensure filter bar wraps and adjusts layout so fields stay within glass container
- make action controls span full width on narrow screens for better responsiveness

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cca42693483229600d8ca49809975