### PR TITLE
Check Existing Category And Unit In Modals

### DIFF
--- a/src/js/modals/materia-prima-categoria-novo.js
+++ b/src/js/modals/materia-prima-categoria-novo.js
@@ -10,6 +10,12 @@
     const nome = form.nome.value.trim();
     if(!nome) return;
     try{
+      const existentes = await window.electronAPI.listarCategorias();
+      if(existentes.map(c => (c.nome_categoria ?? c).toLowerCase()).includes(nome.toLowerCase())){
+        showToast('Categoria já cadastrada!', 'warning');
+        close();
+        return;
+      }
       await window.electronAPI.adicionarCategoria(nome);
       showToast('Categoria adicionada com sucesso!', 'success');
       close();

--- a/src/js/modals/materia-prima-unidade-novo.js
+++ b/src/js/modals/materia-prima-unidade-novo.js
@@ -10,6 +10,12 @@
     const nome = form.nome.value.trim();
     if(!nome) return;
     try{
+      const existentes = await window.electronAPI.listarUnidades();
+      if(existentes.map(u => u.toLowerCase()).includes(nome.toLowerCase())){
+        showToast('Unidade já cadastrada!', 'warning');
+        close();
+        return;
+      }
       await window.electronAPI.adicionarUnidade(nome);
       showToast('Unidade adicionada com sucesso!', 'success');
       close();


### PR DESCRIPTION
## Summary
- prevent adding duplicate unidades in new unit modal with warning toast
- block duplicate categorias in new category modal and close on notice

## Testing
- `npm test` *(fails: Cannot find module '/workspace/App-Gestao/backend')*
- `node --test backend/*.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689e4aa668688322909be00b5fa567b0