### PR TITLE
Implement delegated hover handlers for info popups

### DIFF
--- a/src/js/materia-prima.js
+++ b/src/js/materia-prima.js
@@ -44,6 +44,10 @@ function initMateriaPrima() {
     document.getElementById('zeroStock')?.addEventListener('change', aplicarFiltros);
     document.getElementById('btnNovoInsumo')?.addEventListener('click', abrirNovoInsumo);
 
+    materiaPrimaTableBody = document.getElementById('materiaPrimaTableBody');
+    materiaPrimaTableBody?.addEventListener('mouseover', handleInfoMouseOver);
+    materiaPrimaTableBody?.addEventListener('mouseout', handleInfoMouseOut);
+
     const infoIcon = document.getElementById('totaisInfoIcon');
     const popover = document.getElementById('totaisPopover');
     if (infoIcon && popover) {
@@ -186,6 +190,7 @@ function formatDate(dateStr) {
 // Controle de popup de informações da matéria prima
 let materiais = [];
 let currentRawMaterialPopup = null;
+let materiaPrimaTableBody;
 
 function extractCor(nome, cor) {
     return (cor || (nome && nome.split('/')[1]) || '').trim();
@@ -296,21 +301,22 @@ function hideInfoPopup() {
 
 window.hideRawMaterialInfoPopup = hideInfoPopup;
 
-function attachInfoEvents() {
-    document.querySelectorAll('#materiaPrimaTableBody .info-icon').forEach(icon => {
-        const id = parseInt(icon.dataset.id);
-        window.electronAPI?.log?.(`attachInfoEvents icon=${id}`);
-        icon.addEventListener('mouseenter', () => {
-            const item = materiais.find(m => m.id === id);
-            if (item) showInfoPopup(icon, item);
-        });
-        icon.addEventListener('mouseleave', () => {
-            setTimeout(() => {
-                if (!currentRawMaterialPopup?.matches(':hover')) hideInfoPopup();
-            }, 100);
-        });
-    });
-    if (window.feather) feather.replace();
+function handleInfoMouseOver(e) {
+    const icon = e.target.closest('.info-icon');
+    if (!icon || !materiaPrimaTableBody?.contains(icon)) return;
+    if (e.relatedTarget && icon.contains(e.relatedTarget)) return;
+    const id = parseInt(icon.dataset.id);
+    const item = materiais.find(m => m.id === id);
+    if (item) showInfoPopup(icon, item);
+}
+
+function handleInfoMouseOut(e) {
+    const icon = e.target.closest('.info-icon');
+    if (!icon || !materiaPrimaTableBody?.contains(icon)) return;
+    if (e.relatedTarget && icon.contains(e.relatedTarget)) return;
+    setTimeout(() => {
+        if (!currentRawMaterialPopup?.matches(':hover')) hideInfoPopup();
+    }, 100);
 }
 
 function renderMateriais(listaMateriais) {
@@ -375,7 +381,7 @@ function renderMateriais(listaMateriais) {
         if (delBtn) delBtn.addEventListener('click', e => { e.stopPropagation(); abrirExcluirInsumo(item); });
     });
 
-    attachInfoEvents();
+    if (window.feather) feather.replace();
 }
 
 function abrirNovoInsumo() {

--- a/src/js/produtos.js
+++ b/src/js/produtos.js
@@ -15,6 +15,7 @@ let filtrosPendentes = false;
 // Controle de popup de informações do produto
 let produtosRenderizados = [];
 let currentProductPopup = null;
+let produtosTableBody;
 
 function showToast(message, type = 'info') {
     if (!notificationContainer) {
@@ -106,7 +107,7 @@ function renderProdutos(produtos) {
         });
     }
 
-    attachInfoEvents();
+    if (window.feather) feather.replace();
 }
 
 function popularFiltros() {
@@ -328,21 +329,22 @@ function hideInfoPopup() {
 
 window.hideProductInfoPopup = hideInfoPopup;
 
-function attachInfoEvents() {
-    document.querySelectorAll('#produtosTableBody .info-icon').forEach(icon => {
-        const id = parseInt(icon.dataset.id);
-        window.electronAPI?.log?.(`attachInfoEvents icon=${id}`);
-        icon.addEventListener('mouseenter', () => {
-            const item = produtosRenderizados.find(p => p.id === id);
-            if (item) showInfoPopup(icon, item);
-        });
-        icon.addEventListener('mouseleave', () => {
-            setTimeout(() => {
-                if (!currentProductPopup?.matches(':hover')) hideInfoPopup();
-            }, 100);
-        });
-    });
-    if (window.feather) feather.replace();
+function handleInfoMouseOver(e) {
+    const icon = e.target.closest('.info-icon');
+    if (!icon || !produtosTableBody?.contains(icon)) return;
+    if (e.relatedTarget && icon.contains(e.relatedTarget)) return;
+    const id = parseInt(icon.dataset.id);
+    const item = produtosRenderizados.find(p => p.id === id);
+    if (item) showInfoPopup(icon, item);
+}
+
+function handleInfoMouseOut(e) {
+    const icon = e.target.closest('.info-icon');
+    if (!icon || !produtosTableBody?.contains(icon)) return;
+    if (e.relatedTarget && icon.contains(e.relatedTarget)) return;
+    setTimeout(() => {
+        if (!currentProductPopup?.matches(':hover')) hideInfoPopup();
+    }, 100);
 }
 
 function initProdutos() {
@@ -370,6 +372,10 @@ function initProdutos() {
     document.getElementById('filterPriceMin')?.addEventListener('input', marcarFiltrosPendentes);
     document.getElementById('filterPriceMax')?.addEventListener('input', marcarFiltrosPendentes);
     document.getElementById('zeroStock')?.addEventListener('change', () => aplicarFiltro(true));
+
+    produtosTableBody = document.getElementById('produtosTableBody');
+    produtosTableBody?.addEventListener('mouseover', handleInfoMouseOver);
+    produtosTableBody?.addEventListener('mouseout', handleInfoMouseOut);
 
     carregarProdutos();
 


### PR DESCRIPTION
## Summary
- delegate product info hover events to the table body using `event.target.closest('.info-icon')`
- apply the same delegated hover logic to raw material tables for consistent popups

## Testing
- `npm test`
- `npm start` *(fails: error while loading shared libraries: libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_689e22696a4c8322a6c18827feaa073f