### PR TITLE
Padronizar Ícones De Ordem Duplicada E Renomear Botão Última

### DIFF
--- a/src/html/modals/materia-prima/processo-ordem.html
+++ b/src/html/modals/materia-prima/processo-ordem.html
@@ -4,18 +4,27 @@
       <h3 class="text-lg font-semibold mb-4 text-white">Ordem Duplicada</h3>
       <p class="text-sm text-gray-300">Essa ordem já pertence a um processo. Deseja troca-la?</p>
       <div class="flex justify-center gap-6 mt-6">
-        <div class="flex items-center gap-2">
-          <button id="trocarOrdem" class="btn-warning px-4 py-2 rounded-lg text-white font-medium active:scale-95">Trocar</button>
-          <i class="info-icon" title="Trocar: empurra os processos existentes para baixo."></i>
-        </div>
-        <div class="flex items-center gap-2">
-          <button id="ultimaOrdem" class="btn-primary px-4 py-2 rounded-lg text-white font-medium active:scale-95">Última Ordem</button>
-          <i class="info-icon" title="Última Ordem: adiciona o processo ao final."></i>
-        </div>
-        <div class="flex items-center gap-2">
-          <button id="cancelarOrdem" class="btn-danger px-4 py-2 rounded-lg text-white font-medium active:scale-95">Cancelar</button>
-          <i class="info-icon" title="Cancelar: mantém a ordem existente sem alterações."></i>
-        </div>
+        <button
+          id="trocarOrdem"
+          class="btn-warning px-4 py-2 rounded-lg text-white font-medium flex items-center gap-2 active:scale-95"
+          title="Trocar: empurra os processos existentes para baixo."
+        >
+          Trocar <span class="info-icon"></span>
+        </button>
+        <button
+          id="ultimaOrdem"
+          class="btn-primary px-4 py-2 rounded-lg text-white font-medium flex items-center gap-2 active:scale-95"
+          title="Última: adiciona o processo ao final."
+        >
+          Última <span class="info-icon"></span>
+        </button>
+        <button
+          id="cancelarOrdem"
+          class="btn-danger px-4 py-2 rounded-lg text-white font-medium flex items-center gap-2 active:scale-95"
+          title="Cancelar: mantém a ordem existente sem alterações."
+        >
+          Cancelar <span class="info-icon"></span>
+        </button>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- Move info popups inside duplicate order dialog buttons and rename "Última Ordem" button to "Última"

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f467ffd68832286738863ab4464d6