### PR TITLE
Renomear Funcoes De Info Popup Em Materia Prima E Produtos

### DIFF
--- a/src/js/materia-prima.js
+++ b/src/js/materia-prima.js
@@ -25,7 +25,7 @@ function showToast(message, type = 'info') {
     }, 3000);
 }
 
-window.showToast = showToast;
+window.showToast = window.showToast || showToast;
 
 // Inicializa animações e eventos
 function initMateriaPrima() {
@@ -249,8 +249,8 @@ function createPopupContent(item) {
     </div>`;
 }
 
-function showInfoPopup(target, item) {
-    hideInfoPopup();
+function showRawMaterialInfoPopup(target, item) {
+    hideRawMaterialInfoPopup();
     const popup = document.createElement('div');
     popup.className = 'absolute z-50';
     popup.style.position = 'absolute';
@@ -281,32 +281,34 @@ function showInfoPopup(target, item) {
 
     popup.style.left = `${left + window.scrollX}px`;
     popup.style.top = `${top + window.scrollY}px`;
-    window.electronAPI?.log?.(`showInfoPopup left=${left} top=${top} id=${item.id}`);
-    popup.addEventListener('mouseleave', hideInfoPopup);
+    window.electronAPI?.log?.(`showRawMaterialInfoPopup left=${left} top=${top} id=${item.id}`);
+    popup.addEventListener('mouseleave', hideRawMaterialInfoPopup);
     currentRawMaterialPopup = popup;
 }
 
-function hideInfoPopup() {
+function hideRawMaterialInfoPopup() {
     if (currentRawMaterialPopup) {
         currentRawMaterialPopup.remove();
         currentRawMaterialPopup = null;
     }
-    window.electronAPI?.log?.('hideInfoPopup');
+    window.electronAPI?.log?.('hideRawMaterialInfoPopup');
 }
 
-window.hideRawMaterialInfoPopup = hideInfoPopup;
+window.showRawMaterialInfoPopup = showRawMaterialInfoPopup;
+window.hideRawMaterialInfoPopup = hideRawMaterialInfoPopup;
+window.attachRawMaterialInfoEvents = attachRawMaterialInfoEvents;
 
-function attachInfoEvents() {
+function attachRawMaterialInfoEvents() {
     document.querySelectorAll('#materiaPrimaTableBody .info-icon').forEach(icon => {
         const id = parseInt(icon.dataset.id);
-        window.electronAPI?.log?.(`attachInfoEvents icon=${id}`);
+        window.electronAPI?.log?.(`attachRawMaterialInfoEvents icon=${id}`);
         icon.addEventListener('mouseenter', () => {
             const item = materiais.find(m => m.id === id);
-            if (item) showInfoPopup(icon, item);
+            if (item) showRawMaterialInfoPopup(icon, item);
         });
         icon.addEventListener('mouseleave', () => {
             setTimeout(() => {
-                if (!currentRawMaterialPopup?.matches(':hover')) hideInfoPopup();
+                if (!currentRawMaterialPopup?.matches(':hover')) hideRawMaterialInfoPopup();
             }, 100);
         });
     });
@@ -375,7 +377,7 @@ function renderMateriais(listaMateriais) {
         if (delBtn) delBtn.addEventListener('click', e => { e.stopPropagation(); abrirExcluirInsumo(item); });
     });
 
-    attachInfoEvents();
+    attachRawMaterialInfoEvents();
 }
 
 function abrirNovoInsumo() {

--- a/src/js/produtos.js
+++ b/src/js/produtos.js
@@ -106,7 +106,7 @@ function renderProdutos(produtos) {
         });
     }
 
-    attachInfoEvents();
+    attachProductInfoEvents();
 }
 
 function popularFiltros() {
@@ -281,8 +281,8 @@ function createPopupContent(item) {
     </div>`;
 }
 
-function showInfoPopup(target, item) {
-    hideInfoPopup();
+function showProductInfoPopup(target, item) {
+    hideProductInfoPopup();
     const popup = document.createElement('div');
     popup.className = 'absolute z-50';
     popup.style.position = 'absolute';
@@ -313,32 +313,34 @@ function showInfoPopup(target, item) {
 
     popup.style.left = `${left + window.scrollX}px`;
     popup.style.top = `${top + window.scrollY}px`;
-    window.electronAPI?.log?.(`showInfoPopup left=${left} top=${top} id=${item.id}`);
-    popup.addEventListener('mouseleave', hideInfoPopup);
+    window.electronAPI?.log?.(`showProductInfoPopup left=${left} top=${top} id=${item.id}`);
+    popup.addEventListener('mouseleave', hideProductInfoPopup);
     currentProductPopup = popup;
 }
 
-function hideInfoPopup() {
+function hideProductInfoPopup() {
     if (currentProductPopup) {
         currentProductPopup.remove();
         currentProductPopup = null;
     }
-    window.electronAPI?.log?.('hideInfoPopup');
+    window.electronAPI?.log?.('hideProductInfoPopup');
 }
 
-window.hideProductInfoPopup = hideInfoPopup;
+window.showProductInfoPopup = showProductInfoPopup;
+window.hideProductInfoPopup = hideProductInfoPopup;
+window.attachProductInfoEvents = attachProductInfoEvents;
 
-function attachInfoEvents() {
+function attachProductInfoEvents() {
     document.querySelectorAll('#produtosTableBody .info-icon').forEach(icon => {
         const id = parseInt(icon.dataset.id);
-        window.electronAPI?.log?.(`attachInfoEvents icon=${id}`);
+        window.electronAPI?.log?.(`attachProductInfoEvents icon=${id}`);
         icon.addEventListener('mouseenter', () => {
             const item = produtosRenderizados.find(p => p.id === id);
-            if (item) showInfoPopup(icon, item);
+            if (item) showProductInfoPopup(icon, item);
         });
         icon.addEventListener('mouseleave', () => {
             setTimeout(() => {
-                if (!currentProductPopup?.matches(':hover')) hideInfoPopup();
+                if (!currentProductPopup?.matches(':hover')) hideProductInfoPopup();
             }, 100);
         });
     });


### PR DESCRIPTION
## Summary
- rename info popup helpers in matéria-prima module and expose them under unique window names
- rename info popup helpers in produtos module with unique window exports to avoid conflicts

## Testing
- `npm test`
- `node - <<'NODE' ... NODE`

------
https://chatgpt.com/codex/tasks/task_e_689e2250ae1c8322b223d32b34698ef6