### PR TITLE
Corrigir Erro De Coluna Ordem Ausente Ao Inserir Nova Etapa De Produção

### DIFF
--- a/backend/produtos.js
+++ b/backend/produtos.js
@@ -163,7 +163,7 @@ async function adicionarEtapaProducao(nome, ordem) {
   // Se ordem não for fornecida ou inválida, calcula a próxima ordem disponível
   if (!Number.isInteger(ordem) || ordem <= 0) {
     const { rows } = await pool.query(
-      'SELECT COALESCE(MAX(ordem), 0) + 1 AS prox'
+      'SELECT COALESCE(MAX(ordem), 0) + 1 AS prox FROM etapas_producao'
     );
     ordem = rows[0].prox;
   }


### PR DESCRIPTION
## Summary
- adiciona consulta de `etapas_producao` ao calcular próxima ordem

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f4431ded88322994a8e1bba4cf40e