### PR TITLE
Remove Color From Raw Material Pop-Up

### DIFF
--- a/src/css/materia-prima.css
+++ b/src/css/materia-prima.css
@@ -266,18 +266,6 @@ body {
   color: white; /* Altera a cor do valor para branco */
 }
 
-.popup-color-wrapper {
-  display: block;
-  width: 100%;
-}
-
-.popup-color-bar {
-  width: 100%;
-  height: 0.25rem;
-  margin-top: 0.125rem;
-  border-radius: 0.125rem;
-}
-
 /* Badge de "Sim" ou "Não" */
 .badge {
   display: inline-flex;

--- a/src/js/materia-prima.js
+++ b/src/js/materia-prima.js
@@ -168,28 +168,10 @@ let materiais = [];
 let materiaisMap = new Map();
 let currentRawMaterialPopup = null;
 
-function extractCor(nome, cor) {
-    const base = cor || nome || '';
-    return base.split('/').pop().trim();
-}
-
 function createPopupContent(item) {
-    const cor = extractCor(item.nome, item.cor);
-    const corCss = window.resolveColorCss ? window.resolveColorCss(cor) : cor;
     const infinitoBadge = item.infinito
         ? `<span class="badge badge-sim">✔ Sim</span>`
         : `<span class="badge badge-nao">✖ Não</span>`;
-    const corSection = cor ? `
-        <div class="popup-info-grid">
-          <div>
-            <p class="popup-info-label">Cor:</p>
-            <div class="popup-color-wrapper">
-              <p class="popup-info-value">${cor}</p>
-              <div class="popup-color-bar" style="background-color: ${corCss};"></div>
-            </div>
-          </div>
-          <div></div>
-        </div>` : '';
 
     const processoBadge = item.processo
         ? `<span class="badge ${getProcessBadgeClass(item.processo)}">${item.processo}</span>`
@@ -222,7 +204,6 @@ function createPopupContent(item) {
             ${processoBadge}
           </div>
         </div>
-        ${corSection}
         <div class="popup-description-section">
           <p class="popup-info-label">Descrição Técnica:</p>
           <p class="popup-description-text">${item.descricao || ''}</p>


### PR DESCRIPTION
## Summary
- Remove color details from raw material info popup to match previous layout
- Strip unused color styles from raw material CSS

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f870988008322b4b7657fec765631