### PR TITLE
Adicionar modais para unidades e categoria

### DIFF
--- a/backend/materiaPrima.js
+++ b/backend/materiaPrima.js
@@ -127,6 +127,22 @@ async function listarUnidades() {
   return res.rows.map(r => r.tipo);
 }
 
+async function adicionarCategoria(nome) {
+  const res = await pool.query(
+    'INSERT INTO categoria (nome_categoria) VALUES ($1) RETURNING nome_categoria',
+    [nome]
+  );
+  return res.rows[0]?.nome_categoria;
+}
+
+async function adicionarUnidade(tipo) {
+  const res = await pool.query(
+    'INSERT INTO unidades (tipo) VALUES ($1) RETURNING tipo',
+    [tipo]
+  );
+  return res.rows[0]?.tipo;
+}
+
 module.exports = {
   listarMaterias,
   adicionarMateria,
@@ -136,5 +152,7 @@ module.exports = {
   registrarSaida,
   atualizarPreco,
   listarCategorias,
-  listarUnidades
+  listarUnidades,
+  adicionarCategoria,
+  adicionarUnidade
 };

--- a/main.js
+++ b/main.js
@@ -18,7 +18,9 @@ const {
   registrarSaida,
   atualizarPreco,
   listarCategorias,
-  listarUnidades
+  listarUnidades,
+  adicionarCategoria,
+  adicionarUnidade
 } = require('./backend/materiaPrima');
 const {
   listarProdutos,
@@ -375,6 +377,22 @@ ipcMain.handle('listar-unidades', async () => {
     return await listarUnidades();
   } catch (err) {
     console.error('Erro ao listar unidades:', err);
+    throw err;
+  }
+});
+ipcMain.handle('adicionar-categoria', async (_e, nome) => {
+  try {
+    return await adicionarCategoria(nome);
+  } catch (err) {
+    console.error('Erro ao adicionar categoria:', err);
+    throw err;
+  }
+});
+ipcMain.handle('adicionar-unidade', async (_e, nome) => {
+  try {
+    return await adicionarUnidade(nome);
+  } catch (err) {
+    console.error('Erro ao adicionar unidade:', err);
     throw err;
   }
 });

--- a/preload.js
+++ b/preload.js
@@ -17,6 +17,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
       console.error('listar-unidades error', err);
       return [];
     }),
+  adicionarCategoria: (nome) => ipcRenderer.invoke('adicionar-categoria', nome),
+  adicionarUnidade: (nome) => ipcRenderer.invoke('adicionar-unidade', nome),
   listarProdutos: () => ipcRenderer.invoke('listar-produtos'),
   obterProduto: (codigo) => ipcRenderer.invoke('obter-produto', codigo),
   adicionarProduto: (dados) => ipcRenderer.invoke('adicionar-produto', dados),

--- a/src/html/modals/materia-prima/categoria-novo.html
+++ b/src/html/modals/materia-prima/categoria-novo.html
@@ -1,0 +1,17 @@
+<div id="novaCategoriaOverlay" class="fixed inset-0 bg-black/50 flex items-center justify-center p-4">
+  <div class="max-w-sm w-full glass-surface backdrop-blur-xl rounded-2xl border border-white/10 ring-1 ring-white/5 shadow-2xl/40 animate-modalFade">
+    <header class="relative px-6 py-4 border-b border-white/10">
+      <h2 class="text-lg font-semibold text-center text-white">INSERIR NOVO</h2>
+      <button id="fecharNovaCategoria" class="btn-danger icon-only absolute right-4 top-4 text-white">✕</button>
+    </header>
+    <form id="novaCategoriaForm" class="p-6">
+      <div class="relative">
+        <input id="nomeCategoria" name="nome" type="text" placeholder=" " required class="peer w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-transparent focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+        <label for="nomeCategoria" class="absolute left-4 top-1/2 -translate-y-1/2 text-base text-gray-300 pointer-events-none transition-all duration-150 peer-placeholder-shown:top-1/2 peer-placeholder-shown:-translate-y-1/2 peer-placeholder-shown:text-base peer-focus:top-0 peer-focus:-translate-y-full peer-focus:text-xs peer-focus:text-primary">Nome</label>
+      </div>
+    </form>
+    <footer class="flex justify-end px-6 py-4 border-t border-white/10">
+      <button type="submit" form="novaCategoriaForm" class="btn-primary px-6 py-2 rounded-lg text-white font-medium active:scale-95">Inserir</button>
+    </footer>
+  </div>
+</div>

--- a/src/html/modals/materia-prima/unidade-novo.html
+++ b/src/html/modals/materia-prima/unidade-novo.html
@@ -1,0 +1,17 @@
+<div id="novaUnidadeOverlay" class="fixed inset-0 bg-black/50 flex items-center justify-center p-4">
+  <div class="max-w-sm w-full glass-surface backdrop-blur-xl rounded-2xl border border-white/10 ring-1 ring-white/5 shadow-2xl/40 animate-modalFade">
+    <header class="relative px-6 py-4 border-b border-white/10">
+      <h2 class="text-lg font-semibold text-center text-white">INSERIR NOVO</h2>
+      <button id="fecharNovaUnidade" class="btn-danger icon-only absolute right-4 top-4 text-white">✕</button>
+    </header>
+    <form id="novaUnidadeForm" class="p-6">
+      <div class="relative">
+        <input id="nomeUnidade" name="nome" type="text" placeholder=" " required class="peer w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-transparent focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+        <label for="nomeUnidade" class="absolute left-4 top-1/2 -translate-y-1/2 text-base text-gray-300 pointer-events-none transition-all duration-150 peer-placeholder-shown:top-1/2 peer-placeholder-shown:-translate-y-1/2 peer-placeholder-shown:text-base peer-focus:top-0 peer-focus:-translate-y-full peer-focus:text-xs peer-focus:text-primary">Nome</label>
+      </div>
+    </form>
+    <footer class="flex justify-end px-6 py-4 border-t border-white/10">
+      <button type="submit" form="novaUnidadeForm" class="btn-primary px-6 py-2 rounded-lg text-white font-medium active:scale-95">Inserir</button>
+    </footer>
+  </div>
+</div>

