### PR TITLE
Fix Table Pop Ups Not Appearing

### DIFF
--- a/src/js/materia-prima.js
+++ b/src/js/materia-prima.js
@@ -69,7 +69,7 @@ function initMateriaPrima() {
 
 async function carregarMateriais() {
     try {
-        const lista = await window.electronAPI.listarMateriaPrima('');
+        const lista = await (window.electronAPI?.listarMateriaPrima?.('') ?? []);
         todosMateriais = lista;
         popularFiltros(lista);
         aplicarFiltros();
@@ -281,7 +281,7 @@ function showInfoPopup(target, item) {
 
     popup.style.left = `${left + window.scrollX}px`;
     popup.style.top = `${top + window.scrollY}px`;
-    window.electronAPI.log(`showInfoPopup left=${left} top=${top} id=${item.id}`);
+    window.electronAPI?.log?.(`showInfoPopup left=${left} top=${top} id=${item.id}`);
     popup.addEventListener('mouseleave', hideInfoPopup);
     currentRawMaterialPopup = popup;
 }
@@ -291,7 +291,7 @@ function hideInfoPopup() {
         currentRawMaterialPopup.remove();
         currentRawMaterialPopup = null;
     }
-    window.electronAPI.log('hideInfoPopup');
+    window.electronAPI?.log?.('hideInfoPopup');
 }
 
 window.hideRawMaterialInfoPopup = hideInfoPopup;
@@ -299,7 +299,7 @@ window.hideRawMaterialInfoPopup = hideInfoPopup;
 function attachInfoEvents() {
     document.querySelectorAll('#materiaPrimaTableBody .info-icon').forEach(icon => {
         const id = parseInt(icon.dataset.id);
-        window.electronAPI.log(`attachInfoEvents icon=${id}`);
+        window.electronAPI?.log?.(`attachInfoEvents icon=${id}`);
         icon.addEventListener('mouseenter', () => {
             const item = materiais.find(m => m.id === id);
             if (item) showInfoPopup(icon, item);

--- a/src/js/produtos.js
+++ b/src/js/produtos.js
@@ -43,7 +43,7 @@ window.showToast = window.showToast || showToast;
 
 async function carregarProdutos() {
     try {
-        listaProdutos = await window.electronAPI.listarProdutos();
+        listaProdutos = await (window.electronAPI?.listarProdutos?.() ?? []);
         popularFiltros();
         aplicarFiltro(true);
     } catch (err) {
@@ -313,7 +313,7 @@ function showInfoPopup(target, item) {
 
     popup.style.left = `${left + window.scrollX}px`;
     popup.style.top = `${top + window.scrollY}px`;
-    window.electronAPI.log(`showInfoPopup left=${left} top=${top} id=${item.id}`);
+    window.electronAPI?.log?.(`showInfoPopup left=${left} top=${top} id=${item.id}`);
     popup.addEventListener('mouseleave', hideInfoPopup);
     currentProductPopup = popup;
 }
@@ -323,7 +323,7 @@ function hideInfoPopup() {
         currentProductPopup.remove();
         currentProductPopup = null;
     }
-    window.electronAPI.log('hideInfoPopup');
+    window.electronAPI?.log?.('hideInfoPopup');
 }
 
 window.hideProductInfoPopup = hideInfoPopup;
@@ -331,7 +331,7 @@ window.hideProductInfoPopup = hideInfoPopup;
 function attachInfoEvents() {
     document.querySelectorAll('#produtosTableBody .info-icon').forEach(icon => {
         const id = parseInt(icon.dataset.id);
-        window.electronAPI.log(`attachInfoEvents icon=${id}`);
+        window.electronAPI?.log?.(`attachInfoEvents icon=${id}`);
         icon.addEventListener('mouseenter', () => {
             const item = produtosRenderizados.find(p => p.id === id);
             if (item) showInfoPopup(icon, item);


### PR DESCRIPTION
## Summary
- add guards around window.electronAPI usage so missing APIs no longer block product and raw material pop-ups

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e188a3a208322aefd510deaf42491