### PR TITLE
Remover 'selecione' das caixas de seleção de insumo

### DIFF
--- a/src/js/modals/materia-prima-categoria-novo.js
+++ b/src/js/modals/materia-prima-categoria-novo.js
@@ -21,7 +21,7 @@
       close();
       const categorias = await window.electronAPI.listarCategorias();
       document.querySelectorAll('select#categoria').forEach(sel => {
-        sel.innerHTML = '<option value="">Selecione</option>' + categorias.map(c => `<option value="${c}">${c}</option>`).join('');
+        sel.innerHTML = '<option value=""></option>' + categorias.map(c => `<option value="${c}">${c}</option>`).join('');
         sel.value = nome;
       });
     }catch(err){

--- a/src/js/modals/materia-prima-editar.js
+++ b/src/js/modals/materia-prima-editar.js
@@ -28,13 +28,13 @@
   async function carregarOpcoes(){
     try{
       const categorias = await window.electronAPI.listarCategorias();
-      form.categoria.innerHTML = '<option value="">Selecione</option>' +
+      form.categoria.innerHTML = '<option value=""></option>' +
         categorias.map(c => {
           const nome = c?.nome_categoria ?? c;
           return `<option value="${nome}">${nome}</option>`;
         }).join('');
       const unidades = await window.electronAPI.listarUnidades();
-      form.unidade.innerHTML = '<option value="">Selecione</option>' +
+      form.unidade.innerHTML = '<option value=""></option>' +
         unidades.map(u => {
           const tipo = u?.tipo ?? u;
           return `<option value="${tipo}">${tipo}</option>`;

--- a/src/js/modals/materia-prima-novo.js
+++ b/src/js/modals/materia-prima-novo.js
@@ -19,13 +19,13 @@
   async function carregarOpcoes(){
     try{
       const categorias = await window.electronAPI.listarCategorias();
-      form.categoria.innerHTML = '<option value="">Selecione</option>' +
+      form.categoria.innerHTML = '<option value=""></option>' +
         categorias.map(c => {
           const nome = c?.nome_categoria ?? c;
           return `<option value="${nome}">${nome}</option>`;
         }).join('');
       const unidades = await window.electronAPI.listarUnidades();
-      form.unidade.innerHTML = '<option value="">Selecione</option>' +
+      form.unidade.innerHTML = '<option value=""></option>' +
         unidades.map(u => {
           const tipo = u?.tipo ?? u;
           return `<option value="${tipo}">${tipo}</option>`;

--- a/src/js/modals/materia-prima-unidade-novo.js
+++ b/src/js/modals/materia-prima-unidade-novo.js
@@ -21,7 +21,7 @@
       close();
       const unidades = await window.electronAPI.listarUnidades();
       document.querySelectorAll('select#unidade').forEach(sel => {
-        sel.innerHTML = '<option value="">Selecione</option>' + unidades.map(u => `<option value="${u}">${u}</option>`).join('');
+        sel.innerHTML = '<option value=""></option>' + unidades.map(u => `<option value="${u}">${u}</option>`).join('');
         sel.value = nome;
       });
     }catch(err){


### PR DESCRIPTION
## Summary
- remove placeholder 'Selecione' from category and unit selects when creating insumo
- remove placeholder 'Selecione' from category and unit selects when editing insumo
- ensure dynamically added category and unit lists omit placeholder

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f16f55b408322a0d8e068b55fdf59