### PR TITLE
Hide verbose startup logs

### DIFF
--- a/backend/db.js
+++ b/backend/db.js
@@ -1,4 +1,4 @@
-require('dotenv').config({ path: require('path').resolve(__dirname, '../.env') });
+require('dotenv').config({ path: require('path').resolve(__dirname, '../.env'), quiet: true });
 const { Pool } = require('pg');
 
 let pool;

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,5 +1,5 @@
-// carrega variáveis do .env
-require('dotenv').config();
+// carrega variáveis do .env sem mensagens informativas
+require('dotenv').config({ quiet: true });
 
 // importa libs só uma vez
 const express               = require('express');
@@ -32,7 +32,10 @@ app.get('/resetPasswordRenderer.js', (_req, res) => {
 if (require.main === module) {
   const PORT = process.env.PORT || 3000;
   if (!process.env.PORT) console.warn('PORT not set, defaulting to 3000');
-  app.listen(PORT, () => console.log(`API server running on port ${PORT}`));
+  const DEBUG = process.env.DEBUG === 'true';
+  app.listen(PORT, () => {
+    if (DEBUG) console.log(`API server running on port ${PORT}`);
+  });
 }
 
 module.exports = app;

--- a/backend/verifyTransporter.js
+++ b/backend/verifyTransporter.js
@@ -1,10 +1,14 @@
 // backend/verifyTransporter.js
 
-// 1) carrega as variáveis do .env em process.env
-require('dotenv').config();
+// 1) carrega as variáveis do .env em process.env sem logs verbosos
+require('dotenv').config({ quiet: true });
 
 const transporter = require('../src/email/transporter');
 
-transporter.verify()
-  .then(() => console.log('SMTP OK'))
-  .catch(err => console.error('SMTP Error', err));
+const DEBUG = process.env.DEBUG === 'true';
+transporter
+  .verify()
+  .then(() => {
+    if (DEBUG) console.log('SMTP OK');
+  })
+  .catch((err) => console.error('SMTP Error', err));

--- a/main.js
+++ b/main.js
@@ -1,6 +1,7 @@
 
 const { app, BrowserWindow, ipcMain, screen } = require('electron');
 const path = require('path');
+const DEBUG = process.env.DEBUG === 'true';
 const {
   registrarUsuario,
   loginUsuario,
@@ -91,6 +92,7 @@ let displayFile;
 let currentDisplayId;
 
 function logDisplayInfo(context, selected) {
+  if (!DEBUG) return;
   try {
     const displays = screen.getAllDisplays().map(d => ({ id: d.id, bounds: d.bounds }));
     console.log(`[${context}] available displays:`, JSON.stringify(displays));
@@ -300,7 +302,7 @@ app.whenReady().then(() => {
     console.warn('API_PORT not set, defaulting to 3000');
   }
   apiServer.listen(apiPort, () => {
-    console.log(`API server running on port ${apiPort}`);
+    if (DEBUG) console.log(`API server running on port ${apiPort}`);
   });
 
   // Cria a janela de login sem exibí-la imediatamente.
@@ -683,4 +685,6 @@ ipcMain.handle('get-saved-display', () => {
   return currentDisplayId || null;
 });
 
-ipcMain.on('debug-log', (_, m) => console.log('[popup]', m));
+if (DEBUG) {
+  ipcMain.on('debug-log', (_, m) => console.log('[popup]', m));
+}

--- a/preload.js
+++ b/preload.js
@@ -1,7 +1,10 @@
 const { contextBridge, ipcRenderer } = require('electron');
+const DEBUG = process.env.DEBUG === 'true';
 
 contextBridge.exposeInMainWorld('electronAPI', {
-  log: (msg) => ipcRenderer.send('debug-log', msg),
+  log: (msg) => {
+    if (DEBUG) ipcRenderer.send('debug-log', msg);
+  },
   login: (email, password, pin) => ipcRenderer.invoke('login-usuario', { email, password, pin }),
   register: (name, email, password, pin) =>
     ipcRenderer.invoke('registrar-usuario', { name, email, password, pin }),


### PR DESCRIPTION
## Summary
- silence dotenv runtime output and wrap startup logging behind a DEBUG flag
- expose conditional logger in preload and main processes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f49600b1c8322aabd585daf885b61