### PR TITLE
Ordenar itens e selects de processos conforme etapas

### DIFF
--- a/src/js/modals/materia-prima-editar.js
+++ b/src/js/modals/materia-prima-editar.js
@@ -43,6 +43,7 @@
           return `<option value="${tipo}">${tipo}</option>`;
         }).join('');
       const processos = await window.electronAPI.listarEtapasProducao();
+      processos.sort((a,b) => (a.ordem ?? 0) - (b.ordem ?? 0));
       form.processo.innerHTML = '<option value=""></option>' +
         processos.map(p => {
           const nome = p?.nome ?? p;

--- a/src/js/modals/materia-prima-novo.js
+++ b/src/js/modals/materia-prima-novo.js
@@ -34,6 +34,7 @@
           return `<option value="${tipo}">${tipo}</option>`;
         }).join('');
       const processos = await window.electronAPI.listarEtapasProducao();
+      processos.sort((a,b) => (a.ordem ?? 0) - (b.ordem ?? 0));
       form.processo.innerHTML = '<option value=""></option>' +
         processos.map(p => {
           const nome = p?.nome ?? p;

--- a/src/js/modals/materia-prima-processo-novo.js
+++ b/src/js/modals/materia-prima-processo-novo.js
@@ -26,6 +26,7 @@
       showToast('Processo adicionado com sucesso!', 'success');
       close();
       const processos = await window.electronAPI.listarEtapasProducao();
+      processos.sort((a,b) => (a.ordem ?? 0) - (b.ordem ?? 0));
       document.querySelectorAll('select#processo').forEach(sel => {
         const options = processos
           .map(p => {

--- a/src/js/modals/materia-prima-processo-ordem.js
+++ b/src/js/modals/materia-prima-processo-ordem.js
@@ -6,6 +6,7 @@
 
   async function atualizarSelects(nome){
     const processos = await window.electronAPI.listarEtapasProducao();
+    processos.sort((a,b) => (a.ordem ?? 0) - (b.ordem ?? 0));
     document.querySelectorAll('select#processo').forEach(sel => {
       const options = processos.map(p => {
         const n = p?.nome ?? p;

--- a/src/js/modals/produto-editar.js
+++ b/src/js/modals/produto-editar.js
@@ -148,6 +148,7 @@
     const processos = {};
     const totals = {};
     const processOrder = [];
+    let etapasOrdem = [];
 
     // cálculo por processo
     function updateProcessTotal(proc){
@@ -297,7 +298,16 @@
         grupos[procKey].push(it);
       });
 
-      Object.entries(grupos).forEach(([proc, arr]) => {
+      const ordenados = Object.entries(grupos).sort(([a], [b]) => {
+        const ia = etapasOrdem.indexOf(a);
+        const ib = etapasOrdem.indexOf(b);
+        if (ia === -1 && ib === -1) return a.localeCompare(b);
+        if (ia === -1) return 1;
+        if (ib === -1) return -1;
+        return ia - ib;
+      });
+
+      ordenados.forEach(([proc, arr]) => {
         const header = document.createElement('tr');
         header.className = 'process-row';
         header.innerHTML = `<td colspan="5" class="px-6 py-2 bg-gray-50 border-t border-gray-200 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">${proc}</td>`;
@@ -483,8 +493,10 @@
         l('>> listarEtapasProducao: start');
         const etapas = await window.electronAPI.listarEtapasProducao();
         l('<< listarEtapasProducao: ok', { etapasCount: Array.isArray(etapas) ? etapas.length : 'N/A' });
+        const etapasOrdenadas = (etapas || []).sort((a,b) => (a.ordem ?? 0) - (b.ordem ?? 0));
+        etapasOrdem = etapasOrdenadas.map(e => e.nome);
         if (etapaSelect) {
-          etapaSelect.innerHTML = (etapas || []).map(e => `<option value="${e.id}">${e.nome}</option>`).join('');
+          etapaSelect.innerHTML = etapasOrdenadas.map(e => `<option value="${e.id}">${e.nome}</option>`).join('');
         }
 
         // Render itens

--- a/src/js/modals/produto-estoque-inserir.js
+++ b/src/js/modals/produto-estoque-inserir.js
@@ -22,6 +22,7 @@
   async function carregarProcessos(){ // carga de processos
     try{
       const processos = await window.electronAPI.listarEtapasProducao();
+      processos.sort((a,b) => (a.ordem ?? 0) - (b.ordem ?? 0));
       processoSelect.innerHTML = '<option value="">Selecione um processo…</option>' +
         processos.map(p => `<option value="${p.nome}" data-id="${p.id}">${p.nome}</option>`).join('');
     }catch(err){


### PR DESCRIPTION
## Summary
- respeita a ordem das etapas ao renderizar itens do produto
- ordena seletores que exibem processos segundo sua sequência definida

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f3c1cd40083229f3a007d6ebb4808