### PR TITLE
Handle Falsy IDs In AttachInfoEvents

### DIFF
--- a/src/js/materia-prima.js
+++ b/src/js/materia-prima.js
@@ -300,10 +300,14 @@ window.attachRawMaterialInfoEvents = attachRawMaterialInfoEvents;
 
 function attachRawMaterialInfoEvents() {
     document.querySelectorAll('#materiaPrimaTableBody .info-icon').forEach(icon => {
-        const id = parseInt(icon.dataset.id);
+        const id = icon.dataset.id;
+        if (!id) {
+            window.electronAPI?.log?.('attachRawMaterialInfoEvents invalid id');
+            return;
+        }
         window.electronAPI?.log?.(`attachRawMaterialInfoEvents icon=${id}`);
         icon.addEventListener('mouseenter', () => {
-            const item = materiais.find(m => m.id === id);
+            const item = materiais.find(m => String(m.id) === id);
             if (item) showRawMaterialInfoPopup(icon, item);
         });
         icon.addEventListener('mouseleave', () => {

--- a/src/js/produtos.js
+++ b/src/js/produtos.js
@@ -332,10 +332,14 @@ window.attachProductInfoEvents = attachProductInfoEvents;
 
 function attachProductInfoEvents() {
     document.querySelectorAll('#produtosTableBody .info-icon').forEach(icon => {
-        const id = parseInt(icon.dataset.id);
+        const id = icon.dataset.id;
+        if (!id) {
+            window.electronAPI?.log?.('attachProductInfoEvents invalid id');
+            return;
+        }
         window.electronAPI?.log?.(`attachProductInfoEvents icon=${id}`);
         icon.addEventListener('mouseenter', () => {
-            const item = produtosRenderizados.find(p => p.id === id);
+            const item = produtosRenderizados.find(p => String(p.id) === id);
             if (item) showProductInfoPopup(icon, item);
         });
         icon.addEventListener('mouseleave', () => {


### PR DESCRIPTION
## Summary
- Replace `parseInt` with direct dataset ID access in product and raw material info handlers
- Add early return with debug log when icon ID is missing
- Compare IDs using strings to avoid type mismatches

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689e27a91eec8322887302cb777cc1f0