### PR TITLE
Enable Info Popup On Click For Materia Prima

### DIFF
--- a/src/js/materia-prima.js
+++ b/src/js/materia-prima.js
@@ -258,7 +258,7 @@ function attachRawMaterialInfoEvents() {
         if (icon.dataset.bound) return;
         icon.dataset.bound = 'true';
 
-        icon.addEventListener('mouseenter', () => {
+        icon.addEventListener('click', () => {
             const id = icon.dataset.id;
             if (!id) {
                 window.electronAPI?.log?.('attachRawMaterialInfoEvents invalid id');


### PR DESCRIPTION
## Summary
- Trigger raw material info popup on click, mirroring test popup behavior

## Testing
- `npm test` *(fails: Cannot find module '/workspace/App-Gestao/backend')*

------
https://chatgpt.com/codex/tasks/task_e_689f16805ff48322bae99e93e82fd164