### PR TITLE
Ensure Colors.js Is Included Only Once

### DIFF
--- a/src/utils/colors.js
+++ b/src/utils/colors.js
@@ -1,27 +1,29 @@
 /**
- * Resolve uma cor textual para seu equivalente hexadecimal.
+ * Resolve uma cor textual para seu equivalente hexadecimal e expõe a função
+ * globalmente apenas uma vez, mesmo com múltiplas inclusões do script.
  * Mantém assinatura pública utilizada pela UI.
  * @param {string} cor
  * @returns {string}
  */
-let getColorFromText;
-if (typeof window !== 'undefined' && window.colorParser) {
-  getColorFromText = window.colorParser.getColorFromText;
-} else if (typeof require !== 'undefined') {
-  ({ getColorFromText } = require('./colorParser'));
-}
+(function (global) {
+  if (global.resolveColorCss) return;
 
-function resolveColorCss(cor = '') {
-  if (!getColorFromText) {
-    throw new Error('colorParser not available');
+  let getColorFromText;
+  if (global.colorParser) {
+    getColorFromText = global.colorParser.getColorFromText;
+  } else if (typeof require !== 'undefined') {
+    ({ getColorFromText } = require('./colorParser'));
   }
-  return getColorFromText(cor.trim());
-}
 
-if (typeof window !== 'undefined') {
-  window.resolveColorCss = resolveColorCss;
-}
+  function resolveColorCss(cor = '') {
+    if (!getColorFromText) {
+      throw new Error('colorParser not available');
+    }
+    return getColorFromText(cor.trim());
+  }
 
-if (typeof module !== 'undefined') {
-  module.exports = { resolveColorCss };
-}
+  if (typeof module !== 'undefined') {
+    module.exports = { resolveColorCss };
+  }
+  global.resolveColorCss = resolveColorCss;
+})(typeof window !== 'undefined' ? window : globalThis);


### PR DESCRIPTION
## Summary
- guard `resolveColorCss` inside an IIFE to avoid multiple global declarations
- confirm HTML pages include `colors.js` a single time each
- verify `window.resolveColorCss` remains available after script load

## Testing
- `npm test`
- `node -e "global.window = { colorParser: require('./src/utils/colorParser') }; require('./src/utils/colors'); require('./src/utils/colors'); console.log(typeof window.resolveColorCss);"`


------
https://chatgpt.com/codex/tasks/task_e_689f7f909e4c83229fdb637f2445fcc6