### PR TITLE
Use Database Categories In Filter Dropdowns

### DIFF
--- a/src/js/materia-prima.js
+++ b/src/js/materia-prima.js
@@ -45,7 +45,7 @@ async function carregarMateriais() {
     try {
         const lista = await (window.electronAPI?.listarMateriaPrima?.('') ?? []);
         todosMateriais = lista;
-        popularFiltros(lista);
+        await popularFiltros(lista);
         aplicarFiltros();
     } catch (err) {
         console.error('Erro ao carregar materiais', err);
@@ -54,7 +54,7 @@ async function carregarMateriais() {
 
 window.carregarMateriais = carregarMateriais;
 
-function popularFiltros(lista) {
+async function popularFiltros(lista) {
     const procSel = document.getElementById('filtroProcesso');
     const catSel = document.getElementById('filtroCategoria');
 
@@ -65,9 +65,16 @@ function popularFiltros(lista) {
     }
 
     if (catSel) {
-        const categorias = [...new Set(lista.map(m => m.categoria).filter(Boolean))].sort();
-        catSel.innerHTML = '<option value="">Todas</option>' +
-            categorias.map(c => `<option value="${c}">${c}</option>`).join('');
+        try {
+            const categorias = await (window.electronAPI?.listarCategorias?.() ?? []);
+            catSel.innerHTML = '<option value="">Todas</option>' +
+                categorias.map(c => {
+                    const nome = c?.nome_categoria ?? c;
+                    return `<option value="${nome}">${nome}</option>`;
+                }).join('');
+        } catch (err) {
+            console.error('Erro ao listar categorias', err);
+        }
     }
 }
 

--- a/src/js/produtos.js
+++ b/src/js/produtos.js
@@ -19,7 +19,7 @@ let productInfoEventsBound = false;
 async function carregarProdutos() {
     try {
         listaProdutos = await (window.electronAPI?.listarProdutos?.() ?? []);
-        popularFiltros();
+        await popularFiltros();
         aplicarFiltro(true);
     } catch (err) {
         console.error('Erro ao carregar produtos', err);
@@ -85,14 +85,23 @@ function renderProdutos(produtos) {
     attachProductInfoEvents();
 }
 
-function popularFiltros() {
+async function popularFiltros() {
     const categoriaSelect = document.getElementById('filterCategory');
     const statusSelect = document.getElementById('filterStatus');
+
     if (categoriaSelect) {
-        const categorias = [...new Set(listaProdutos.map(p => p.categoria).filter(Boolean))];
-        categoriaSelect.innerHTML = '<option value="">Todas as Categorias</option>' +
-            categorias.map(c => `<option value="${c}">${c}</option>`).join('');
+        try {
+            const categorias = await (window.electronAPI?.listarCategorias?.() ?? []);
+            categoriaSelect.innerHTML = '<option value="">Todas as Categorias</option>' +
+                categorias.map(c => {
+                    const nome = c?.nome_categoria ?? c;
+                    return `<option value="${nome}">${nome}</option>`;
+                }).join('');
+        } catch (err) {
+            console.error('Erro ao listar categorias', err);
+        }
     }
+
     if (statusSelect) {
         const status = [...new Set(listaProdutos.map(p => p.status).filter(Boolean))];
         statusSelect.innerHTML = '<option value="">Todos</option>' +


### PR DESCRIPTION
## Summary
- Fetch category options for raw material filter directly from database
- Populate product category filters from the categoria table

## Testing
- ⚠️ `npm test` (fails: Cannot find module '/workspace/App-Gestao/backend')

------
https://chatgpt.com/codex/tasks/task_e_689e4888be8c83228604237edc30b255