### PR TITLE
Fix product stock quantity update error

### DIFF
--- a/src/js/modals/produto-detalhes.js
+++ b/src/js/modals/produto-detalhes.js
@@ -83,7 +83,7 @@
         await window.electronAPI.atualizarLoteProduto({ id: dados.id, quantidade: novaQtd });
         showToast('Quantidade atualizada', 'success');
         carregarDetalhes(item.codigo, item.id);
-        carregarProdutos();
+        if (typeof carregarProdutos === 'function') carregarProdutos();
       } catch (err) {
         console.error(err);
         showToast('Erro ao atualizar quantidade', 'error');
@@ -97,7 +97,7 @@
       id,
       reload: () => {
         carregarDetalhes(item.codigo, item.id);
-        carregarProdutos();
+        if (typeof carregarProdutos === 'function') carregarProdutos();
       }
     };
     Modal.open('modals/produtos/excluir-lote.html', '../js/modals/produto-lote-excluir.js', 'excluirLote', true);


### PR DESCRIPTION
## Summary
- Guard product list refresh in product detail modal to avoid crashes when atualizarLoteProduto is used in pages without the main product table

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689cf98fa0b48322b5d4aa746cb46be7