### PR TITLE
Lazy Load ColorParser In ResolveColorCss

### DIFF
--- a/src/utils/colors.js
+++ b/src/utils/colors.js
@@ -1,5 +1,3 @@
-const { getColorFromText } = require('./colorParser');
-
 /**
  * Resolve uma cor textual para seu equivalente hexadecimal.
  * Mantém assinatura pública utilizada pela UI.
@@ -7,6 +5,7 @@ const { getColorFromText } = require('./colorParser');
  * @returns {string}
  */
 function resolveColorCss(cor = '') {
+  const { getColorFromText } = require('./colorParser');
   return getColorFromText((cor.split('/')[1] || cor).trim());
 }
 


### PR DESCRIPTION
## Summary
- defer loading colorParser until resolveColorCss runs to avoid unnecessary module loading

## Testing
- `node manual-tests/resolveColorCss.js`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f34b72fa08322bb289ef8f17d9af0