### PR TITLE
Corrigir Fundo Transparente nas Mensagens de Ação de Produtos

### DIFF
--- a/src/css/produtos.css
+++ b/src/css/produtos.css
@@ -135,6 +135,19 @@ body {
 @keyframes modalFade { from { opacity:0; } to { opacity:1; } }
 @keyframes slideIn { from { transform: translateY(16px); opacity:0; } to { transform: translateY(0); opacity:1; } }
 
+/* Toast notifications */
+.toast {
+    color: white;
+    padding: 0.5rem 1rem;
+    border-radius: 0.25rem;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    transition: opacity 0.5s ease-in-out;
+    background-color: #374151;
+}
+.toast-success { background-color: #16a34a; }
+.toast-error { background-color: #dc2626; }
+.toast-info { background-color: #2563eb; }
+
 /* Status badges */
 .badge-success {
     background: rgba(162, 255, 166, 0.2);


### PR DESCRIPTION
## Summary
- Adicionar estilos de toast ao módulo de produtos para garantir fundo nas mensagens de sucesso e erro

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689e19bc53c083228eaa3f9c9b3cb826