### PR TITLE
Add Info Icons To Duplicate Order Dialog

### DIFF
--- a/src/html/modals/materia-prima/processo-ordem.html
+++ b/src/html/modals/materia-prima/processo-ordem.html
@@ -1,15 +1,21 @@
 <div id="ordemDuplicadaOverlay" class="fixed inset-0 bg-black/50 flex items-center justify-center p-4">
-  <div class="max-w-sm w-full bg-surface/60 backdrop-blur-xl rounded-2xl border border-yellow-500 ring-1 ring-yellow-500/50 shadow-2xl/40 animate-modalFade">
+  <div class="w-full max-w-md bg-surface/60 backdrop-blur-xl rounded-2xl border border-yellow-500 ring-1 ring-yellow-500/50 shadow-2xl/40 animate-modalFade">
     <div class="p-6 text-center">
       <h3 class="text-lg font-semibold mb-4 text-white">Ordem Duplicada</h3>
       <p class="text-sm text-gray-300">Essa ordem já pertence a um processo. Deseja troca-la?</p>
-      <div class="flex justify-center gap-4 mt-6">
-        <button id="trocarOrdem" class="btn-warning px-4 py-2 rounded-lg text-white font-medium active:scale-95">Trocar</button>
-        <button id="ultimaOrdem" class="btn-primary px-4 py-2 rounded-lg text-white font-medium active:scale-95">Ultima Ordem</button>
-        <button id="cancelarOrdem" class="btn-danger px-4 py-2 rounded-lg text-white font-medium active:scale-95">Cancelar</button>
-      </div>
-      <div class="mt-4 text-gray-300 text-xs">
-        <span class="cursor-help" title="Trocar: empurra os processos existentes para baixo.\nÚltima Ordem: adiciona o processo ao final.">i</span>
+      <div class="flex justify-center gap-6 mt-6">
+        <div class="flex items-center gap-2">
+          <button id="trocarOrdem" class="btn-warning px-4 py-2 rounded-lg text-white font-medium active:scale-95">Trocar</button>
+          <i class="info-icon" title="Trocar: empurra os processos existentes para baixo."></i>
+        </div>
+        <div class="flex items-center gap-2">
+          <button id="ultimaOrdem" class="btn-primary px-4 py-2 rounded-lg text-white font-medium active:scale-95">Última Ordem</button>
+          <i class="info-icon" title="Última Ordem: adiciona o processo ao final."></i>
+        </div>
+        <div class="flex items-center gap-2">
+          <button id="cancelarOrdem" class="btn-danger px-4 py-2 rounded-lg text-white font-medium active:scale-95">Cancelar</button>
+          <i class="info-icon" title="Cancelar: mantém a ordem existente sem alterações."></i>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- add dedicated info icons to each action button in duplicated order dialog
- expand dialog width for better content fit

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f439ca7f4832288398b43a1cdd6d7