### PR TITLE
Allow Materia Prima Search Box To Shrink

### DIFF
--- a/src/css/materia-prima.css
+++ b/src/css/materia-prima.css
@@ -151,6 +151,11 @@ body {
     height: 48px;
 }
 
+/* Permite que a barra de busca encolha para evitar sobreposição quando a sidebar estiver ativa */
+#materiaPrimaSearch {
+    min-width: 1vw;
+}
+
 /* Ícone de informações e popover */
 .info-icon {
     width: 20px;


### PR DESCRIPTION
## Summary
- prevent search input in Materia Prima module from overlapping when sidebar is open by allowing it to shrink

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cd3bfc01883228d0ec104191067a4