### PR TITLE
Fix raw material table popover

### DIFF
--- a/src/html/materia-prima.html
+++ b/src/html/materia-prima.html
@@ -77,6 +77,8 @@
             <div id="processTags" class="flex flex-wrap gap-2"></div>
         </div>
 
+        <div id="materiaInfoPopover" class="resumo-popover glass-surface rounded-xl p-4 text-white"></div>
+
         <!-- Materials Table -->
         <div class="glass-surface rounded-xl shadow-lg animate-fade-in-up table-scroll">
                  <table class="w-full">

--- a/src/js/materia-prima.js
+++ b/src/js/materia-prima.js
@@ -38,6 +38,9 @@ function initMateriaPrima() {
         popover.addEventListener('mouseleave', ocultar);
     }
 
+    materiaInfoPopover = document.getElementById('materiaInfoPopover');
+    materiaInfoPopover?.addEventListener('mouseleave', hideRawMaterialInfoPopup);
+
     carregarMateriais();
 }
 
@@ -161,7 +164,7 @@ function formatDate(dateStr) {
 let materiais = [];
 // Mapa auxiliar para lookup rápido pelo id
 let materiaisMap = new Map();
-let currentRawMaterialPopup = null;
+let materiaInfoPopover = null;
 
 function extractCor(nome, cor) {
     return (cor || (nome && nome.split('/')[1]) || '').trim();
@@ -226,16 +229,19 @@ function createPopupContent(item) {
 }
 
 function showRawMaterialInfoPopup(target, item) {
-    hideRawMaterialInfoPopup();
-    const { popup, left, top } = createPopup(target, createPopupContent(item), { onHide: hideRawMaterialInfoPopup });
-    window.electronAPI?.log?.(`showRawMaterialInfoPopup left=${left} top=${top} id=${item.id}`);
-    currentRawMaterialPopup = popup;
+    if (!materiaInfoPopover) return;
+    materiaInfoPopover.innerHTML = createPopupContent(item);
+    materiaInfoPopover.classList.add('show');
+    const rect = target.getBoundingClientRect();
+    const popRect = materiaInfoPopover.getBoundingClientRect();
+    materiaInfoPopover.style.left = `${rect.left + rect.width / 2 - popRect.width / 2}px`;
+    materiaInfoPopover.style.top = `${rect.top - popRect.height - 4}px`;
+    window.electronAPI?.log?.(`showRawMaterialInfoPopup left=${materiaInfoPopover.style.left} top=${materiaInfoPopover.style.top} id=${item.id}`);
 }
 
 function hideRawMaterialInfoPopup() {
-    if (currentRawMaterialPopup) {
-        currentRawMaterialPopup.remove();
-        currentRawMaterialPopup = null;
+    if (materiaInfoPopover) {
+        materiaInfoPopover.classList.remove('show');
     }
     window.electronAPI?.log?.('hideRawMaterialInfoPopup');
 }
@@ -265,7 +271,7 @@ function attachRawMaterialInfoEvents() {
 
         icon.addEventListener('mouseleave', () => {
             setTimeout(() => {
-                if (!currentRawMaterialPopup?.matches(':hover')) hideRawMaterialInfoPopup();
+                if (!materiaInfoPopover?.matches(':hover')) hideRawMaterialInfoPopup();
             }, 100);
         });
     });


### PR DESCRIPTION
## Summary
- adapt raw material table popover to use static totals-style popup
- add static popover container in HTML for raw material info

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689e4374a7c48322b059887348e8be60