### PR TITLE
Add light border around color sample in product popup

### DIFF
--- a/src/css/produtos.css
+++ b/src/css/produtos.css
@@ -329,6 +329,10 @@ body {
   border-radius: 0.125rem;
 }
 
+.popup-color-bar-outline {
+  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.6);
+}
+
 /* Seção de descrição técnica */
 .popup-description-section {
   padding-top: 0.75rem;

--- a/src/js/produtos.js
+++ b/src/js/produtos.js
@@ -224,9 +224,23 @@ function extrairCorDimensoes(nome) {
 
 const resolveColorCss = window.resolveColorCss || (c => c);
 
+function isDarkColor(hex) {
+    const sanitized = hex.replace('#', '');
+    const full = sanitized.length === 3
+        ? sanitized.replace(/(.)/g, '$1$1')
+        : sanitized;
+    const bigint = parseInt(full, 16);
+    const r = (bigint >> 16) & 255;
+    const g = (bigint >> 8) & 255;
+    const b = bigint & 255;
+    const brightness = (r * 299 + g * 587 + b * 114) / 1000;
+    return brightness < 128;
+}
+
 function createPopupContent(item) {
     const { cor, dimensoes } = extrairCorDimensoes(item.nome);
     const corCss = resolveColorCss(cor);
+    const outlineClass = isDarkColor(corCss) ? ' popup-color-bar-outline' : '';
     return `
     <div class="popup-card">
       <div class="popup-header">
@@ -249,7 +263,7 @@ function createPopupContent(item) {
             <p class="popup-info-label">Cor:</p>
             <div class="popup-color-wrapper">
               <p class="popup-info-value">${cor}</p>
-              <div class="popup-color-bar" style="background-color: ${corCss};"></div>
+              <div class="popup-color-bar${outlineClass}" style="background-color: ${corCss};"></div>
             </div>
           </div>
           <div>


### PR DESCRIPTION
## Summary
- add light border to color swatch when its color is dark

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ce227b4d48322913ab05e0913b3ab