### PR TITLE
Fix Require Is Not Defined In Colors.js

### DIFF
--- a/src/html/menu.html
+++ b/src/html/menu.html
@@ -363,6 +363,7 @@
 
     <!-- Script de controle do menu -->
     <script src="../utils/modal.js"></script>
+    <script src="../utils/colorParser.js"></script>
     <script src="../utils/colors.js"></script>
     <script src="../js/utils/notifications.js"></script>
     <script src="../js/menu.js"></script>

--- a/src/utils/colorParser.js
+++ b/src/utils/colorParser.js
@@ -308,7 +308,7 @@ function getColorFromText(text = '') {
   return hex;
 }
 
-module.exports = {
+const colorParser = {
   normalize,
   extractModifiers,
   resolveBaseColor,
@@ -316,4 +316,10 @@ module.exports = {
   getColorFromText,
   colorDictionary,
 };
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = colorParser;
+} else if (typeof window !== 'undefined') {
+  window.colorParser = colorParser;
+}
 

--- a/src/utils/colors.js
+++ b/src/utils/colors.js
@@ -4,8 +4,17 @@
  * @param {string} cor
  * @returns {string}
  */
+let getColorFromText;
+if (typeof window !== 'undefined' && window.colorParser) {
+  getColorFromText = window.colorParser.getColorFromText;
+} else if (typeof require !== 'undefined') {
+  ({ getColorFromText } = require('./colorParser'));
+}
+
 function resolveColorCss(cor = '') {
-  const { getColorFromText } = require('./colorParser');
+  if (!getColorFromText) {
+    throw new Error('colorParser not available');
+  }
   return getColorFromText((cor.split('/')[1] || cor).trim());
 }
 
@@ -13,4 +22,6 @@ if (typeof window !== 'undefined') {
   window.resolveColorCss = resolveColorCss;
 }
 
-module.exports = { resolveColorCss };
+if (typeof module !== 'undefined') {
+  module.exports = { resolveColorCss };
+}


### PR DESCRIPTION
## Summary
- expose color parser for browser usage and attach global helper
- make color resolution utility compatible with browser and Node
- load parser before colors helper in menu

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f4541dbe083228bf523e66438c12e