### PR TITLE
Fix Popup Color Extraction

### DIFF
--- a/src/js/materia-prima.js
+++ b/src/js/materia-prima.js
@@ -169,7 +169,8 @@ let materiaisMap = new Map();
 let currentRawMaterialPopup = null;
 
 function extractCor(nome, cor) {
-    return (cor || (nome && nome.split('/')[1]) || '').trim();
+    const base = cor || nome || '';
+    return base.split('/')[0].trim();
 }
 
 function createPopupContent(item) {

--- a/src/js/produtos.js
+++ b/src/js/produtos.js
@@ -199,6 +199,10 @@ function extrairCorDimensoes(item) {
         cor = partes[2].trim();
     }
 
+    if (cor.includes('/')) {
+        cor = cor.split('/')[0].trim();
+    }
+
     let dimensoes = '';
     if (partes[1]) {
         const match = partes[1].match(/\(([^)]+)\)/);


### PR DESCRIPTION
## Summary
- strip secondary color names after `/` before rendering product and raw material popup samples

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f54b26ca88322b8f58c823a9053e8