### PR TITLE
Accept Text Stage Name For Inventory Batches

### DIFF
--- a/backend/inserirLoteProduto.test.js
+++ b/backend/inserirLoteProduto.test.js
@@ -30,7 +30,7 @@ test('inserirLoteProduto insere e retorna o lote criado', async () => {
   const { inserirLoteProduto, pool } = setup();
   const lote = await inserirLoteProduto({
     produtoId: 1,
-    etapaId: 'Corte',
+    etapa: 'Corte',
     ultimoInsumoId: 3,
     quantidade: 5
   });
@@ -45,8 +45,8 @@ test('inserirLoteProduto insere e retorna o lote criado', async () => {
 
 test('inserirLoteProduto permite múltiplas inserções', async () => {
   const { inserirLoteProduto, pool } = setup();
-  await inserirLoteProduto({ produtoId: 1, etapaId: 'Corte', ultimoInsumoId: 1, quantidade: 1 });
-  await inserirLoteProduto({ produtoId: 2, etapaId: 'Costura', ultimoInsumoId: 2, quantidade: 2 });
+await inserirLoteProduto({ produtoId: 1, etapa: 'Corte', ultimoInsumoId: 1, quantidade: 1 });
+await inserirLoteProduto({ produtoId: 2, etapa: 'Costura', ultimoInsumoId: 2, quantidade: 2 });
   const rows = await pool.query('SELECT quantidade FROM produtos_em_cada_ponto ORDER BY id');
   assert.deepStrictEqual(rows.rows.map(r => r.quantidade), [1, 2]);
 });

--- a/backend/produtos.js
+++ b/backend/produtos.js
@@ -149,7 +149,7 @@ async function listarEtapasProducao() {
  * Lista itens de um processo para um produto (dependente de etapa)
  * Aceita etapa por id (int) OU por nome (text).
  */
-async function listarItensProcessoProduto(codigo, etapaIdOuNome, busca = '') {
+async function listarItensProcessoProduto(codigo, etapa, busca = '') {
   const sql = `
     SELECT DISTINCT mp.id, mp.nome
       FROM materia_prima mp
@@ -159,7 +159,7 @@ async function listarItensProcessoProduto(codigo, etapaIdOuNome, busca = '') {
        AND mp.processo = ep.nome
        AND mp.nome ILIKE $3
      ORDER BY mp.nome ASC`;
-  const res = await pool.query(sql, [codigo, etapaIdOuNome, '%' + busca + '%']);
+  const res = await pool.query(sql, [codigo, etapa, '%' + busca + '%']);
   return res.rows;
 }
 
@@ -201,16 +201,16 @@ async function excluirProduto(id) {
  *
  * @param {Object} params                Dados do lote a ser criado.
  * @param {number} params.produtoId      Identificador do produto.
- * @param {string} params.etapaId        Etapa da produção em que o lote se encontra.
+ * @param {string} params.etapa          Etapa da produção em que o lote se encontra.
  * @param {number} params.ultimoInsumoId Último insumo utilizado na produção.
  * @param {number} params.quantidade     Quantidade de itens produzidos no lote.
  * @returns {Promise<Object>}            Registro completo do lote recém inserido.
  */
-async function inserirLoteProduto({ produtoId, etapaId, ultimoInsumoId, quantidade }) {
+async function inserirLoteProduto({ produtoId, etapa, ultimoInsumoId, quantidade }) {
   const res = await pool.query(
     `INSERT INTO produtos_em_cada_ponto (produto_id, etapa_id, ultimo_insumo_id, quantidade, data_hora_completa)
      VALUES ($1::int, $2::text, $3::int, $4::int, NOW()) RETURNING *`,
-    [produtoId, etapaId, ultimoInsumoId, quantidade]
+    [produtoId, etapa, ultimoInsumoId, quantidade]
   );
   return res.rows[0];
 }

--- a/docs/inserir-lote-produto.md
+++ b/docs/inserir-lote-produto.md
@@ -7,7 +7,7 @@ Esta função grava um registro na tabela `produtos_em_cada_ponto` contendo o pr
 
 ## Parâmetros
 - `produtoId` – identificador do produto.
-- `etapaId` – nome da etapa do processo onde o lote foi adicionado.
+- `etapa` – nome da etapa do processo onde o lote foi adicionado.
 - `ultimoInsumoId` – último insumo utilizado na produção.
 - `quantidade` – quantidade produzida neste lote.
 
@@ -15,7 +15,7 @@ Esta função grava um registro na tabela `produtos_em_cada_ponto` contendo o pr
 ```js
 await window.electronAPI.inserirLoteProduto({
   produtoId: 7,
-  etapaId: 'Corte',
+  etapa: 'Corte',
   ultimoInsumoId: 12,
   quantidade: 50
 });

--- a/main.js
+++ b/main.js
@@ -406,8 +406,8 @@ ipcMain.handle('listar-insumos-produto', async (_e, codigo) => {
 ipcMain.handle('listar-etapas-producao', async () => {
   return listarEtapasProducao();
 });
-ipcMain.handle('listar-itens-processo-produto', async (_e, { codigo, etapaId, busca }) => {
-  return listarItensProcessoProduto(codigo, etapaId, busca);
+ipcMain.handle('listar-itens-processo-produto', async (_e, { codigo, etapa, busca }) => {
+  return listarItensProcessoProduto(codigo, etapa, busca);
 });
 ipcMain.handle('salvar-produto-detalhado', async (_e, { codigo, produto, itens }) => {
   return salvarProdutoDetalhado(codigo, produto, itens);

--- a/preload.js
+++ b/preload.js
@@ -17,8 +17,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
   excluirLoteProduto: (id) => ipcRenderer.invoke('excluir-lote-produto', id),
   listarInsumosProduto: (codigo) => ipcRenderer.invoke('listar-insumos-produto', codigo),
   listarEtapasProducao: () => ipcRenderer.invoke('listar-etapas-producao'),
-  listarItensProcessoProduto: (codigo, etapaId, busca) =>
-    ipcRenderer.invoke('listar-itens-processo-produto', { codigo, etapaId, busca }),
+  listarItensProcessoProduto: (codigo, etapa, busca) =>
+    ipcRenderer.invoke('listar-itens-processo-produto', { codigo, etapa, busca }),
   salvarProdutoDetalhado: (codigo, produto, itens) =>
     ipcRenderer.invoke('salvar-produto-detalhado', { codigo, produto, itens }),
   adicionarMateriaPrima: (dados) => ipcRenderer.invoke('adicionar-materia-prima', dados),

--- a/src/js/modals/produto-estoque-inserir.js
+++ b/src/js/modals/produto-estoque-inserir.js
@@ -97,7 +97,7 @@
       try{
         await window.electronAPI.inserirLoteProduto({
           produtoId: produto.id,
-          etapaId: etapa,
+          etapa,
           ultimoInsumoId: itemId,
           quantidade
         });


### PR DESCRIPTION
## Summary
- Adjust inventory batch APIs to accept stage names instead of numeric IDs, matching database text columns
- Update front-end modal and preload bridge to send and handle text stage names
- Refresh documentation and tests to reflect the text-based stage identifiers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cf0d34f4c832294c186d979c7c6db