### PR TITLE
Ajusta filtros de matéria-prima para evitar sobreposição na sidebar

### DIFF
--- a/src/css/materia-prima.css
+++ b/src/css/materia-prima.css
@@ -135,6 +135,7 @@ body {
     margin-top: 1vw;
     width: 100%;
     justify-content: flex-start;
+    flex-wrap: wrap; /* Permite contração para evitar sobreposição */
 }
 
 @media (min-width: 768px) {
@@ -364,5 +365,6 @@ body {
 .toast-error { background-color: #dc2626; }
 
 #onoff {
-    margin-left: -6vw;
+    margin-left: 0; /* Evita sobreposição do toggle com a barra lateral */
+    flex-shrink: 1;
 }


### PR DESCRIPTION
## Summary
- Permite que ações do filtro de matéria-prima quebrem linha quando a largura é reduzida
- Remove margem negativa do toggle de 0 estoque para evitar sobreposição com a sidebar

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ce0a45db483228f1be368ae6f8e30