### PR TITLE
Fix raw material info popup display

### DIFF
--- a/src/js/materia-prima.js
+++ b/src/js/materia-prima.js
@@ -159,6 +159,8 @@ function formatDate(dateStr) {
 
 // Controle de popup de informações da matéria prima
 let materiais = [];
+// Mapa auxiliar para lookup rápido pelo id
+let materiaisMap = new Map();
 let currentRawMaterialPopup = null;
 let rawMaterialInfoEventsBound = false;
 
@@ -258,7 +260,7 @@ function attachRawMaterialInfoEvents() {
             return;
         }
         window.electronAPI?.log?.(`attachRawMaterialInfoEvents icon=${id}`);
-        const item = materiais.find(m => String(m.id) === id);
+        const item = materiaisMap.get(id);
         if (item) showRawMaterialInfoPopup(icon, item);
     });
 
@@ -273,6 +275,7 @@ function attachRawMaterialInfoEvents() {
 
 function renderMateriais(listaMateriais) {
     materiais = listaMateriais;
+    materiaisMap = new Map(listaMateriais.map(m => [String(m.id), m]));
     const tbody = document.getElementById('materiaPrimaTableBody');
     if (!tbody) return;
     tbody.innerHTML = '';


### PR DESCRIPTION
## Summary
- use in-memory map to locate material by id when hovering info icon

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e394c275c8322946ba2f22474bda3