### PR TITLE
Fix Table Pop-Ups Not Appearing

### DIFF
--- a/src/js/materia-prima.js
+++ b/src/js/materia-prima.js
@@ -281,7 +281,7 @@ function showInfoPopup(target, item) {
 
     popup.style.left = `${left + window.scrollX}px`;
     popup.style.top = `${top + window.scrollY}px`;
-    window.electronAPI.log(`showInfoPopup left=${left} top=${top} id=${item.id}`);
+    window.electronAPI?.log(`showInfoPopup left=${left} top=${top} id=${item.id}`);
     popup.addEventListener('mouseleave', hideInfoPopup);
     currentRawMaterialPopup = popup;
 }
@@ -291,7 +291,7 @@ function hideInfoPopup() {
         currentRawMaterialPopup.remove();
         currentRawMaterialPopup = null;
     }
-    window.electronAPI.log('hideInfoPopup');
+    window.electronAPI?.log('hideInfoPopup');
 }
 
 window.hideRawMaterialInfoPopup = hideInfoPopup;
@@ -299,7 +299,7 @@ window.hideRawMaterialInfoPopup = hideInfoPopup;
 function attachInfoEvents() {
     document.querySelectorAll('#materiaPrimaTableBody .info-icon').forEach(icon => {
         const id = parseInt(icon.dataset.id);
-        window.electronAPI.log(`attachInfoEvents icon=${id}`);
+        window.electronAPI?.log(`attachInfoEvents icon=${id}`);
         icon.addEventListener('mouseenter', () => {
             const item = materiais.find(m => m.id === id);
             if (item) showInfoPopup(icon, item);

--- a/src/js/produtos.js
+++ b/src/js/produtos.js
@@ -313,7 +313,7 @@ function showInfoPopup(target, item) {
 
     popup.style.left = `${left + window.scrollX}px`;
     popup.style.top = `${top + window.scrollY}px`;
-    window.electronAPI.log(`showInfoPopup left=${left} top=${top} id=${item.id}`);
+    window.electronAPI?.log(`showInfoPopup left=${left} top=${top} id=${item.id}`);
     popup.addEventListener('mouseleave', hideInfoPopup);
     currentProductPopup = popup;
 }
@@ -323,7 +323,7 @@ function hideInfoPopup() {
         currentProductPopup.remove();
         currentProductPopup = null;
     }
-    window.electronAPI.log('hideInfoPopup');
+    window.electronAPI?.log('hideInfoPopup');
 }
 
 window.hideProductInfoPopup = hideInfoPopup;
@@ -331,7 +331,7 @@ window.hideProductInfoPopup = hideInfoPopup;
 function attachInfoEvents() {
     document.querySelectorAll('#produtosTableBody .info-icon').forEach(icon => {
         const id = parseInt(icon.dataset.id);
-        window.electronAPI.log(`attachInfoEvents icon=${id}`);
+        window.electronAPI?.log(`attachInfoEvents icon=${id}`);
         icon.addEventListener('mouseenter', () => {
             const item = produtosRenderizados.find(p => p.id === id);
             if (item) showInfoPopup(icon, item);

--- a/src/utils/modal.js
+++ b/src/utils/modal.js
@@ -73,6 +73,9 @@ const ModalManager = (() => {
     if (window.hideRawMaterialInfoPopup) {
       window.hideRawMaterialInfoPopup();
     }
+    if (window.hideProductInfoPopup) {
+      window.hideProductInfoPopup();
+    }
   }
 
   return { open, close, closeAll };
@@ -97,6 +100,9 @@ function closeAllModals() {
   document.body.classList.remove('overflow-hidden');
   if (window.hideRawMaterialInfoPopup) {
     window.hideRawMaterialInfoPopup();
+  }
+  if (window.hideProductInfoPopup) {
+    window.hideProductInfoPopup();
   }
 }
 


### PR DESCRIPTION
## Summary
- Guard popup debug logging with optional chaining so missing Electron APIs no longer break popup event wiring.
- Ensure global modal closure hides both product and raw material info popups.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e188a3a208322aefd510deaf42491