### PR TITLE
Handle Product Code Update And Display Errors

### DIFF
--- a/src/js/modals/produto-editar.js
+++ b/src/js/modals/produto-editar.js
@@ -442,6 +442,7 @@
           close();
         }catch(err){
           console.error('Erro ao salvar produto', err);
+          showToast('Erro ao salvar produto', 'error');
         }
       });
     }


### PR DESCRIPTION
## Summary
- allow changing product code by inserting new record, migrating relationships, and removing old entry
- show toast notification when saving a product fails
- cover product code change with regression test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f587250b883228f185d1f7a3eba50