### PR TITLE
Fix Insumo Modal Alignment And Data Loading

### DIFF
--- a/src/html/modals/materia-prima/editar.html
+++ b/src/html/modals/materia-prima/editar.html
@@ -11,9 +11,9 @@
       </div>
       <div>
         <label for="categoria" class="block text-sm font-medium text-gray-300 mb-2">Categoria</label>
-        <div class="relative">
-          <select id="categoria" name="categoria" required class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white pr-10 focus:border-primary focus:ring-2 focus:ring-primary/50 transition"></select>
-          <button type="button" id="addCategoriaEditar" class="absolute right-3 top-1/2 -translate-y-1/2 text-gray-300 hover:text-white"><i class="fas fa-plus"></i></button>
+        <div class="flex items-center gap-2">
+          <select id="categoria" name="categoria" required class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition"></select>
+          <button type="button" id="addCategoriaEditar" class="btn-neutral icon-only text-gray-300 hover:text-white"><i class="fas fa-plus"></i></button>
         </div>
       </div>
       <div class="relative">
@@ -22,9 +22,9 @@
       </div>
       <div>
         <label for="unidade" class="block text-sm font-medium text-gray-300 mb-2">Unidade</label>
-        <div class="relative">
-          <select id="unidade" name="unidade" required class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white pr-10 focus:border-primary focus:ring-2 focus:ring-primary/50 transition"></select>
-          <button type="button" id="addUnidadeEditar" class="absolute right-3 top-1/2 -translate-y-1/2 text-gray-300 hover:text-white"><i class="fas fa-plus"></i></button>
+        <div class="flex items-center gap-2">
+          <select id="unidade" name="unidade" required class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition"></select>
+          <button type="button" id="addUnidadeEditar" class="btn-neutral icon-only text-gray-300 hover:text-white"><i class="fas fa-plus"></i></button>
         </div>
       </div>
       <div class="relative">

--- a/src/html/modals/materia-prima/novo.html
+++ b/src/html/modals/materia-prima/novo.html
@@ -11,9 +11,9 @@
       </div>
       <div>
         <label for="categoria" class="block text-sm font-medium text-gray-300 mb-2">Categoria</label>
-        <div class="relative">
-          <select id="categoria" name="categoria" required class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white pr-10 focus:border-primary focus:ring-2 focus:ring-primary/50 transition"></select>
-          <button type="button" id="addCategoriaNovo" class="absolute right-3 top-1/2 -translate-y-1/2 text-gray-300 hover:text-white"><i class="fas fa-plus"></i></button>
+        <div class="flex items-center gap-2">
+          <select id="categoria" name="categoria" required class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition"></select>
+          <button type="button" id="addCategoriaNovo" class="btn-neutral icon-only text-gray-300 hover:text-white"><i class="fas fa-plus"></i></button>
         </div>
       </div>
       <div class="relative">
@@ -22,9 +22,9 @@
       </div>
       <div>
         <label for="unidade" class="block text-sm font-medium text-gray-300 mb-2">Unidade</label>
-        <div class="relative">
-          <select id="unidade" name="unidade" required class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white pr-10 focus:border-primary focus:ring-2 focus:ring-primary/50 transition"></select>
-          <button type="button" id="addUnidadeNovo" class="absolute right-3 top-1/2 -translate-y-1/2 text-gray-300 hover:text-white"><i class="fas fa-plus"></i></button>
+        <div class="flex items-center gap-2">
+          <select id="unidade" name="unidade" required class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition"></select>
+          <button type="button" id="addUnidadeNovo" class="btn-neutral icon-only text-gray-300 hover:text-white"><i class="fas fa-plus"></i></button>
         </div>
       </div>
       <div class="relative">

--- a/src/js/modals/materia-prima-editar.js
+++ b/src/js/modals/materia-prima-editar.js
@@ -21,9 +21,17 @@
   async function carregarOpcoes(){
     try{
       const categorias = await window.electronAPI.listarCategorias();
-      form.categoria.innerHTML = '<option value="">Selecione</option>' + categorias.map(c => `<option value="${c}">${c}</option>`).join('');
+      form.categoria.innerHTML = '<option value="">Selecione</option>' +
+        categorias.map(c => {
+          const nome = c?.nome_categoria ?? c;
+          return `<option value="${nome}">${nome}</option>`;
+        }).join('');
       const unidades = await window.electronAPI.listarUnidades();
-      form.unidade.innerHTML = '<option value="">Selecione</option>' + unidades.map(u => `<option value="${u}">${u}</option>`).join('');
+      form.unidade.innerHTML = '<option value="">Selecione</option>' +
+        unidades.map(u => {
+          const tipo = u?.tipo ?? u;
+          return `<option value="${tipo}">${tipo}</option>`;
+        }).join('');
       if(item){
         form.categoria.value = item.categoria || '';
         form.unidade.value = item.unidade || '';

--- a/src/js/modals/materia-prima-novo.js
+++ b/src/js/modals/materia-prima-novo.js
@@ -12,9 +12,17 @@
   async function carregarOpcoes(){
     try{
       const categorias = await window.electronAPI.listarCategorias();
-      form.categoria.innerHTML = '<option value="">Selecione</option>' + categorias.map(c => `<option value="${c}">${c}</option>`).join('');
+      form.categoria.innerHTML = '<option value="">Selecione</option>' +
+        categorias.map(c => {
+          const nome = c?.nome_categoria ?? c;
+          return `<option value="${nome}">${nome}</option>`;
+        }).join('');
       const unidades = await window.electronAPI.listarUnidades();
-      form.unidade.innerHTML = '<option value="">Selecione</option>' + unidades.map(u => `<option value="${u}">${u}</option>`).join('');
+      form.unidade.innerHTML = '<option value="">Selecione</option>' +
+        unidades.map(u => {
+          const tipo = u?.tipo ?? u;
+          return `<option value="${tipo}">${tipo}</option>`;
+        }).join('');
     }catch(err){
       console.error('Erro ao carregar opções', err);
     }


### PR DESCRIPTION
## Summary
- adjust layout of category and unit selectors and move add buttons after the inputs
- load category and unit options from database columns when opening the modals

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689e1f076ee0832288f8de7d806c2e44