### PR TITLE
Handle duplicate items when registering in edit products modal

### DIFF
--- a/src/js/modals/produto-proxima-etapa.js
+++ b/src/js/modals/produto-proxima-etapa.js
@@ -203,14 +203,14 @@
   });
 
   // registrar/transferir
-  if (registrarBtn) registrarBtn.addEventListener('click',()=>{
+  if (registrarBtn) registrarBtn.addEventListener('click', async ()=>{
     if(!itens.length){
       showToast('Nada para registrar', 'error');
       return;
     }
     if(window.produtoEditarAPI && typeof window.produtoEditarAPI.adicionarProcessoItens==='function'){
       const novos = itens.map(it=>({ ...it }));
-      window.produtoEditarAPI.adicionarProcessoItens(novos);
+      await window.produtoEditarAPI.adicionarProcessoItens(novos);
     }
     closeOverlay();
   });


### PR DESCRIPTION
## Summary
- warn about duplicate items when adding them in edit product flow
- prompt user to sum, replace, or keep existing items
- ensure registration waits for decisions before closing modal

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689dfbb65ff483229b2080660e7d495d