### PR TITLE
Add color approximation utility

### DIFF
--- a/manual-tests/resolveColorCss.js
+++ b/manual-tests/resolveColorCss.js
@@ -1,0 +1,6 @@
+const { resolveColorCss } = require('../src/utils/colors');
+
+const inputs = ['navy', '#7fff00', 'vermelho'];
+for (const name of inputs) {
+  console.log(name + ' -> ' + resolveColorCss(name));
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "cors": "^2.8.5",
         "dotenv": "^17.0.1",
         "express": "^5.1.0",
+        "nearest-color": "^0.4.4",
         "nodemailer": "^7.0.5",
         "pg": "^8.16.0"
       },
@@ -3858,6 +3859,12 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node_modules/nearest-color": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/nearest-color/-/nearest-color-0.4.4.tgz",
+      "integrity": "sha512-orhcaIORC10tf41Ld2wwlcC+FaAavHG87JHWB3eHH5p7v2k9Tzym2XNEZzLAm5YJwGv6Q38WWc7SOb+Qfu/4NQ==",
+      "license": "MIT"
     },
     "node_modules/nearley": {
       "version": "2.20.1",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "cors": "^2.8.5",
     "dotenv": "^17.0.1",
     "express": "^5.1.0",
+    "nearest-color": "^0.4.4",
     "nodemailer": "^7.0.5",
     "pg": "^8.16.0"
   },

--- a/src/utils/colors.js
+++ b/src/utils/colors.js
@@ -18,10 +18,26 @@ const colorMap = {
   offwhite: '#f5f5f5'
 };
 
+const nearest = require('nearest-color').from(colorMap);
+
+/**
+ * Resolve a cor para um valor CSS hexadecimal.
+ * Entradas desconhecidas resultam na cor mais próxima disponível.
+ */
 function resolveColorCss(cor = '') {
   const corSample = (cor.split('/')[1] || cor).trim();
   const key = corSample.toLowerCase().replace(/[\s-]+/g, '');
-  return colorMap[key] || corSample;
+  const mapped = colorMap[key];
+  if (mapped) return mapped;
+  try {
+    return nearest(corSample).value;
+  } catch (err) {
+    return corSample;
+  }
 }
 
-window.resolveColorCss = resolveColorCss;
+if (typeof window !== 'undefined') {
+  window.resolveColorCss = resolveColorCss;
+}
+
+module.exports = { resolveColorCss };


### PR DESCRIPTION
## Summary
- integrate `nearest-color` for approximate color lookup
- resolve unknown colors to nearest hex and document behavior
- add manual script to showcase color resolution

## Testing
- `npm test`
- `node manual-tests/resolveColorCss.js`


------
https://chatgpt.com/codex/tasks/task_e_689ccff984b08322b69b65e8c681e3f6