### PR TITLE
Enable Popup For Alphanumeric IDs - via Codex

### DIFF
--- a/src/js/materia-prima.js
+++ b/src/js/materia-prima.js
@@ -298,10 +298,10 @@ window.hideRawMaterialInfoPopup = hideInfoPopup;
 
 function attachInfoEvents() {
     document.querySelectorAll('#materiaPrimaTableBody .info-icon').forEach(icon => {
-        const id = parseInt(icon.dataset.id);
+        const id = icon.dataset.id;
         window.electronAPI?.log?.(`attachInfoEvents icon=${id}`);
         icon.addEventListener('mouseenter', () => {
-            const item = materiais.find(m => m.id === id);
+            const item = materiais.find(m => String(m.id) === id);
             if (item) showInfoPopup(icon, item);
         });
         icon.addEventListener('mouseleave', () => {

--- a/src/js/produtos.js
+++ b/src/js/produtos.js
@@ -330,10 +330,10 @@ window.hideProductInfoPopup = hideInfoPopup;
 
 function attachInfoEvents() {
     document.querySelectorAll('#produtosTableBody .info-icon').forEach(icon => {
-        const id = parseInt(icon.dataset.id);
+        const id = icon.dataset.id;
         window.electronAPI?.log?.(`attachInfoEvents icon=${id}`);
         icon.addEventListener('mouseenter', () => {
-            const item = produtosRenderizados.find(p => p.id === id);
+            const item = produtosRenderizados.find(p => String(p.id) === id);
             if (item) showInfoPopup(icon, item);
         });
         icon.addEventListener('mouseleave', () => {


### PR DESCRIPTION
## Summary
- support string-based IDs when showing product info popups
- allow raw material info popups to handle alphanumeric IDs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e226a9b3483228c6ab32b92d72d34