### PR TITLE
Corrigir Carregamento De Cor Após Barra

### DIFF
--- a/backend/colorParser.test.js
+++ b/backend/colorParser.test.js
@@ -26,3 +26,7 @@ test('variações de acento', () => {
   assert.strictEqual(getColorFromText('salmão'), '#FA8072');
   assert.strictEqual(getColorFromText('salmao'), '#FA8072');
 });
+
+test('texto com barra', () => {
+  assert.strictEqual(getColorFromText('Peroba/Grafite'), '#2F2F2F');
+});

--- a/src/utils/colorParser.js
+++ b/src/utils/colorParser.js
@@ -180,6 +180,9 @@ function extractModifiers(text) {
  */
 function resolveBaseColor(base) {
   const normalized = normalize(base);
+  for (const entry of colorDictionary) {
+    if (normalize(entry.name) === normalized) return entry.hex;
+  }
   for (const entry of keywordIndex) {
     if (normalized === entry.keyword) return entry.hex;
   }
@@ -298,7 +301,8 @@ const FALLBACK_HEX = resolveBaseColor('cinza') || '#808080';
  * getColorFromText('rosa choque'); // '#FF1493'
  */
 function getColorFromText(text = '') {
-  const normalized = normalize(text);
+  const segment = text.split('/').pop();
+  const normalized = normalize(segment);
   const direct = resolveBaseColor(normalized);
   if (direct) return direct;
   const { base, mods } = extractModifiers(normalized);


### PR DESCRIPTION
## Summary
- Ajuste para considerar apenas o trecho após a barra ao resolver a cor
- Prioriza correspondência por nome de cor antes de palavras-chave
- Cobre casos com barra em `getColorFromText`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f57e94c6c8322a1b602bf7428ae87