### PR TITLE
Implement Budget Edit Modal

### DIFF
--- a/src/html/modals/orcamentos/editar.html
+++ b/src/html/modals/orcamentos/editar.html
@@ -1,0 +1,98 @@
+<div id="editarOrcamentoOverlay" class="fixed inset-0 bg-black/50 flex items-center justify-center p-4">
+  <div role="dialog" aria-modal="true" tabindex="0" class="w-full max-w-5xl max-h-[90vh] bg-surface/60 backdrop-blur-xl rounded-3xl border border-white/10 ring-1 ring-white/5 shadow-2xl/40 animate-modalFade slide-in overflow-hidden flex flex-col">
+    <header class="flex items-center justify-between px-8 py-5 border-b border-white/10 flex-shrink-0">
+      <h2 id="tituloEditarOrcamento" class="text-lg font-semibold text-white">Editar Orçamento</h2>
+      <button id="fecharEditarOrcamento" class="btn-danger icon-only text-white">✕</button>
+    </header>
+    <div class="flex-1 overflow-y-auto p-8 space-y-6">
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div>
+          <label class="block text-sm font-medium text-gray-300 mb-2">Cliente</label>
+          <input id="editarCliente" type="text" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+        </div>
+        <div>
+          <label class="block text-sm font-medium text-gray-300 mb-2">Contato</label>
+          <input id="editarContato" type="text" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+        </div>
+        <div>
+          <label class="block text-sm font-medium text-gray-300 mb-2">Validade</label>
+          <input id="editarValidade" type="date" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+        </div>
+        <div>
+          <label class="block text-sm font-medium text-gray-300 mb-2">Condição de pagamento</label>
+          <select id="editarCondicao" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition select-arrow appearance-none">
+            <option value="vista">À vista</option>
+            <option value="prazo">À prazo</option>
+          </select>
+        </div>
+        <div>
+          <label class="block text-sm font-medium text-gray-300 mb-2">Status</label>
+          <select id="editarStatus" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition select-arrow appearance-none">
+            <option value="rascunho">Rascunho</option>
+            <option value="aberto">Aberto</option>
+            <option value="enviado">Enviado</option>
+            <option value="aprovado">Aprovado</option>
+            <option value="recusado">Recusado</option>
+          </select>
+        </div>
+        <div class="md:col-span-2">
+          <label class="block text-sm font-medium text-gray-300 mb-2">Observações</label>
+          <textarea id="editarObservacoes" rows="2" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition"></textarea>
+        </div>
+      </div>
+
+      <div>
+        <h3 class="text-lg font-semibold mb-4 text-white">Itens</h3>
+        <!-- manipulação de itens -->
+        <div class="grid grid-cols-1 md:grid-cols-5 gap-4 mb-4 items-end">
+          <div class="md:col-span-2">
+            <input id="novoItemNome" type="text" placeholder="Produto" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+          </div>
+          <div>
+            <input id="novoItemQtd" type="number" min="1" value="1" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+          </div>
+          <div>
+            <input id="novoItemValor" type="number" min="0" step="0.01" placeholder="0,00" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+          </div>
+          <div>
+            <input id="novoItemDesc" type="number" min="0" value="0" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+          </div>
+          <div>
+            <button id="adicionarItem" class="w-full btn-success px-4 py-3 rounded-lg font-medium">+ Inserir</button>
+          </div>
+        </div>
+
+        <div class="bg-surface/40 rounded-xl border border-white/10 overflow-hidden">
+          <table id="orcamentoItens" class="w-full text-sm">
+            <thead class="bg-surface/60">
+              <tr class="border-b border-white/10">
+                <th class="text-left py-3 px-4 text-gray-300 font-medium">Item</th>
+                <th class="text-center py-3 px-4 text-gray-300 font-medium">Qtd</th>
+                <th class="text-right py-3 px-4 text-gray-300 font-medium">Valor Unit. (R$)</th>
+                <th class="text-center py-3 px-4 text-gray-300 font-medium">Desc. %</th>
+                <th class="text-right py-3 px-4 text-gray-300 font-medium">Total (R$)</th>
+                <th class="text-center py-3 px-4 text-gray-300 font-medium">Ações</th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+        </div>
+
+        <!-- recálculo de totais -->
+        <div class="flex justify-end gap-8 mt-4 text-sm">
+          <div class="text-gray-300">Subtotal: <span id="subtotalOrcamento">R$ 0,00</span></div>
+          <div class="text-gray-300">Desconto: <span id="descontoOrcamento">R$ 0,00</span></div>
+          <div class="text-white font-semibold">Total: <span id="totalOrcamento">R$ 0,00</span></div>
+        </div>
+      </div>
+    </div>
+
+    <!-- salvar/fechar e converter -->
+    <footer class="flex justify-end gap-3 px-8 py-6 border-t border-white/10 flex-shrink-0">
+      <button id="salvarOrcamento" class="btn-primary px-6 py-3 rounded-lg text-white font-medium">Salvar</button>
+      <button id="salvarFecharOrcamento" class="btn-secondary px-6 py-3 rounded-lg text-white font-medium">Salvar e Fechar</button>
+      <button id="converterOrcamento" class="btn-success px-6 py-3 rounded-lg font-medium">Converter em Pedido</button>
+      <button id="cancelarOrcamento" class="btn-neutral px-6 py-3 rounded-lg text-white font-medium">Cancelar</button>
+    </footer>
+  </div>
+</div>

