### PR TITLE
Remove nearest-color dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "cors": "^2.8.5",
         "dotenv": "^17.0.1",
         "express": "^5.1.0",
-        "nearest-color": "^0.4.4",
         "nodemailer": "^7.0.5",
         "pg": "^8.16.0"
       },
@@ -3859,12 +3858,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-    },
-    "node_modules/nearest-color": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/nearest-color/-/nearest-color-0.4.4.tgz",
-      "integrity": "sha512-orhcaIORC10tf41Ld2wwlcC+FaAavHG87JHWB3eHH5p7v2k9Tzym2XNEZzLAm5YJwGv6Q38WWc7SOb+Qfu/4NQ==",
-      "license": "MIT"
     },
     "node_modules/nearley": {
       "version": "2.20.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "cors": "^2.8.5",
     "dotenv": "^17.0.1",
     "express": "^5.1.0",
-    "nearest-color": "^0.4.4",
     "nodemailer": "^7.0.5",
     "pg": "^8.16.0"
   },


### PR DESCRIPTION
## Summary
- remove unused nearest-color dependency

## Testing
- `npm install`
- `npm run dist`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f3b22d6508322a7c7c8e92767913f