### PR TITLE
Corrigir erro de chave duplicada ao salvar produto detalhado

### DIFF
--- a/backend/produtos.js
+++ b/backend/produtos.js
@@ -532,7 +532,10 @@ async function salvarProdutoDetalhado(codigoOriginal, produto, itens) {
     // Processa inserções
     for (const ins of (itens.inseridos || [])) {
       await client.query(
-        'INSERT INTO produtos_insumos (produto_codigo, insumo_id, quantidade) VALUES ($1,$2,$3)',
+        `INSERT INTO produtos_insumos (produto_codigo, insumo_id, quantidade)
+         VALUES ($1,$2,$3)
+         ON CONFLICT (produto_codigo, insumo_id)
+         DO UPDATE SET quantidade = EXCLUDED.quantidade`,
         [codigoDestino, ins.insumo_id, ins.quantidade]
       );
     }

--- a/backend/salvarProdutoDetalhado.test.js
+++ b/backend/salvarProdutoDetalhado.test.js
@@ -23,7 +23,8 @@ function createMockDb() {
     id serial primary key,
     produto_codigo text references produtos(codigo),
     insumo_id integer,
-    quantidade numeric
+    quantidade numeric,
+    UNIQUE (produto_codigo, insumo_id)
   );`);
   db.public.none(`INSERT INTO produtos (codigo, pct_fabricacao, pct_acabamento, pct_montagem, pct_embalagem, pct_markup, pct_comissao, pct_imposto, preco_base, preco_venda)
                   VALUES ('P001',0,0,0,0,0,0,0,0,0);`);
@@ -88,4 +89,48 @@ test('salvarProdutoDetalhado atualiza codigo e mantém vínculos', async () => {
   assert.deepStrictEqual(resProdutos.rows.map(r => r.codigo), ['P002']);
   const resInsumos = await pool.query('SELECT produto_codigo FROM produtos_insumos');
   assert.strictEqual(resInsumos.rows[0].produto_codigo, 'P002');
+});
+
+test('salvarProdutoDetalhado substitui insumo existente sem erro de duplicidade', async () => {
+  const mem = createMockDb();
+  const { Pool } = mem.adapters.createPg();
+  const pool = new Pool();
+
+  const dbModulePath = require.resolve('./db');
+  require.cache[dbModulePath] = {
+    exports: {
+      query: (text, params) => pool.query(text, params),
+      connect: () => pool.connect()
+    }
+  };
+  delete require.cache[require.resolve('./produtos')];
+  const { salvarProdutoDetalhado } = require('./produtos');
+
+  await pool.query(
+    'INSERT INTO produtos_insumos (produto_codigo, insumo_id, quantidade) VALUES ($1,$2,$3)',
+    ['P001', 7, 1]
+  );
+
+  await salvarProdutoDetalhado(
+    'P001',
+    {
+      pct_fabricacao: 0,
+      pct_acabamento: 0,
+      pct_montagem: 0,
+      pct_embalagem: 0,
+      pct_markup: 0,
+      pct_comissao: 0,
+      pct_imposto: 0,
+      preco_base: 0,
+      preco_venda: 0
+    },
+    { inseridos: [{ insumo_id: 7, quantidade: 5 }] }
+  );
+
+  const { rows } = await pool.query(
+    'SELECT quantidade FROM produtos_insumos WHERE produto_codigo=$1 AND insumo_id=$2',
+    ['P001', 7]
+  );
+  assert.strictEqual(rows.length, 1);
+  assert.strictEqual(Number(rows[0].quantidade), 5);
 });


### PR DESCRIPTION
## Summary
- Atualiza inserção de insumos para substituir registros existentes em vez de falhar por duplicidade
- Ajusta testes com constraint de unicidade e adiciona verificação para substituição de insumo

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f7d3f57a48322af3f93da6cdbfdfd