### PR TITLE
Fix category filter not refreshing after deletion

### DIFF
--- a/src/js/modals/materia-prima-categoria-excluir.js
+++ b/src/js/modals/materia-prima-categoria-excluir.js
@@ -34,6 +34,13 @@
       document.querySelectorAll('select#categoria').forEach(sel => {
         sel.innerHTML = '<option value=""></option>' + categorias.map(c => `<option value="${c}">${c}</option>`).join('');
       });
+      const filtro = document.getElementById('filtroCategoria');
+      if (filtro) {
+        const selecionada = filtro.value;
+        filtro.innerHTML = '<option value="">Todas</option>' + categorias.map(c => `<option value="${c}">${c}</option>`).join("");
+        if (!categorias.includes(selecionada)) filtro.value = '';
+        filtro.dispatchEvent(new Event('change'));
+      }
       showToast('Categoria excluída', 'success');
       close();
     } catch (err) {


### PR DESCRIPTION
## Summary
- refresh category filter options when a category is removed

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f52072d0483228963e05bb8366574