### PR TITLE
Display startup success banner

### DIFF
--- a/main.js
+++ b/main.js
@@ -43,6 +43,16 @@ const {
   salvarProdutoDetalhado
 } = require('./backend/produtos');
 const apiServer = require('./backend/server');
+
+function showStartupBanner() {
+  const banner = `\n\u001b[32m
+╔══════════════════════════════════════════╗
+║ 🚀  Aplicativo iniciado com sucesso!    ║
+╚══════════════════════════════════════════╝
+\u001b[0m\n`;
+  console.log(banner);
+}
+
 // Impede que múltiplas instâncias do aplicativo sejam abertas
 const gotTheLock = app.requestSingleInstanceLock();
 if (!gotTheLock) {
@@ -324,6 +334,8 @@ app.whenReady().then(() => {
       createLoginWindow(false, true);
     }
   });
+
+  showStartupBanner();
 });
 
 app.on('window-all-closed', () => {


### PR DESCRIPTION
## Summary
- add a colorful startup banner
- show banner after app initialization completes

## Testing
- `npm test`
- `npm start -- --headless` *(fails: error while loading shared libraries: libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_689f4ca35a28832290401dfb5065b258