### PR TITLE
Adapta caixa de diálogo de próxima etapa para acomodar botões

### DIFF
--- a/src/html/modals/produtos/proxima-etapa.html
+++ b/src/html/modals/produtos/proxima-etapa.html
@@ -1,8 +1,8 @@
 <div id="proximaEtapaOverlay" class="fixed inset-0 bg-black/50 flex items-center justify-center p-4">
-  <div role="dialog" aria-modal="true" tabindex="0" class="w-full max-w-4xl max-h-[90vh] bg-surface/60 backdrop-blur-xl rounded-3xl border border-white/10 ring-1 ring-white/5 shadow-2xl/40 animate-modalFade slide-in overflow-hidden flex flex-col">
-      <header class="flex items-center justify-between px-8 py-5 border-b border-white/10 flex-shrink-0">
+  <div role="dialog" aria-modal="true" tabindex="0" class="w-full max-w-7xl max-h-[90vh] bg-surface/60 backdrop-blur-xl rounded-3xl border border-white/10 ring-1 ring-white/5 shadow-2xl/40 animate-modalFade slide-in overflow-hidden flex flex-col">
+      <header class="flex flex-wrap items-center justify-between gap-4 px-8 py-5 border-b border-white/10 flex-shrink-0">
         <button id="voltarProximaEtapa" class="btn-neutral px-4 py-2 rounded-lg text-white font-medium flex items-center gap-2">← Voltar</button>
-        <h2 id="proximaEtapaTitulo" class="text-lg font-semibold text-white"></h2>
+        <h2 id="proximaEtapaTitulo" class="text-lg font-semibold text-white flex-1 text-center"></h2>
         <div class="flex items-center gap-3">
           <button id="registrarProximaEtapa" class="btn-primary px-6 py-2 rounded-lg text-white font-medium">Registrar</button>
         </div>
@@ -21,7 +21,7 @@
             <span id="proximaEtapaUnidade" class="absolute right-4 top-1/2 transform -translate-y-1/2 text-gray-300 pointer-events-none"></span>
           </div>
         </div>
-        <div class="flex gap-4">
+        <div class="flex flex-wrap gap-4">
           <button id="inserirProximaEtapa" class="btn-primary px-6 py-3 rounded-lg text-white font-medium">+ Inserir</button>
           <button id="limparProximaEtapa" class="btn-danger-light px-6 py-3 rounded-lg font-medium">Limpar Tudo</button>
         </div>


### PR DESCRIPTION
## Summary
- Allow next-step modal to expand width and wrap header elements so no buttons overflow
- Enable wrapping for action buttons inside modal to keep them inside container

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f43b5b2088322b3c39cea824c6c06