### PR TITLE
Add Processo Dropdown To Insumo Forms

### DIFF
--- a/backend/produtos.js
+++ b/backend/produtos.js
@@ -140,9 +140,17 @@ async function listarInsumosProduto(codigo) {
  */
 async function listarEtapasProducao() {
   const res = await pool.query(
-    'SELECT id, nome FROM etapas_producao ORDER BY nome ASC'
+    'SELECT id, nome FROM etapas_producao ORDER BY id'
   );
   return res.rows;
+}
+
+async function adicionarEtapaProducao(nome) {
+  const res = await pool.query(
+    'INSERT INTO etapas_producao (nome) VALUES ($1) RETURNING id, nome',
+    [nome]
+  );
+  return res.rows[0];
 }
 
 /**
@@ -341,6 +349,7 @@ module.exports = {
   listarInsumosProduto,
   listarEtapasProducao,
   listarItensProcessoProduto,
+  adicionarEtapaProducao,
   adicionarProduto,
   atualizarProduto,
   excluirProduto,

--- a/main.js
+++ b/main.js
@@ -31,6 +31,7 @@ const {
   listarDetalhesProduto,
   listarInsumosProduto,
   listarEtapasProducao,
+  adicionarEtapaProducao,
   listarItensProcessoProduto,
   inserirLoteProduto,
   atualizarLoteProduto,
@@ -441,6 +442,9 @@ ipcMain.handle('listar-insumos-produto', async (_e, codigo) => {
 });
 ipcMain.handle('listar-etapas-producao', async () => {
   return listarEtapasProducao();
+});
+ipcMain.handle('adicionar-etapa-producao', async (_e, nome) => {
+  return adicionarEtapaProducao(nome);
 });
 ipcMain.handle('listar-itens-processo-produto', async (_e, { codigo, etapa, busca }) => {
   return listarItensProcessoProduto(codigo, etapa, busca);

--- a/preload.js
+++ b/preload.js
@@ -30,6 +30,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   excluirLoteProduto: (id) => ipcRenderer.invoke('excluir-lote-produto', id),
   listarInsumosProduto: (codigo) => ipcRenderer.invoke('listar-insumos-produto', codigo),
   listarEtapasProducao: () => ipcRenderer.invoke('listar-etapas-producao'),
+  adicionarEtapaProducao: (nome) => ipcRenderer.invoke('adicionar-etapa-producao', nome),
   listarItensProcessoProduto: (codigo, etapa, busca) =>
     ipcRenderer.invoke('listar-itens-processo-produto', { codigo, etapa, busca }),
   salvarProdutoDetalhado: (codigo, produto, itens) =>

--- a/src/html/modals/materia-prima/editar.html
+++ b/src/html/modals/materia-prima/editar.html
@@ -93,18 +93,26 @@
         </label>
       </div>
 
-      <!-- Processo (floating) -->
+      <!-- Processo (floating + botão + embutido) -->
       <div class="relative">
-        <input id="processo" name="processo" type="text" placeholder=" " required
-               class="peer w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-transparent focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+        <select id="processo" name="processo" required
+                class="peer w-full appearance-none bg-input border border-inputBorder rounded-lg px-4 pr-12 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition"
+                data-filled="false">
+          <option value="" disabled selected hidden></option>
+          <!-- opções existentes são preenchidas pelo seu JS -->
+        </select>
         <label for="processo"
                class="absolute left-4 top-1/2 -translate-y-1/2 text-base text-gray-300 pointer-events-none transition-all duration-150
-                      peer-placeholder-shown:top-1/2 peer-placeholder-shown:-translate-y-1/2 peer-placeholder-shown:text-base
                       peer-focus:top-0 peer-focus:-translate-y-full peer-focus:text-xs peer-focus:text-primary
-                      peer-valid:top-0 peer-valid:-translate-y-full peer-valid:text-xs
+                      peer-data-[filled=true]:top-0 peer-data-[filled=true]:-translate-y-full peer-data-[filled=true]:text-xs
                       peer-disabled:top-0 peer-disabled:-translate-y-full peer-disabled:text-xs">
           Processo
         </label>
+        <button type="button" id="addProcessoEditar"
+                class="absolute right-2 top-1/2 -translate-y-1/2 btn-neutral icon-only text-gray-300 hover:text-white"
+                aria-label="Adicionar processo">
+          <i class="fas fa-plus"></i>
+        </button>
       </div>
 
       <!-- Estoque Infinito -->
@@ -139,7 +147,7 @@
     <script>
       (function () {
         const setFilled = el => el && el.setAttribute('data-filled', String(!!el.value));
-        ['categoria','unidade'].forEach(id => {
+        ['categoria','unidade','processo'].forEach(id => {
           const el = document.getElementById(id);
           if (!el) return;
           setFilled(el);

--- a/src/html/modals/materia-prima/novo.html
+++ b/src/html/modals/materia-prima/novo.html
@@ -91,17 +91,25 @@
         </label>
       </div>
 
-      <!-- Processo (floating) -->
+      <!-- Processo (floating em select + botão "+") -->
       <div class="relative">
-        <input id="processo" name="processo" type="text" placeholder=" " required
-               class="peer w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-transparent focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+        <select id="processo" name="processo" required
+                class="peer w-full appearance-none bg-input border border-inputBorder rounded-lg px-4 pr-12 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition"
+                data-filled="false">
+          <option value="" disabled selected hidden></option>
+          <!-- opções populadas pelo seu JS -->
+        </select>
         <label for="processo"
                class="absolute left-4 top-1/2 -translate-y-1/2 text-base text-gray-300 pointer-events-none transition-all duration-150
-                      peer-placeholder-shown:top-1/2 peer-placeholder-shown:-translate-y-1/2 peer-placeholder-shown:text-base
                       peer-focus:top-0 peer-focus:-translate-y-full peer-focus:text-xs peer-focus:text-primary
-                      peer-valid:top-0 peer-valid:-translate-y-full peer-valid:text-xs">
+                      peer-data-[filled=true]:top-0 peer-data-[filled=true]:-translate-y-full peer-data-[filled=true]:text-xs">
           Processo
         </label>
+        <button type="button" id="addProcessoNovo"
+                class="absolute right-2 top-1/2 -translate-y-1/2 btn-neutral icon-only text-gray-300 hover:text-white"
+                aria-label="Adicionar processo">
+          <i class="fas fa-plus"></i>
+        </button>
       </div>
 
       <!-- Estoque infinito -->

--- a/src/html/modals/materia-prima/processo-novo.html
+++ b/src/html/modals/materia-prima/processo-novo.html
@@ -1,0 +1,17 @@
+<div id="novoProcessoOverlay" class="fixed inset-0 bg-black/50 flex items-center justify-center p-4">
+  <div class="max-w-sm w-full glass-surface backdrop-blur-xl rounded-2xl border border-white/10 ring-1 ring-white/5 shadow-2xl/40 animate-modalFade">
+    <header class="relative px-6 py-4 border-b border-white/10">
+      <h2 class="text-lg font-semibold text-center text-white">INSERIR NOVO</h2>
+      <button id="fecharNovoProcesso" class="btn-danger icon-only absolute right-4 top-4 text-white">✕</button>
+    </header>
+    <form id="novoProcessoForm" class="p-6">
+      <div class="relative">
+        <input id="nomeProcesso" name="nome" type="text" placeholder=" " required class="peer w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-transparent focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+        <label for="nomeProcesso" class="absolute left-4 top-1/2 -translate-y-1/2 text-base text-gray-300 pointer-events-none transition-all duration-150 peer-placeholder-shown:top-1/2 peer-placeholder-shown:-translate-y-1/2 peer-placeholder-shown:text-base peer-focus:top-0 peer-focus:-translate-y-full peer-focus:text-xs peer-focus:text-primary">Nome</label>
+      </div>
+    </form>
+    <footer class="flex justify-end px-6 py-4 border-t border-white/10">
+      <button type="submit" form="novoProcessoForm" class="btn-primary px-6 py-2 rounded-lg text-white font-medium active:scale-95">Inserir</button>
+    </footer>
+  </div>
+</div>

--- a/src/js/modals/materia-prima-editar.js
+++ b/src/js/modals/materia-prima-editar.js
@@ -16,6 +16,9 @@
   document.getElementById('addUnidadeEditar').addEventListener('click', () => {
     Modal.open('modals/materia-prima/unidade-novo.html', '../js/modals/materia-prima-unidade-novo.js', 'novaUnidade', true);
   });
+  document.getElementById('addProcessoEditar').addEventListener('click', () => {
+    Modal.open('modals/materia-prima/processo-novo.html', '../js/modals/materia-prima-processo-novo.js', 'novoProcesso', true);
+  });
   if(item){
     form.nome.value = item.nome || '';
     quantidadeInput.value = item.quantidade || '';
@@ -39,11 +42,18 @@
           const tipo = u?.tipo ?? u;
           return `<option value="${tipo}">${tipo}</option>`;
         }).join('');
+      const processos = await window.electronAPI.listarEtapasProducao();
+      form.processo.innerHTML = '<option value=""></option>' +
+        processos.map(p => {
+          const nome = p?.nome ?? p;
+          return `<option value="${nome}">${nome}</option>`;
+        }).join('');
       if(item){
         form.categoria.value = item.categoria || '';
         form.unidade.value = item.unidade || '';
+        form.processo.value = item.processo || '';
       }
-      ['categoria','unidade'].forEach(id=>{
+      ['categoria','unidade','processo'].forEach(id=>{
         const el=form[id];
         if(el) el.setAttribute('data-filled', el.value !== '');
       });

--- a/src/js/modals/materia-prima-novo.js
+++ b/src/js/modals/materia-prima-novo.js
@@ -15,6 +15,9 @@
   document.getElementById('addUnidadeNovo').addEventListener('click', () => {
     Modal.open('modals/materia-prima/unidade-novo.html', '../js/modals/materia-prima-unidade-novo.js', 'novaUnidade', true);
   });
+  document.getElementById('addProcessoNovo').addEventListener('click', () => {
+    Modal.open('modals/materia-prima/processo-novo.html', '../js/modals/materia-prima-processo-novo.js', 'novoProcesso', true);
+  });
 
   async function carregarOpcoes(){
     try{
@@ -30,7 +33,13 @@
           const tipo = u?.tipo ?? u;
           return `<option value="${tipo}">${tipo}</option>`;
         }).join('');
-      ['categoria','unidade'].forEach(id=>{
+      const processos = await window.electronAPI.listarEtapasProducao();
+      form.processo.innerHTML = '<option value=""></option>' +
+        processos.map(p => {
+          const nome = p?.nome ?? p;
+          return `<option value="${nome}">${nome}</option>`;
+        }).join('');
+      ['categoria','unidade','processo'].forEach(id=>{
         const el=form[id];
         if(!el) return;
         const sync = () => el.setAttribute('data-filled', el.value !== '');

--- a/src/js/modals/materia-prima-processo-novo.js
+++ b/src/js/modals/materia-prima-processo-novo.js
@@ -1,0 +1,33 @@
+(function(){
+  const overlay = document.getElementById('novoProcessoOverlay');
+  const close = () => Modal.close('novoProcesso');
+  overlay.addEventListener('click', e => { if (e.target === overlay) close(); });
+  document.getElementById('fecharNovoProcesso').addEventListener('click', close);
+  document.addEventListener('keydown', function esc(e){ if(e.key==='Escape'){ close(); document.removeEventListener('keydown', esc); }});
+  const form = document.getElementById('novoProcessoForm');
+  form.addEventListener('submit', async e => {
+    e.preventDefault();
+    const nome = form.nome.value.trim();
+    if(!nome) return;
+    try{
+      const existentes = await window.electronAPI.listarEtapasProducao();
+      if(existentes.map(p => (p.nome ?? p).toLowerCase()).includes(nome.toLowerCase())){
+        showToast('Processo já cadastrado!', 'warning');
+        close();
+        return;
+      }
+      await window.electronAPI.adicionarEtapaProducao(nome);
+      showToast('Processo adicionado com sucesso!', 'success');
+      close();
+      const processos = await window.electronAPI.listarEtapasProducao();
+      document.querySelectorAll('select#processo').forEach(sel => {
+        sel.innerHTML = '<option value=""></option>' + processos.map(p => `<option value="${p.nome}">${p.nome}</option>`).join('');
+        sel.value = nome;
+        sel.setAttribute('data-filled', 'true');
+      });
+    }catch(err){
+      console.error(err);
+      showToast('Erro ao adicionar processo', 'error');
+    }
+  });
+})();


### PR DESCRIPTION
## Summary
- Populate processo dropdowns in new and edit insumo modals from etapas_producao, respecting database order
- Add backend and IPC support to list and create processos
- Introduce modal for adding novos processos with automatic select refresh

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f194eec548322832ef347098d015b