### PR TITLE
Fix startup banner ASCII

### DIFF
--- a/main.js
+++ b/main.js
@@ -45,11 +45,7 @@ const {
 const apiServer = require('./backend/server');
 
 function showStartupBanner() {
-  const banner = `\n\u001b[32m
-╔══════════════════════════════════════════╗
-║ 🚀  Aplicativo iniciado com sucesso!    ║
-╚══════════════════════════════════════════╝
-\u001b[0m\n`;
+  const banner = `\n==============================\n Aplicativo iniciado com sucesso! \n==============================\n`;
   console.log(banner);
 }
 


### PR DESCRIPTION
## Summary
- replace Unicode box drawing startup banner with plain ASCII to avoid garbled characters in Windows terminals

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f512ec5688322b77ff20801eed900