### PR TITLE
Add secondary popup for Materia Prima name column

### DIFF
--- a/src/css/materia-prima.css
+++ b/src/css/materia-prima.css
@@ -173,6 +173,31 @@ body {
     transition: all 150ms ease;
 }
 
+.test-icon {
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    background: rgba(255, 255, 255, 0.1);
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 12px;
+    color: #fff;
+    cursor: pointer;
+    transition: all 150ms ease;
+}
+
+.test-icon::after {
+    content: 't';
+    font-weight: bold;
+}
+
+.test-icon:hover {
+    background: rgba(255, 255, 255, 0.445);
+    transform: scale(1.1);
+}
+
 .info-icon::after {
     content: 'i';
     font-style: italic;

--- a/src/js/materia-prima.js
+++ b/src/js/materia-prima.js
@@ -162,6 +162,7 @@ let materiais = [];
 // Mapa auxiliar para lookup rápido pelo id
 let materiaisMap = new Map();
 let currentRawMaterialPopup = null;
+let currentRawMaterialTestPopup = null;
 
 function extractCor(nome, cor) {
     return (cor || (nome && nome.split('/')[1]) || '').trim();
@@ -271,6 +272,43 @@ function attachRawMaterialInfoEvents() {
     });
 }
 
+function showRawMaterialTestPopup(target) {
+    hideRawMaterialTestPopup();
+    const { popup } = createPopup(target, `<div class="resumo-popover bg-gray-800 text-white text-xs rounded-lg p-2 shadow-lg">teste</div>`, { onHide: hideRawMaterialTestPopup });
+    currentRawMaterialTestPopup = popup;
+}
+
+function hideRawMaterialTestPopup() {
+    if (currentRawMaterialTestPopup) {
+        currentRawMaterialTestPopup.remove();
+        currentRawMaterialTestPopup = null;
+    }
+}
+
+function attachRawMaterialTestEvents() {
+    const tbody = document.getElementById('materiaPrimaTableBody');
+    if (!tbody) return;
+
+    tbody.querySelectorAll('.test-icon').forEach(icon => {
+        if (icon.dataset.bound) return;
+        icon.dataset.bound = 'true';
+
+        icon.addEventListener('click', () => {
+            showRawMaterialTestPopup(icon);
+        });
+
+        icon.addEventListener('mouseleave', () => {
+            setTimeout(() => {
+                if (!currentRawMaterialTestPopup?.matches(':hover')) hideRawMaterialTestPopup();
+            }, 100);
+        });
+    });
+}
+
+window.showRawMaterialTestPopup = showRawMaterialTestPopup;
+window.hideRawMaterialTestPopup = hideRawMaterialTestPopup;
+window.attachRawMaterialTestEvents = attachRawMaterialTestEvents;
+
 function renderMateriais(listaMateriais) {
     materiais = listaMateriais;
     materiaisMap = new Map(listaMateriais.map(m => [String(m.id), m]));
@@ -321,6 +359,7 @@ function renderMateriais(listaMateriais) {
                 <div class="flex items-center">
                     <span class="text-sm text-white">${item.nome}</span>
                     <i class="info-icon ml-2" data-id="${item.id}"></i>
+                    <i class="test-icon ml-2" data-id="${item.id}"></i>
                 </div>
             </td>
             <td class="px-6 py-4 whitespace-nowrap text-sm text-white">${quantidadeValor}</td>
@@ -336,6 +375,7 @@ function renderMateriais(listaMateriais) {
 
     if (window.feather) feather.replace();
     attachRawMaterialInfoEvents();
+    attachRawMaterialTestEvents();
 }
 
 function abrirNovoInsumo() {


### PR DESCRIPTION
## Summary
- show new test popup in raw materials name column
- style and attach handlers for new test icon

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689e46d6b6108322a5a02f849bc58334