--- a/src/js/modals/orcamento-editar.js
+++ b/src/js/modals/orcamento-editar.js
@@ -1,0 +1,112 @@
+(() => {
+  const overlayId = 'editarOrcamento';
+
+  // carga de dados
+  const data = window.selectedQuoteData || {};
+  const titulo = document.getElementById('tituloEditarOrcamento');
+  if (data.id && data.cliente) {
+    titulo.textContent = `Editar Orçamento #${data.id} – ${data.cliente}`;
+  }
+  document.getElementById('editarCliente').value = data.cliente || '';
+  document.getElementById('editarCondicao').value = data.condicao || 'vista';
+  document.getElementById('editarStatus').value = (data.status || 'rascunho').toLowerCase();
+
+  const itensTbody = document.querySelector('#orcamentoItens tbody');
+
+  function formatCurrency(v) {
+    return v.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
+  }
+
+  // manipulação de itens
+  function addItem(item) {
+    const tr = document.createElement('tr');
+    tr.innerHTML = `
+      <td class="py-2 px-4 text-white">${item.nome}</td>
+      <td class="py-2 px-4 text-center"><input type="number" class="w-16 bg-input border border-inputBorder rounded px-2 py-1 text-white text-xs focus:border-primary focus:ring-1 focus:ring-primary/50 transition" value="${item.qtd}" min="1"></td>
+      <td class="py-2 px-4 text-right"><input type="number" class="w-24 bg-input border border-inputBorder rounded px-2 py-1 text-white text-xs text-right focus:border-primary focus:ring-1 focus:ring-primary/50 transition" value="${item.valor.toFixed(2)}" min="0" step="0.01"></td>
+      <td class="py-2 px-4 text-center"><input type="number" class="w-16 bg-input border border-inputBorder rounded px-2 py-1 text-white text-xs focus:border-primary focus:ring-1 focus:ring-primary/50 transition" value="${item.desc}" min="0" max="100"></td>
+      <td class="py-2 px-4 text-right text-white total-cell"></td>
+      <td class="py-2 px-4 text-center"><button class="icon-only bg-red-600/20 text-red-400 hover:bg-red-600/30 transition">🗑</button></td>
+    `;
+    itensTbody.appendChild(tr);
+
+    const qtyInput = tr.children[1].querySelector('input');
+    const valInput = tr.children[2].querySelector('input');
+    const descInput = tr.children[3].querySelector('input');
+    const totalCell = tr.querySelector('.total-cell');
+
+    function recalc() {
+      const q = parseFloat(qtyInput.value) || 0;
+      const v = parseFloat(valInput.value) || 0;
+      const d = parseFloat(descInput.value) || 0;
+      const line = q * v * (1 - d / 100);
+      totalCell.textContent = formatCurrency(line);
+      recalcTotals();
+    }
+    qtyInput.addEventListener('input', recalc);
+    valInput.addEventListener('input', recalc);
+    descInput.addEventListener('input', recalc);
+    tr.querySelector('button').addEventListener('click', () => {
+      tr.remove();
+      recalcTotals();
+    });
+    recalc();
+  }
+
+  (data.items || [{ nome: 'Item Exemplo', qtd: 1, valor: 100, desc: 0 }]).forEach(addItem);
+
+  document.getElementById('adicionarItem').addEventListener('click', () => {
+    const nome = document.getElementById('novoItemNome').value.trim();
+    const qtd = parseFloat(document.getElementById('novoItemQtd').value) || 1;
+    const valor = parseFloat(document.getElementById('novoItemValor').value) || 0;
+    const desc = parseFloat(document.getElementById('novoItemDesc').value) || 0;
+    if (!nome) return;
+    addItem({ nome, qtd, valor, desc });
+    document.getElementById('novoItemNome').value = '';
+    document.getElementById('novoItemQtd').value = 1;
+    document.getElementById('novoItemValor').value = '';
+    document.getElementById('novoItemDesc').value = 0;
+  });
+
+  function recalcTotals() {
+    // recálculo de totais
+    let subtotal = 0;
+    let desconto = 0;
+    document.querySelectorAll('#orcamentoItens tbody tr').forEach(tr => {
+      const qty = parseFloat(tr.children[1].querySelector('input').value) || 0;
+      const val = parseFloat(tr.children[2].querySelector('input').value) || 0;
+      const desc = parseFloat(tr.children[3].querySelector('input').value) || 0;
+      subtotal += qty * val;
+      desconto += qty * val * (desc / 100);
+    });
+    const total = subtotal - desconto;
+    document.getElementById('subtotalOrcamento').textContent = formatCurrency(subtotal);
+    document.getElementById('descontoOrcamento').textContent = formatCurrency(desconto);
+    document.getElementById('totalOrcamento').textContent = formatCurrency(total);
+  }
+
+  function saveChanges(closeAfter) {
+    // salvar/fechar e converter
+    if (data.row) {
+      data.row.cells[3].textContent = document.getElementById('totalOrcamento').textContent;
+      const statusCell = data.row.cells[5];
+      statusCell.innerHTML = '';
+      const statusValue = document.getElementById('editarStatus').value;
+      const statusText = document.getElementById('editarStatus').options[document.getElementById('editarStatus').selectedIndex].textContent;
+      const statusSpan = document.createElement('span');
+      statusSpan.className = `badge-${statusValue} px-3 py-1 rounded-full text-xs font-medium`;
+      statusSpan.textContent = statusText;
+      statusCell.appendChild(statusSpan);
+    }
+    if (closeAfter) Modal.close(overlayId);
+  }
+
+  document.getElementById('salvarOrcamento').addEventListener('click', () => saveChanges(false));
+  document.getElementById('salvarFecharOrcamento').addEventListener('click', () => saveChanges(true));
+  document.getElementById('cancelarOrcamento').addEventListener('click', () => Modal.close(overlayId));
+  document.getElementById('fecharEditarOrcamento').addEventListener('click', () => Modal.close(overlayId));
+  document.getElementById('converterOrcamento').addEventListener('click', () => {
+    saveChanges(true);
+    alert('Orçamento convertido em pedido!');
+  });
+})();

--- a/src/js/orcamentos.js
+++ b/src/js/orcamentos.js
@@ -7,6 +7,19 @@ function initOrcamentos() {
             el.style.transform = 'translateY(0)';
         }, index * 100);
     });
+
+    document.querySelectorAll('.fa-edit').forEach(icon => {
+        icon.addEventListener('click', e => {
+            e.stopPropagation();
+            const row = e.currentTarget.closest('tr');
+            const id = row.cells[0].textContent.trim();
+            const cliente = row.cells[1].textContent.trim();
+            const condicao = row.cells[4]?.textContent.trim();
+            const status = row.cells[5]?.innerText.trim();
+            window.selectedQuoteData = { id, cliente, condicao, status, row };
+            Modal.open('modals/orcamentos/editar.html', '../js/modals/orcamento-editar.js', 'editarOrcamento');
+        });
+    });
 }
 
 if (document.readyState === 'loading') {


### PR DESCRIPTION
## Summary
- add edit budget modal with fields, item table, totals and action buttons
- enable editing logic with item manipulation, total recalculation, and saving
- wire budget table edit icons to open the new modal

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f7f3bf6508322801780647464a4e9