### PR TITLE
Fix hover pop-ups for info icons in tables

### DIFF
--- a/src/js/materia-prima.js
+++ b/src/js/materia-prima.js
@@ -277,6 +277,7 @@ function showInfoPopup(target, item) {
 
     popup.style.left = `${left + window.scrollX}px`;
     popup.style.top = `${top + window.scrollY}px`;
+    popup.addEventListener('mouseleave', hideInfoPopup);
     currentRawMaterialPopup = popup;
 }
 
@@ -296,7 +297,11 @@ function attachInfoEvents() {
             const item = materiais.find(m => m.id === id);
             if (item) showInfoPopup(icon, item);
         });
-        icon.addEventListener('mouseleave', hideInfoPopup);
+        icon.addEventListener('mouseleave', () => {
+            setTimeout(() => {
+                if (!currentRawMaterialPopup?.matches(':hover')) hideInfoPopup();
+            }, 100);
+        });
     });
     if (window.feather) feather.replace();
 }

--- a/src/js/produtos.js
+++ b/src/js/produtos.js
@@ -309,6 +309,7 @@ function showInfoPopup(target, item) {
 
     popup.style.left = `${left + window.scrollX}px`;
     popup.style.top = `${top + window.scrollY}px`;
+    popup.addEventListener('mouseleave', hideInfoPopup);
     currentProductPopup = popup;
 }
 
@@ -328,7 +329,11 @@ function attachInfoEvents() {
             const item = produtosRenderizados.find(p => p.id === id);
             if (item) showInfoPopup(icon, item);
         });
-        icon.addEventListener('mouseleave', hideInfoPopup);
+        icon.addEventListener('mouseleave', () => {
+            setTimeout(() => {
+                if (!currentProductPopup?.matches(':hover')) hideInfoPopup();
+            }, 100);
+        });
     });
     if (window.feather) feather.replace();
 }


### PR DESCRIPTION
## Summary
- keep product and raw material info pop-ups visible until cursor leaves both icon and card
- ensure pop-up closes properly when cursor leaves the card

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689df931394c8322bcc357605c517c05