### PR TITLE
Avoid Line Breaks In Materia Prima Filters

### DIFF
--- a/src/css/materia-prima.css
+++ b/src/css/materia-prima.css
@@ -121,7 +121,7 @@ body {
 /* Barra de filtros responsiva */
 .filter-bar {
     gap: 24px;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
 }
 
 @media (max-width: 767px) {

--- a/src/html/materia-prima.html
+++ b/src/html/materia-prima.html
@@ -27,15 +27,15 @@
 
         <!-- Filters & Totals -->
         <div class="glass-surface rounded-xl p-6 mb-6 animate-fade-in-up">
-            <div class="filter-bar flex flex-col md:flex-row md:flex-wrap items-center w-full">
+            <div class="filter-bar flex flex-col md:flex-row md:flex-nowrap items-center w-full">
                 <!-- Search -->
-                <div class="flex-1 min-w-[250px]">
+                <div class="flex-1 min-w-0">
                     <label class="block text-sm font-medium mb-2 text-white">Buscar Insumo</label>
                     <input id="materiaPrimaSearch" type="text" placeholder="Nome, Categoria ou Processo" class="input-glass text-white rounded-md px-4 py-3 w-full placeholder-white/50">
                 </div>
 
                 <!-- Processo -->
-                <div class="flex-1 min-w-[200px]">
+                <div class="flex-1 min-w-0">
                     <label class="block text-sm font-medium mb-2 text-white">Processo</label>
                     <select id="filtroProcesso" class="input-glass text-white rounded-md px-4 py-3 w-full">
                         <option value="">Todos</option>
@@ -43,7 +43,7 @@
                 </div>
 
                 <!-- Categoria -->
-                <div class="flex-1 min-w-[200px]">
+                <div class="flex-1 min-w-0">
                     <label class="block text-sm font-medium mb-2 text-white">Categoria</label>
                     <select id="filtroCategoria" class="input-glass text-white rounded-md px-4 py-3 w-full">
                         <option value="">Todas</option>
@@ -51,7 +51,7 @@
                 </div>
 
                 <!-- Totais -->
-                <div class="flex flex-col flex-1 min-w-[200px]">
+                <div class="flex flex-col flex-1 min-w-0">
                     <label class="block text-sm font-medium mb-1 text-white flex items-center gap-2">Totais por Tipo <i id="totaisInfoIcon" class="info-icon"></i></label>
                     <div id="totaisTags" class="flex flex-wrap gap-2">
                         <!-- Tags geradas dinamicamente -->


### PR DESCRIPTION
## Summary
- Prevent filter bar wrapping by enforcing nowrap on Materia Prima page and allowing controls to shrink.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ccdda44408322bd99a8bf1169b8ba