--- a/src/js/modals/materia-prima-categoria-novo.js
+++ b/src/js/modals/materia-prima-categoria-novo.js
@@ -1,0 +1,26 @@
+(function(){
+  const overlay = document.getElementById('novaCategoriaOverlay');
+  const close = () => Modal.close('novaCategoria');
+  overlay.addEventListener('click', e => { if (e.target === overlay) close(); });
+  document.getElementById('fecharNovaCategoria').addEventListener('click', close);
+  document.addEventListener('keydown', function esc(e){ if(e.key==='Escape'){ close(); document.removeEventListener('keydown', esc); }});
+  const form = document.getElementById('novaCategoriaForm');
+  form.addEventListener('submit', async e => {
+    e.preventDefault();
+    const nome = form.nome.value.trim();
+    if(!nome) return;
+    try{
+      await window.electronAPI.adicionarCategoria(nome);
+      showToast('Categoria adicionada com sucesso!', 'success');
+      close();
+      const categorias = await window.electronAPI.listarCategorias();
+      document.querySelectorAll('select#categoria').forEach(sel => {
+        sel.innerHTML = '<option value="">Selecione</option>' + categorias.map(c => `<option value="${c}">${c}</option>`).join('');
+        sel.value = nome;
+      });
+    }catch(err){
+      console.error(err);
+      showToast('Erro ao adicionar categoria', 'error');
+    }
+  });
+})();

--- a/src/js/modals/materia-prima-editar.js
+++ b/src/js/modals/materia-prima-editar.js
@@ -9,6 +9,13 @@
   const quantidadeInput = form.quantidade;
   const infinitoCheckbox = form.infinito;
   const item = window.materiaSelecionada;
+
+  document.getElementById('addCategoriaEditar').addEventListener('click', () => {
+    Modal.open('modals/materia-prima/categoria-novo.html', '../js/modals/materia-prima-categoria-novo.js', 'novaCategoria');
+  });
+  document.getElementById('addUnidadeEditar').addEventListener('click', () => {
+    Modal.open('modals/materia-prima/unidade-novo.html', '../js/modals/materia-prima-unidade-novo.js', 'novaUnidade');
+  });
   if(item){
     form.nome.value = item.nome || '';
     quantidadeInput.value = item.quantidade || '';

--- a/src/js/modals/materia-prima-novo.js
+++ b/src/js/modals/materia-prima-novo.js
@@ -9,6 +9,13 @@
   const quantidadeInput = form.quantidade;
   const infinitoCheckbox = form.infinito;
 
+  document.getElementById('addCategoriaNovo').addEventListener('click', () => {
+    Modal.open('modals/materia-prima/categoria-novo.html', '../js/modals/materia-prima-categoria-novo.js', 'novaCategoria');
+  });
+  document.getElementById('addUnidadeNovo').addEventListener('click', () => {
+    Modal.open('modals/materia-prima/unidade-novo.html', '../js/modals/materia-prima-unidade-novo.js', 'novaUnidade');
+  });
+
   async function carregarOpcoes(){
     try{
       const categorias = await window.electronAPI.listarCategorias();

--- a/src/js/modals/materia-prima-unidade-novo.js
+++ b/src/js/modals/materia-prima-unidade-novo.js
@@ -1,0 +1,26 @@
+(function(){
+  const overlay = document.getElementById('novaUnidadeOverlay');
+  const close = () => Modal.close('novaUnidade');
+  overlay.addEventListener('click', e => { if (e.target === overlay) close(); });
+  document.getElementById('fecharNovaUnidade').addEventListener('click', close);
+  document.addEventListener('keydown', function esc(e){ if(e.key==='Escape'){ close(); document.removeEventListener('keydown', esc); }});
+  const form = document.getElementById('novaUnidadeForm');
+  form.addEventListener('submit', async e => {
+    e.preventDefault();
+    const nome = form.nome.value.trim();
+    if(!nome) return;
+    try{
+      await window.electronAPI.adicionarUnidade(nome);
+      showToast('Unidade adicionada com sucesso!', 'success');
+      close();
+      const unidades = await window.electronAPI.listarUnidades();
+      document.querySelectorAll('select#unidade').forEach(sel => {
+        sel.innerHTML = '<option value="">Selecione</option>' + unidades.map(u => `<option value="${u}">${u}</option>`).join('');
+        sel.value = nome;
+      });
+    }catch(err){
+      console.error(err);
+      showToast('Erro ao adicionar unidade', 'error');
+    }
+  });
+})();


### PR DESCRIPTION
## Summary
- Support creating units and categories with new backend methods and IPC channels
- Add “INSERIR NOVO” modals for categoria and unidade with simple name field and Inserir button
- Hook plus buttons on matéria-prima forms to open the new modals and refresh select options

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e30e638888322ab99754017d039fe