### PR TITLE
Padronizar Modais De Novo E Editar Orçamento

### DIFF
--- a/src/html/modals/orcamentos/editar.html
+++ b/src/html/modals/orcamentos/editar.html
@@ -1,8 +1,10 @@
 <div id="editarOrcamentoOverlay" class="fixed inset-0 bg-black/50 flex items-center justify-center p-4">
   <div role="dialog" aria-modal="true" tabindex="0" class="w-full max-w-5xl max-h-[90vh] bg-surface/60 backdrop-blur-xl rounded-3xl border border-white/10 ring-1 ring-white/5 shadow-2xl/40 animate-modalFade slide-in overflow-hidden flex flex-col">
-    <header class="flex items-center justify-between px-8 py-5 border-b border-white/10 flex-shrink-0">
-      <h2 id="tituloEditarOrcamento" class="text-lg font-semibold text-white">Editar Orçamento</h2>
-      <button id="fecharEditarOrcamento" class="btn-danger icon-only text-white">✕</button>
+    <header class="flex items-center px-8 py-5 border-b border-white/10">
+      <button id="voltarEditarOrcamento" class="btn-neutral px-4 py-2 rounded-lg text-white font-medium flex items-center gap-2">
+        ← Voltar
+      </button>
+      <h2 id="tituloEditarOrcamento" class="flex-1 text-lg font-semibold text-white text-center">EDITAR ORÇAMENTO</h2>
     </header>
     <div class="flex-1 overflow-y-auto p-8 space-y-6">
       <div class="grid grid-cols-1 md:grid-cols-2 gap-4">

--- a/src/html/modals/orcamentos/novo.html
+++ b/src/html/modals/orcamentos/novo.html
@@ -1,8 +1,11 @@
 <div id="novoOrcamentoOverlay" class="fixed inset-0 bg-black/50 flex items-center justify-center p-4">
   <div role="dialog" aria-modal="true" tabindex="0" class="w-full max-w-5xl max-h-[90vh] bg-surface/60 backdrop-blur-xl rounded-3xl border border-white/10 ring-1 ring-white/5 shadow-2xl/40 animate-modalFade slide-in overflow-hidden flex flex-col">
     <header class="flex items-center justify-between px-8 py-5 border-b border-white/10 flex-shrink-0">
-      <h2 class="text-lg font-semibold text-white">Novo Orçamento</h2>
-      <button id="fecharNovoOrcamento" class="btn-danger icon-only text-white">✕</button>
+      <button id="voltarNovoOrcamento" class="btn-neutral px-4 py-2 rounded-lg text-white font-medium flex items-center gap-2">
+        ← Voltar
+      </button>
+      <h2 class="text-lg font-semibold text-white">NOVO ORÇAMENTO</h2>
+      <button id="limparNovoOrcamento" class="btn-danger px-4 py-2 rounded-lg text-white font-medium">Limpar Tudo</button>
     </header>
     <div class="flex-1 overflow-y-auto p-8 space-y-6">
       <div class="grid grid-cols-1 md:grid-cols-2 gap-4">

--- a/src/js/modals/orcamento-editar.js
+++ b/src/js/modals/orcamento-editar.js
@@ -1,11 +1,15 @@
 (() => {
   const overlayId = 'editarOrcamento';
+  const overlay = document.getElementById('editarOrcamentoOverlay');
+  const close = () => Modal.close(overlayId);
+  overlay.addEventListener('click', e => { if (e.target === overlay) close(); });
+  document.addEventListener('keydown', function esc(e){ if(e.key === 'Escape'){ close(); document.removeEventListener('keydown', esc); } });
 
   // carga de dados
   const data = window.selectedQuoteData || {};
   const titulo = document.getElementById('tituloEditarOrcamento');
   if (data.id && data.cliente) {
-    titulo.textContent = `Editar Orçamento #${data.id} – ${data.cliente}`;
+    titulo.textContent = `EDITAR ORÇAMENTO #${data.id} – ${data.cliente}`;
   }
   document.getElementById('editarCliente').value = data.cliente || '';
   document.getElementById('editarCondicao').value = data.condicao || 'vista';
@@ -103,8 +107,8 @@
 
   document.getElementById('salvarOrcamento').addEventListener('click', () => saveChanges(false));
   document.getElementById('salvarFecharOrcamento').addEventListener('click', () => saveChanges(true));
-  document.getElementById('cancelarOrcamento').addEventListener('click', () => Modal.close(overlayId));
-  document.getElementById('fecharEditarOrcamento').addEventListener('click', () => Modal.close(overlayId));
+  document.getElementById('cancelarOrcamento').addEventListener('click', close);
+  document.getElementById('voltarEditarOrcamento').addEventListener('click', close);
   document.getElementById('converterOrcamento').addEventListener('click', () => {
     saveChanges(true);
     alert('Orçamento convertido em pedido!');

--- a/src/js/modals/orcamento-novo.js
+++ b/src/js/modals/orcamento-novo.js
@@ -1,5 +1,9 @@
 (() => {
   const overlayId = 'novoOrcamento';
+  const overlay = document.getElementById('novoOrcamentoOverlay');
+  const close = () => Modal.close(overlayId);
+  overlay.addEventListener('click', e => { if (e.target === overlay) close(); });
+  document.addEventListener('keydown', function esc(e){ if(e.key === 'Escape'){ close(); document.removeEventListener('keydown', esc); } });
 
   const clients = {
     'joao-silva': { nome: 'João Silva', contatos: ['João Contato'] },
@@ -167,6 +171,16 @@
 
   document.getElementById('salvarNovoOrcamento').addEventListener('click', () => saveQuote('Rascunho'));
   document.getElementById('enviarNovoOrcamento').addEventListener('click', () => saveQuote('Enviado'));
-  document.getElementById('cancelarNovoOrcamento').addEventListener('click', () => Modal.close(overlayId));
-  document.getElementById('fecharNovoOrcamento').addEventListener('click', () => Modal.close(overlayId));
+  document.getElementById('cancelarNovoOrcamento').addEventListener('click', close);
+  document.getElementById('voltarNovoOrcamento').addEventListener('click', close);
+
+  const limparBtn = document.getElementById('limparNovoOrcamento');
+  if (limparBtn) {
+    limparBtn.addEventListener('click', () => {
+      overlay.querySelectorAll('input').forEach(i => i.value = '');
+      overlay.querySelectorAll('select').forEach(s => s.selectedIndex = 0);
+      itensTbody.innerHTML = '';
+      recalcTotals();
+    });
+  }
 })();


### PR DESCRIPTION
## Summary
- Harmonize novo orçamento modal layout with project visual standards, adding Voltar and Limpar Tudo actions.
- Align editar orçamento modal header to match existing design and support Esc/overlay close.
- Update modal scripts to handle new controls, overlay clicks, and input clearing.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f880a41588322b72909bb67a89dc9