### PR TITLE
Centralizar 0 Estoque De Materia Prima

### DIFF
--- a/src/html/materia-prima.html
+++ b/src/html/materia-prima.html
@@ -83,7 +83,7 @@
                     <thead class="bg-gray-50 sticky top-0" style="z-index:9999;">
                             <tr>
                                 <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Nome</th>
-                                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Quantidade</th>
+                                <th class="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">Quantidade</th>
                                 <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Unidade</th>
                                 <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Preço Unitário</th>
                                 <th class="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">Ações</th>

--- a/src/js/materia-prima.js
+++ b/src/js/materia-prima.js
@@ -366,7 +366,7 @@ function renderMateriais(listaMateriais) {
                     <i class="info-icon ml-2" data-id="${item.id}"></i>
                 </div>
             </td>
-            <td class="px-6 py-4 whitespace-nowrap text-sm text-white">${quantidadeValor}</td>
+            <td class="px-6 py-4 whitespace-nowrap text-sm text-white text-center">${quantidadeValor}</td>
             <td class="px-6 py-4 whitespace-nowrap text-sm" style="color: var(--color-violet)">${item.unidade || ''}</td>
             <td class="px-6 py-4 whitespace-nowrap text-sm text-white">R$ ${preco.toFixed(2).replace('.', ',')}</td>
             <td class="px-6 py-4 whitespace-nowrap text-center">${acoes}</td>`;


### PR DESCRIPTION
## Summary
- centralize quantidade column header in raw-material inventory table
- center quantity values for better alignment

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689cf05807688322ab0e9711d63db321