### PR TITLE
Corrige erro ao inserir etapa de produção

### DIFF
--- a/backend/produtos.js
+++ b/backend/produtos.js
@@ -152,8 +152,16 @@ async function listarEtapasProducao() {
  * Se nenhuma ordem for informada, a etapa é adicionada ao final.
  */
 async function adicionarEtapaProducao(nome, ordem) {
-  // Se ordem não for fornecida, calcula a próxima ordem disponível
-  if (ordem === undefined || ordem === null || isNaN(ordem)) {
+  // Permite chamada com um único objeto: adicionarEtapaProducao({ nome, ordem })
+  if (typeof nome === 'object' && nome !== null) {
+    ({ nome, ordem } = nome);
+  }
+
+  // Garante que 'ordem' seja um número válido
+  ordem = Number(ordem);
+
+  // Se ordem não for fornecida ou inválida, calcula a próxima ordem disponível
+  if (!Number.isInteger(ordem) || ordem <= 0) {
     const { rows } = await pool.query(
       'SELECT COALESCE(MAX(ordem), 0) + 1 AS prox'
     );

--- a/main.js
+++ b/main.js
@@ -444,8 +444,7 @@ ipcMain.handle('listar-etapas-producao', async () => {
   return listarEtapasProducao();
 });
 ipcMain.handle('adicionar-etapa-producao', async (_e, dados) => {
-  const { nome, ordem } = dados || {};
-  return adicionarEtapaProducao(nome, ordem);
+  return adicionarEtapaProducao(dados);
 });
 ipcMain.handle('listar-itens-processo-produto', async (_e, { codigo, etapa, busca }) => {
   return listarItensProcessoProduto(codigo, etapa, busca);


### PR DESCRIPTION
## Summary
- permite adicionar etapa de produção com objeto completo
- repassa dados diretamente do handler IPC

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f3af738488322a821e952aebd7125