### PR TITLE
Enforce required fields when creating a piece

### DIFF
--- a/backend/produtos.js
+++ b/backend/produtos.js
@@ -231,6 +231,22 @@ async function listarItensProcessoProduto(codigo, etapa, busca = '') {
 async function adicionarProduto(dados) {
   const { codigo, nome, preco_venda, pct_markup, status } = dados;
   const categoria = dados.categoria || (nome ? String(nome).trim().split(' ')[0] : null);
+  const required = {
+    codigo: 'Código',
+    nome: 'Nome',
+    preco_venda: 'Preço de venda',
+    pct_markup: 'Markup',
+    status: 'Status'
+  };
+  for (const [key, label] of Object.entries(required)) {
+    const val = dados[key];
+    if (val === undefined || val === null || String(val).trim() === '') {
+      const err = new Error(`${label} é obrigatório`);
+      err.code = 'CAMPO_OBRIGATORIO';
+      err.field = key;
+      throw err;
+    }
+  }
   const codigoDup = await pool.query('SELECT 1 FROM produtos WHERE codigo=$1', [codigo]);
   if (codigoDup.rowCount > 0) {
     const err = new Error('Código já existe');

--- a/backend/produtosDuplicados.test.js
+++ b/backend/produtosDuplicados.test.js
@@ -43,6 +43,30 @@ function setup() {
   return { adicionarProduto, atualizarProduto, salvarProdutoDetalhado, pool };
 }
 
+test('adicionarProduto exige todos os campos', async () => {
+  const { adicionarProduto } = setup();
+  await assert.rejects(
+    adicionarProduto({ nome: 'Prod1', preco_venda: 0, pct_markup: 0, status: 'ativo' }),
+    /Código é obrigatório/
+  );
+  await assert.rejects(
+    adicionarProduto({ codigo: 'P1', preco_venda: 0, pct_markup: 0, status: 'ativo' }),
+    /Nome é obrigatório/
+  );
+  await assert.rejects(
+    adicionarProduto({ codigo: 'P1', nome: 'Prod1', pct_markup: 0, status: 'ativo' }),
+    /Preço de venda é obrigatório/
+  );
+  await assert.rejects(
+    adicionarProduto({ codigo: 'P1', nome: 'Prod1', preco_venda: 0, status: 'ativo' }),
+    /Markup é obrigatório/
+  );
+  await assert.rejects(
+    adicionarProduto({ codigo: 'P1', nome: 'Prod1', preco_venda: 0, pct_markup: 0 }),
+    /Status é obrigatório/
+  );
+});
+
 test('atualizarProduto atualiza produtos_insumos ao mudar codigo', async () => {
   const { adicionarProduto, atualizarProduto, pool } = setup();
   const { id } = await adicionarProduto({

--- a/src/js/modals/produto-novo.js
+++ b/src/js/modals/produto-novo.js
@@ -163,13 +163,28 @@
   const registrarBtn = document.getElementById('registrarNovoProduto');
   if(registrarBtn){
     registrarBtn.addEventListener('click', async () => {
-      const nome = nomeInput?.value.trim();
-      const codigo = codigoInput?.value.trim();
-      const ncm = ncmInput?.value.trim().slice(0,8);
-      if(!nome || !codigo){
-        showToast('Nome e código são obrigatórios', 'error');
-        return;
+      const campos = [
+        { el: nomeInput, nome: 'Nome' },
+        { el: codigoInput, nome: 'Código' },
+        { el: ncmInput, nome: 'NCM' },
+        { el: fabricacaoInput, nome: 'Marcenaria' },
+        { el: acabamentoInput, nome: 'Acabamento' },
+        { el: montagemInput, nome: 'Montagem' },
+        { el: embalagemInput, nome: 'Embalagem' },
+        { el: markupInput, nome: 'Markup' },
+        { el: commissionInput, nome: 'Comissão' },
+        { el: taxInput, nome: 'Imposto' }
+      ];
+      for(const campo of campos){
+        if(campo.el && String(campo.el.value).trim() === ''){
+          showToast(`${campo.nome} é obrigatório`, 'error');
+          campo.el.focus();
+          return;
+        }
       }
+      const nome = nomeInput.value.trim();
+      const codigo = codigoInput.value.trim();
+      const ncm = ncmInput.value.trim().slice(0,8);
       try{
         const existentes = await window.electronAPI.listarProdutos();
         if(existentes.some(p => p.codigo === codigo)){


### PR DESCRIPTION
## Summary
- Validate required fields server-side for product creation
- Ensure product form fields are filled and show specific missing field messages
- Add tests for missing field validations

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f91030f0c8322ad99b41795d6d7d9