### PR TITLE
Fix process name storage for product lots

### DIFF
--- a/backend/inserirLoteProduto.test.js
+++ b/backend/inserirLoteProduto.test.js
@@ -7,7 +7,7 @@ function setup() {
   db.public.none(`CREATE TABLE produtos_em_cada_ponto (
     id serial primary key,
     produto_id int,
-    etapa_id int,
+    etapa_id text,
     ultimo_insumo_id int,
     quantidade int,
     data_hora_completa timestamp
@@ -30,12 +30,12 @@ test('inserirLoteProduto insere e retorna o lote criado', async () => {
   const { inserirLoteProduto, pool } = setup();
   const lote = await inserirLoteProduto({
     produtoId: 1,
-    etapaId: 2,
+    etapaId: 'Corte',
     ultimoInsumoId: 3,
     quantidade: 5
   });
   assert.strictEqual(lote.produto_id, 1);
-  assert.strictEqual(lote.etapa_id, 2);
+  assert.strictEqual(lote.etapa_id, 'Corte');
   assert.strictEqual(lote.ultimo_insumo_id, 3);
   assert.strictEqual(lote.quantidade, 5);
   assert(lote.data_hora_completa instanceof Date);
@@ -45,8 +45,8 @@ test('inserirLoteProduto insere e retorna o lote criado', async () => {
 
 test('inserirLoteProduto permite múltiplas inserções', async () => {
   const { inserirLoteProduto, pool } = setup();
-  await inserirLoteProduto({ produtoId: 1, etapaId: 1, ultimoInsumoId: 1, quantidade: 1 });
-  await inserirLoteProduto({ produtoId: 2, etapaId: 2, ultimoInsumoId: 2, quantidade: 2 });
+  await inserirLoteProduto({ produtoId: 1, etapaId: 'Corte', ultimoInsumoId: 1, quantidade: 1 });
+  await inserirLoteProduto({ produtoId: 2, etapaId: 'Costura', ultimoInsumoId: 2, quantidade: 2 });
   const rows = await pool.query('SELECT quantidade FROM produtos_em_cada_ponto ORDER BY id');
   assert.deepStrictEqual(rows.rows.map(r => r.quantidade), [1, 2]);
 });

--- a/backend/produtos.js
+++ b/backend/produtos.js
@@ -201,7 +201,7 @@ async function excluirProduto(id) {
  *
  * @param {Object} params                Dados do lote a ser criado.
  * @param {number} params.produtoId      Identificador do produto.
- * @param {number} params.etapaId        Etapa da produção em que o lote se encontra.
+ * @param {string} params.etapaId        Etapa da produção em que o lote se encontra.
  * @param {number} params.ultimoInsumoId Último insumo utilizado na produção.
  * @param {number} params.quantidade     Quantidade de itens produzidos no lote.
  * @returns {Promise<Object>}            Registro completo do lote recém inserido.
@@ -209,7 +209,7 @@ async function excluirProduto(id) {
 async function inserirLoteProduto({ produtoId, etapaId, ultimoInsumoId, quantidade }) {
   const res = await pool.query(
     `INSERT INTO produtos_em_cada_ponto (produto_id, etapa_id, ultimo_insumo_id, quantidade, data_hora_completa)
-     VALUES ($1::int, $2::int, $3::int, $4::int, NOW()) RETURNING *`,
+     VALUES ($1::int, $2::text, $3::int, $4::int, NOW()) RETURNING *`,
     [produtoId, etapaId, ultimoInsumoId, quantidade]
   );
   return res.rows[0];

--- a/docs/inserir-lote-produto.md
+++ b/docs/inserir-lote-produto.md
@@ -7,7 +7,7 @@ Esta função grava um registro na tabela `produtos_em_cada_ponto` contendo o pr
 
 ## Parâmetros
 - `produtoId` – identificador do produto.
-- `etapaId` – etapa do processo onde o lote foi adicionado.
+- `etapaId` – nome da etapa do processo onde o lote foi adicionado.
 - `ultimoInsumoId` – último insumo utilizado na produção.
 - `quantidade` – quantidade produzida neste lote.
 
@@ -15,7 +15,7 @@ Esta função grava um registro na tabela `produtos_em_cada_ponto` contendo o pr
 ```js
 await window.electronAPI.inserirLoteProduto({
   produtoId: 7,
-  etapaId: 3,
+  etapaId: 'Corte',
   ultimoInsumoId: 12,
   quantidade: 50
 });

--- a/src/js/modals/produto-estoque-inserir.js
+++ b/src/js/modals/produto-estoque-inserir.js
@@ -23,7 +23,7 @@
     try{
       const processos = await window.electronAPI.listarEtapasProducao();
       processoSelect.innerHTML = '<option value="">Selecione um processo…</option>' +
-        processos.map(p => `<option value="${p.id}">${p.nome}</option>`).join('');
+        processos.map(p => `<option value="${p.nome}" data-id="${p.id}">${p.nome}</option>`).join('');
     }catch(err){
       console.error('Erro ao listar processos', err);
     }
@@ -33,11 +33,11 @@
     itemInput.disabled = true;
     itemMensagem.textContent = '';
     itemOptions.innerHTML = '';
-    const etapaId = processoSelect.value;
+    const etapa = processoSelect.value;
     const codigo = window.produtoDetalhes?.codigo;
-    if(!etapaId || !codigo){ itemInput.disabled = true; return; }
+    if(!etapa || !codigo){ itemInput.disabled = true; return; }
     try{
-      const itens = await window.electronAPI.listarItensProcessoProduto(codigo, etapaId, termo);
+      const itens = await window.electronAPI.listarItensProcessoProduto(codigo, etapa, termo);
       if(itens.length){
         itemOptions.innerHTML = itens.map(i => `<option value="${i.nome}" data-id="${i.id}"></option>`).join('');
       }else{
@@ -65,18 +65,18 @@
   if(form){
     form.addEventListener('submit', async e => {
       e.preventDefault();
-      const etapaId = processoSelect.value;
+      const etapa = processoSelect.value;
       const itemNome = itemInput.value.trim();
       const option = Array.from(itemOptions.querySelectorAll('option')).find(o => o.value === itemNome);
       const itemId = option?.dataset.id;
       const quantidade = Number(quantidadeInput.value);
-      if(!etapaId || !itemId || !quantidade){
+      if(!etapa || !itemId || !quantidade){
         showToast('Preencha todos os campos', 'error');
         return;
       }
       const produto = window.produtoDetalhes;
       if(!produto) return;
-      const existente = produto.lotes?.find(l => String(l.etapa) === String(etapaId) && String(l.ultimo_insumo_id) === String(itemId));
+      const existente = produto.lotes?.find(l => String(l.etapa) === String(etapa) && String(l.ultimo_insumo_id) === String(itemId));
       if(existente){
         window.somarEstoqueInfo = {
           existing: existente,
@@ -97,7 +97,7 @@
       try{
         await window.electronAPI.inserirLoteProduto({
           produtoId: produto.id,
-          etapaId,
+          etapaId: etapa,
           ultimoInsumoId: itemId,
           quantidade
         });


### PR DESCRIPTION
## Summary
- Use process name instead of id when inserting product stock
- Store stage identifier as text in backend and update tests
- Clarify inserir-lote-produto docs to note etapaId uses process name

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ce3b0440083229edb5df1993f2b6d