### PR TITLE
Corrigir Amostra De Cor Para Qualquer Cor

### DIFF
--- a/manual-tests/resolveColorCss.js
+++ b/manual-tests/resolveColorCss.js
@@ -1,6 +1,6 @@
 const { resolveColorCss } = require('../src/utils/colors');
 
-const inputs = ['navy', '#7fff00', 'vermelho'];
+const inputs = ['navy', '#7fff00', 'vermelho', 'grafite'];
 for (const name of inputs) {
   console.log(name + ' -> ' + resolveColorCss(name));
 }

--- a/src/utils/colors.js
+++ b/src/utils/colors.js
@@ -158,6 +158,7 @@ const colorMap = {
   rosa: '#ffc0cb',
   marrom: '#a52a2a',
   cinza: '#808080',
+  grafite: '#484848',
   bege: '#f5f5dc',
   prata: '#c0c0c0',
   dourado: '#ffd700',
@@ -173,13 +174,21 @@ const nearest = require('nearest-color').from(colorMap);
  */
 function resolveColorCss(cor = '') {
   const corSample = (cor.split('/')[1] || cor).trim();
-  const key = corSample.toLowerCase().replace(/[\s-]+/g, '');
+  const key = corSample
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[\s-]+/g, '');
   const mapped = colorMap[key];
   if (mapped) return mapped;
   try {
     return nearest(corSample).value;
-  } catch (err) {
-    return corSample;
+  } catch {
+    let hash = 0;
+    for (let i = 0; i < key.length; i++) {
+      hash = key.charCodeAt(i) + ((hash << 5) - hash);
+    }
+    return `#${(hash >>> 0).toString(16).padStart(6, '0').slice(0, 6)}`;
   }
 }
 


### PR DESCRIPTION
## Summary
- add graphite color mapping and hash fallback for unknown colors
- expand manual color resolution test with graphite entry

## Testing
- `npm test`
- `node manual-tests/resolveColorCss.js`


------
https://chatgpt.com/codex/tasks/task_e_689cdf6c6d388322ad605fb0af0295f5