### PR TITLE
Fix Piece Color Sample Not Displaying

### DIFF
--- a/src/html/materia-prima.html
+++ b/src/html/materia-prima.html
@@ -96,6 +96,8 @@
         </div>
     </div>
 
+  <script src="../utils/colorParser.js"></script>
+  <script src="../utils/colors.js"></script>
   <script src="../js/utils/notifications.js"></script>
   <script src="../js/materia-prima.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- include color parsing utilities on raw material page so color samples render properly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f4f45e2508322b3460b4a72b830f9