### PR TITLE
Handle Duplicate Items On Register

### DIFF
--- a/src/js/modals/produto-proxima-etapa.js
+++ b/src/js/modals/produto-proxima-etapa.js
@@ -203,14 +203,14 @@
   });
 
   // registrar/transferir
-  if (registrarBtn) registrarBtn.addEventListener('click',()=>{
+  if (registrarBtn) registrarBtn.addEventListener('click', async ()=>{
     if(!itens.length){
       showToast('Nada para registrar', 'error');
       return;
     }
     if(window.produtoEditarAPI && typeof window.produtoEditarAPI.adicionarProcessoItens==='function'){
       const novos = itens.map(it=>({ ...it }));
-      window.produtoEditarAPI.adicionarProcessoItens(novos);
+      await window.produtoEditarAPI.adicionarProcessoItens(novos);
     }
     closeOverlay();
   });


### PR DESCRIPTION
## Summary
- warn about duplicated items and allow user decision when registering new process items
- await duplicate resolution before closing modal

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689df8fd8b388322916f9ca9a572344f