### PR TITLE
Implement Color Parsing After Slash

### DIFF
--- a/src/js/materia-prima.js
+++ b/src/js/materia-prima.js
@@ -170,7 +170,7 @@ let currentRawMaterialPopup = null;
 
 function extractCor(nome, cor) {
     const base = cor || nome || '';
-    return base.split('/')[0].trim();
+    return base.split('/').pop().trim();
 }
 
 function createPopupContent(item) {

--- a/src/js/produtos.js
+++ b/src/js/produtos.js
@@ -202,7 +202,7 @@ function extrairCorDimensoes(item) {
     let corAmostra = corNome;
     if (corNome.includes('/')) {
         const partesCor = corNome.split('/');
-        corAmostra = partesCor[1] ? partesCor[1].trim() : partesCor[0].trim();
+        corAmostra = partesCor[partesCor.length - 1].trim();
     }
 
     let dimensoes = '';

--- a/src/utils/colors.js
+++ b/src/utils/colors.js
@@ -15,7 +15,7 @@ function resolveColorCss(cor = '') {
   if (!getColorFromText) {
     throw new Error('colorParser not available');
   }
-  return getColorFromText((cor.split('/')[1] || cor).trim());
+  return getColorFromText(cor.trim());
 }
 
 if (typeof window !== 'undefined') {


### PR DESCRIPTION
## Summary
- Ensure color parser uses raw input without manual slash splitting
- Use final segment after any slash in product color names for sample display
- Extract raw material colors from text using last slash segment

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f72ed63b88322a9fdf9cf26b4442b