### PR TITLE
Corrigir sobreposição do título no modal de inserir processo

### DIFF
--- a/src/html/modals/materia-prima/processo-novo.html
+++ b/src/html/modals/materia-prima/processo-novo.html
@@ -7,11 +7,11 @@
     <form id="novoProcessoForm" class="p-6">
       <div class="relative">
         <input id="nomeProcesso" name="nome" type="text" placeholder=" " required class="peer w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-transparent focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
-        <label for="nomeProcesso" class="absolute left-4 top-1/2 -translate-y-1/2 text-base text-gray-300 pointer-events-none transition-all duration-150 peer-placeholder-shown:top-1/2 peer-placeholder-shown:-translate-y-1/2 peer-placeholder-shown:text-base peer-focus:top-0 peer-focus:-translate-y-full peer-focus:text-xs peer-focus:text-primary">Nome</label>
+          <label for="nomeProcesso" class="absolute left-4 top-1/2 -translate-y-1/2 text-base text-gray-300 pointer-events-none transition-all duration-150 peer-placeholder-shown:top-1/2 peer-placeholder-shown:-translate-y-1/2 peer-placeholder-shown:text-base peer-focus:top-0 peer-focus:-translate-y-full peer-focus:text-xs peer-focus:text-primary peer-valid:top-0 peer-valid:-translate-y-full peer-valid:text-xs">Nome</label>
       </div>
       <div class="relative mt-4 w-24">
         <input id="ordemProcesso" name="ordem" type="number" min="1" placeholder=" " required class="peer w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-transparent focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
-        <label for="ordemProcesso" class="absolute left-4 top-1/2 -translate-y-1/2 text-base text-gray-300 pointer-events-none transition-all duration-150 peer-placeholder-shown:top-1/2 peer-placeholder-shown:-translate-y-1/2 peer-placeholder-shown:text-base peer-focus:top-0 peer-focus:-translate-y-full peer-focus:text-xs peer-focus:text-primary">Ordem</label>
+          <label for="ordemProcesso" class="absolute left-4 top-1/2 -translate-y-1/2 text-base text-gray-300 pointer-events-none transition-all duration-150 peer-placeholder-shown:top-1/2 peer-placeholder-shown:-translate-y-1/2 peer-placeholder-shown:text-base peer-focus:top-0 peer-focus:-translate-y-full peer-focus:text-xs peer-focus:text-primary peer-valid:top-0 peer-valid:-translate-y-full peer-valid:text-xs">Ordem</label>
       </div>
     </form>
     <footer class="flex justify-end px-6 py-4 border-t border-white/10">


### PR DESCRIPTION
## Summary
- manter rótulos acima ao preencher campos no modal de novo processo

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f3dafcffc8322bf35107b0caf6a11