### PR TITLE
Load categories for raw material filter from database

### DIFF
--- a/src/js/materia-prima.js
+++ b/src/js/materia-prima.js
@@ -45,7 +45,7 @@ async function carregarMateriais() {
     try {
         const lista = await (window.electronAPI?.listarMateriaPrima?.('') ?? []);
         todosMateriais = lista;
-        popularFiltros(lista);
+        await popularFiltros(lista);
         aplicarFiltros();
     } catch (err) {
         console.error('Erro ao carregar materiais', err);
@@ -54,7 +54,7 @@ async function carregarMateriais() {
 
 window.carregarMateriais = carregarMateriais;
 
-function popularFiltros(lista) {
+async function popularFiltros(lista) {
     const procSel = document.getElementById('filtroProcesso');
     const catSel = document.getElementById('filtroCategoria');
 
@@ -65,7 +65,12 @@ function popularFiltros(lista) {
     }
 
     if (catSel) {
-        const categorias = [...new Set(lista.map(m => m.categoria).filter(Boolean))].sort();
+        let categorias = [];
+        try {
+            categorias = await (window.electronAPI?.listarCategorias?.() ?? []);
+        } catch (e) {
+            console.error('Erro ao carregar categorias', e);
+        }
         catSel.innerHTML = '<option value="">Todas</option>' +
             categorias.map(c => `<option value="${c}">${c}</option>`).join('');
     }


### PR DESCRIPTION
## Summary
- Populate raw material category filter using categories fetched directly from the `categoria` table

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689e4995f4948322a678ffd6d4172f40