### PR TITLE
Fix Deletion Modal Reopen Issue

### DIFF
--- a/src/js/modals/materia-prima-categoria-excluir.js
+++ b/src/js/modals/materia-prima-categoria-excluir.js
@@ -1,45 +1,47 @@
-const close = () => Modal.close('excluirCategoria');
+;(function(){
+  const close = () => Modal.close('excluirCategoria');
 
-document.getElementById('fecharExcluirCategoria').addEventListener('click', close);
-document.getElementById('cancelarExcluirCategoria').addEventListener('click', close);
+  document.getElementById('fecharExcluirCategoria').addEventListener('click', close);
+  document.getElementById('cancelarExcluirCategoria').addEventListener('click', close);
 
-const select = document.getElementById('categoriaExcluir');
-(async () => {
-  try {
-    const categorias = await window.electronAPI.listarCategorias();
-    select.innerHTML = '<option value=""></option>' + categorias.map(c => `<option value="${c}">${c}</option>`).join('');
-    const setFilled = () => select.setAttribute('data-filled', select.value !== '');
-    setFilled();
-    select.addEventListener('change', setFilled);
-    select.addEventListener('blur', setFilled);
-  } catch (e) {
-    console.error(e);
-  }
-})();
-
-const confirmTxt = document.getElementById('confirmExcluirCategoria');
-let confirm = false;
-document.getElementById('excluirCategoria').addEventListener('click', async () => {
-  const nome = select.value;
-  if (!nome) return;
-  if (!confirm) {
-    confirmTxt.classList.remove('hidden');
-    confirm = true;
-    return;
-  }
-  try {
-    await window.electronAPI.removerCategoria(nome);
-    const categorias = await window.electronAPI.listarCategorias();
-    document.querySelectorAll('select#categoria').forEach(sel => {
-      sel.innerHTML = '<option value=""></option>' + categorias.map(c => `<option value="${c}">${c}</option>`).join('');
-    });
-    showToast('Categoria excluída', 'success');
-    close();
-  } catch (err) {
-    if (err.message === 'DEPENDENTE' || err.code === 'DEPENDENTE') {
-      Modal.open('modals/materia-prima/dependencia.html', '../js/modals/materia-prima-dependencia.js', 'dependencia', true);
-    } else {
-      showToast('Erro ao excluir categoria', 'error');
+  const select = document.getElementById('categoriaExcluir');
+  (async () => {
+    try {
+      const categorias = await window.electronAPI.listarCategorias();
+      select.innerHTML = '<option value=""></option>' + categorias.map(c => `<option value="${c}">${c}</option>`).join('');
+      const setFilled = () => select.setAttribute('data-filled', select.value !== '');
+      setFilled();
+      select.addEventListener('change', setFilled);
+      select.addEventListener('blur', setFilled);
+    } catch (e) {
+      console.error(e);
     }
-  }
-});
+  })();
+
+  const confirmTxt = document.getElementById('confirmExcluirCategoria');
+  let confirm = false;
+  document.getElementById('excluirCategoria').addEventListener('click', async () => {
+    const nome = select.value;
+    if (!nome) return;
+    if (!confirm) {
+      confirmTxt.classList.remove('hidden');
+      confirm = true;
+      return;
+    }
+    try {
+      await window.electronAPI.removerCategoria(nome);
+      const categorias = await window.electronAPI.listarCategorias();
+      document.querySelectorAll('select#categoria').forEach(sel => {
+        sel.innerHTML = '<option value=""></option>' + categorias.map(c => `<option value="${c}">${c}</option>`).join('');
+      });
+      showToast('Categoria excluída', 'success');
+      close();
+    } catch (err) {
+      if (err.message === 'DEPENDENTE' || err.code === 'DEPENDENTE') {
+        Modal.open('modals/materia-prima/dependencia.html', '../js/modals/materia-prima-dependencia.js', 'dependencia', true);
+      } else {
+        showToast('Erro ao excluir categoria', 'error');
+      }
+    }
+  });
+})();

--- a/src/js/modals/materia-prima-processo-excluir.js
+++ b/src/js/modals/materia-prima-processo-excluir.js
@@ -1,53 +1,55 @@
-const close = () => Modal.close('excluirProcesso');
+;(function(){
+  const close = () => Modal.close('excluirProcesso');
 
-document.getElementById('fecharExcluirProcesso').addEventListener('click', close);
-document.getElementById('cancelarExcluirProcesso').addEventListener('click', close);
+  document.getElementById('fecharExcluirProcesso').addEventListener('click', close);
+  document.getElementById('cancelarExcluirProcesso').addEventListener('click', close);
 
-const select = document.getElementById('processoExcluir');
-(async () => {
-  try {
-    const processos = await window.electronAPI.listarEtapasProducao();
-    processos.sort((a,b) => (a.ordem ?? 0) - (b.ordem ?? 0));
-    select.innerHTML = '<option value=""></option>' + processos.map(p => {
-      const nome = p?.nome || p;
-      return `<option value="${nome}">${nome}</option>`;
-    }).join('');
-    const setFilled = () => select.setAttribute('data-filled', select.value !== '');
-    setFilled();
-    select.addEventListener('change', setFilled);
-    select.addEventListener('blur', setFilled);
-  } catch (e) {
-    console.error(e);
-  }
-})();
-
-const confirmTxt = document.getElementById('confirmExcluirProcesso');
-let confirm = false;
-document.getElementById('excluirProcesso').addEventListener('click', async () => {
-  const nome = select.value;
-  if (!nome) return;
-  if (!confirm) {
-    confirmTxt.classList.remove('hidden');
-    confirm = true;
-    return;
-  }
-  try {
-    await window.electronAPI.removerEtapaProducao(nome);
-    const processos = await window.electronAPI.listarEtapasProducao();
-    processos.sort((a,b) => (a.ordem ?? 0) - (b.ordem ?? 0));
-    document.querySelectorAll('select#processo').forEach(sel => {
-      sel.innerHTML = '<option value=""></option>' + processos.map(p => {
+  const select = document.getElementById('processoExcluir');
+  (async () => {
+    try {
+      const processos = await window.electronAPI.listarEtapasProducao();
+      processos.sort((a,b) => (a.ordem ?? 0) - (b.ordem ?? 0));
+      select.innerHTML = '<option value=""></option>' + processos.map(p => {
         const nome = p?.nome || p;
         return `<option value="${nome}">${nome}</option>`;
       }).join('');
-    });
-    showToast('Processo excluído', 'success');
-    close();
-  } catch (err) {
-    if (err.message === 'DEPENDENTE' || err.code === 'DEPENDENTE') {
-      Modal.open('modals/materia-prima/dependencia.html', '../js/modals/materia-prima-dependencia.js', 'dependencia', true);
-    } else {
-      showToast('Erro ao excluir processo', 'error');
+      const setFilled = () => select.setAttribute('data-filled', select.value !== '');
+      setFilled();
+      select.addEventListener('change', setFilled);
+      select.addEventListener('blur', setFilled);
+    } catch (e) {
+      console.error(e);
     }
-  }
-});
+  })();
+
+  const confirmTxt = document.getElementById('confirmExcluirProcesso');
+  let confirm = false;
+  document.getElementById('excluirProcesso').addEventListener('click', async () => {
+    const nome = select.value;
+    if (!nome) return;
+    if (!confirm) {
+      confirmTxt.classList.remove('hidden');
+      confirm = true;
+      return;
+    }
+    try {
+      await window.electronAPI.removerEtapaProducao(nome);
+      const processos = await window.electronAPI.listarEtapasProducao();
+      processos.sort((a,b) => (a.ordem ?? 0) - (b.ordem ?? 0));
+      document.querySelectorAll('select#processo').forEach(sel => {
+        sel.innerHTML = '<option value=""></option>' + processos.map(p => {
+          const nome = p?.nome || p;
+          return `<option value="${nome}">${nome}</option>`;
+        }).join('');
+      });
+      showToast('Processo excluído', 'success');
+      close();
+    } catch (err) {
+      if (err.message === 'DEPENDENTE' || err.code === 'DEPENDENTE') {
+        Modal.open('modals/materia-prima/dependencia.html', '../js/modals/materia-prima-dependencia.js', 'dependencia', true);
+      } else {
+        showToast('Erro ao excluir processo', 'error');
+      }
+    }
+  });
+})();

--- a/src/js/modals/materia-prima-unidade-excluir.js
+++ b/src/js/modals/materia-prima-unidade-excluir.js
@@ -1,45 +1,47 @@
-const close = () => Modal.close('excluirUnidade');
+;(function(){
+  const close = () => Modal.close('excluirUnidade');
 
-document.getElementById('fecharExcluirUnidade').addEventListener('click', close);
-document.getElementById('cancelarExcluirUnidade').addEventListener('click', close);
+  document.getElementById('fecharExcluirUnidade').addEventListener('click', close);
+  document.getElementById('cancelarExcluirUnidade').addEventListener('click', close);
 
-const select = document.getElementById('unidadeExcluir');
-(async () => {
-  try {
-    const unidades = await window.electronAPI.listarUnidades();
-    select.innerHTML = '<option value=""></option>' + unidades.map(u => `<option value="${u}">${u}</option>`).join('');
-    const setFilled = () => select.setAttribute('data-filled', select.value !== '');
-    setFilled();
-    select.addEventListener('change', setFilled);
-    select.addEventListener('blur', setFilled);
-  } catch (e) {
-    console.error(e);
-  }
-})();
-
-const confirmTxt = document.getElementById('confirmExcluirUnidade');
-let confirm = false;
-document.getElementById('excluirUnidade').addEventListener('click', async () => {
-  const nome = select.value;
-  if (!nome) return;
-  if (!confirm) {
-    confirmTxt.classList.remove('hidden');
-    confirm = true;
-    return;
-  }
-  try {
-    await window.electronAPI.removerUnidade(nome);
-    const unidades = await window.electronAPI.listarUnidades();
-    document.querySelectorAll('select#unidade').forEach(sel => {
-      sel.innerHTML = '<option value=""></option>' + unidades.map(u => `<option value="${u}">${u}</option>`).join('');
-    });
-    showToast('Unidade excluída', 'success');
-    close();
-  } catch (err) {
-    if (err.message === 'DEPENDENTE' || err.code === 'DEPENDENTE') {
-      Modal.open('modals/materia-prima/dependencia.html', '../js/modals/materia-prima-dependencia.js', 'dependencia', true);
-    } else {
-      showToast('Erro ao excluir unidade', 'error');
+  const select = document.getElementById('unidadeExcluir');
+  (async () => {
+    try {
+      const unidades = await window.electronAPI.listarUnidades();
+      select.innerHTML = '<option value=""></option>' + unidades.map(u => `<option value="${u}">${u}</option>`).join('');
+      const setFilled = () => select.setAttribute('data-filled', select.value !== '');
+      setFilled();
+      select.addEventListener('change', setFilled);
+      select.addEventListener('blur', setFilled);
+    } catch (e) {
+      console.error(e);
     }
-  }
-});
+  })();
+
+  const confirmTxt = document.getElementById('confirmExcluirUnidade');
+  let confirm = false;
+  document.getElementById('excluirUnidade').addEventListener('click', async () => {
+    const nome = select.value;
+    if (!nome) return;
+    if (!confirm) {
+      confirmTxt.classList.remove('hidden');
+      confirm = true;
+      return;
+    }
+    try {
+      await window.electronAPI.removerUnidade(nome);
+      const unidades = await window.electronAPI.listarUnidades();
+      document.querySelectorAll('select#unidade').forEach(sel => {
+        sel.innerHTML = '<option value=""></option>' + unidades.map(u => `<option value="${u}">${u}</option>`).join('');
+      });
+      showToast('Unidade excluída', 'success');
+      close();
+    } catch (err) {
+      if (err.message === 'DEPENDENTE' || err.code === 'DEPENDENTE') {
+        Modal.open('modals/materia-prima/dependencia.html', '../js/modals/materia-prima-dependencia.js', 'dependencia', true);
+      } else {
+        showToast('Erro ao excluir unidade', 'error');
+      }
+    }
+  });
+})();


### PR DESCRIPTION
## Summary
- wrap unit deletion modal logic in local scope to allow reopening
- isolate category deletion modal script to prevent redeclaration on reopen
- scope process deletion modal code so it works every time

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f4fda27588322a8386ecb5f6ab0e1