### PR TITLE
Excluir Produto Com Verificacao Em Pedido Ou Orcamento

### DIFF
--- a/backend/excluirProduto.test.js
+++ b/backend/excluirProduto.test.js
@@ -1,0 +1,63 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { newDb } = require('pg-mem');
+
+function setup() {
+  const db = newDb();
+  db.public.none(`CREATE TABLE produtos (
+    id serial primary key,
+    codigo text
+  );`);
+  db.public.none(`CREATE TABLE produtos_insumos (
+    id serial primary key,
+    produto_codigo text
+  );`);
+  db.public.none(`CREATE TABLE produtos_em_cada_ponto (
+    id serial primary key,
+    produto_id int
+  );`);
+  db.public.none(`CREATE TABLE orcamento (
+    id serial primary key,
+    produto_id int
+  );`);
+  db.public.none(`CREATE TABLE pedido (
+    id serial primary key,
+    produto_id int
+  );`);
+  db.public.none("INSERT INTO produtos (id, codigo) VALUES (1, 'P001');");
+  db.public.none("INSERT INTO produtos_insumos (produto_codigo) VALUES ('P001');");
+  db.public.none('INSERT INTO produtos_em_cada_ponto (produto_id) VALUES (1);');
+  const { Pool } = db.adapters.createPg();
+  const pool = new Pool();
+  const dbModulePath = require.resolve('./db');
+  require.cache[dbModulePath] = {
+    exports: {
+      query: (text, params) => pool.query(text, params),
+      connect: () => pool.connect()
+    }
+  };
+  const produtosPath = require.resolve('./produtos');
+  delete require.cache[produtosPath];
+  const { excluirProduto } = require('./produtos');
+  return { excluirProduto, pool };
+}
+
+test('excluirProduto remove dependências', async () => {
+  const { excluirProduto, pool } = setup();
+  await excluirProduto(1);
+  assert.strictEqual((await pool.query('SELECT * FROM produtos')).rowCount, 0);
+  assert.strictEqual((await pool.query('SELECT * FROM produtos_insumos')).rowCount, 0);
+  assert.strictEqual((await pool.query('SELECT * FROM produtos_em_cada_ponto')).rowCount, 0);
+});
+
+test('excluirProduto bloqueia se estiver em orçamento', async () => {
+  const { excluirProduto, pool } = setup();
+  await pool.query('INSERT INTO orcamento (produto_id) VALUES (1);');
+  await assert.rejects(() => excluirProduto(1), /orçamento/i);
+});
+
+test('excluirProduto bloqueia se estiver em pedido', async () => {
+  const { excluirProduto, pool } = setup();
+  await pool.query('INSERT INTO pedido (produto_id) VALUES (1);');
+  await assert.rejects(() => excluirProduto(1), /pedido/i);
+});

--- a/src/js/modals/produto-excluir.js
+++ b/src/js/modals/produto-excluir.js
@@ -14,7 +14,7 @@
       carregarProdutos();
     }catch(err){
       console.error(err);
-      showToast('Erro ao excluir produto', 'error');
+      showToast(err.message || 'Erro ao excluir produto', 'error');
     }
   });
 })();


### PR DESCRIPTION
## Summary
- prevent deleting a product if it appears in `orcamento` or `pedido`
- cascade product deletion across related tables and expose backend error messages in UI
- add tests covering the new deletion logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f83048dc08322928629f96720ae2f