### PR TITLE
Improve Product Entry Interface

### DIFF
--- a/src/html/modals/produtos/editar.html
+++ b/src/html/modals/produtos/editar.html
@@ -11,37 +11,11 @@
 
     <div class="flex-1 overflow-y-auto">
       <div class="px-8 py-6 border-b border-white/10">
-        <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mb-6">
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
           <div>
-            <p class="text-sm text-gray-400 mb-3">Opções de Atualização</p>
-            <div class="space-y-2">
-              <label class="flex items-center gap-2 text-sm text-gray-300">
-                <input type="radio" name="updateOption" value="update" checked class="text-primary focus:ring-primary/50" />
-                Atualizar Tabela Fixa
-              </label>
-              <label class="flex items-center gap-2 text-sm text-gray-300">
-                <input type="radio" name="updateOption" value="noUpdate" class="text-primary focus:ring-primary/50" />
-                Não Atualizar Tabela Fixa
-              </label>
-            </div>
-            <p class="text-sm text-gray-400 mb-3 mt-6">Status</p>
-            <div class="space-y-2">
-              <label class="flex items-center gap-2 text-sm text-gray-300">
-                <input type="radio" name="statusOption" value="Em linha" class="text-primary focus:ring-primary/50" />
-                Em Linha
-              </label>
-              <label class="flex items-center gap-2 text-sm text-gray-300">
-                <input type="radio" name="statusOption" value="Fora de linha" class="text-primary focus:ring-primary/50" />
-                Fora de Linha
-              </label>
-            </div>
-          </div>
-
-          <div class="text-center">
             <p class="text-sm text-gray-400 mb-1">Preço de Venda</p>
             <p id="precoVenda" class="text-3xl font-bold text-white"></p>
           </div>
-
           <div class="text-right">
             <p class="text-sm text-gray-400 mb-1">Data Última Modificação</p>
             <p id="ultimaModificacaoData" class="text-sm text-gray-300"></p>

--- a/src/html/modals/produtos/novo.html
+++ b/src/html/modals/produtos/novo.html
@@ -5,9 +5,10 @@
         ← Voltar
       </button>
       <h2 class="text-lg font-semibold text-white">INSERIR NOVO PRODUTO</h2>
-      <button id="limparNovoProduto" class="btn-danger px-4 py-2 rounded-lg text-white font-medium">
-        Limpar Tudo
-      </button>
+      <div class="flex items-center gap-3">
+        <button id="registrarNovoProduto" class="btn-success px-4 py-2 rounded-lg text-white font-medium">Registrar</button>
+        <button id="limparNovoProduto" class="btn-danger px-4 py-2 rounded-lg text-white font-medium">Limpar Tudo</button>
+      </div>
     </header>
     <div class="flex-1 overflow-y-auto">
       <div class="px-8 py-6 border-b border-white/10">
@@ -45,8 +46,8 @@
         </div>
       </div>
       <div class="px-8 py-6 grid grid-cols-1 xl:grid-cols-2 gap-8">
-        <div class="space-y-6">
-          <div class="bg-surface/40 rounded-xl p-6 border border-white/10">
+        <div class="space-y-6 h-full flex flex-col">
+          <div class="bg-surface/40 rounded-xl p-6 border border-white/10 h-full">
             <h3 class="text-lg font-semibold mb-4 text-white">PERCENTAGENS</h3>
             <div class="space-y-4">
               <div class="flex justify-between items-center">
@@ -80,10 +81,10 @@
             </div>
           </div>
         </div>
-        <div class="space-y-6">
-          <div class="bg-surface/40 rounded-xl p-6 border border-white/10">
+        <div class="space-y-6 h-full flex flex-col">
+          <div class="bg-surface/40 rounded-xl p-6 border border-white/10 h-full">
             <h3 class="text-lg font-semibold mb-4 text-white">SOMAS</h3>
-            <div class="space-y-3 text-sm">
+            <div class="space-y-3 text-sm flex-1">
               <div class="flex justify-between">
                 <span class="text-gray-300">Total Insumos</span>
                 <span id="totalInsumos" class="text-white font-medium">R$ 0,00</span>
@@ -112,31 +113,36 @@
                 <span class="text-gray-300">Imposto</span>
                 <span id="impostoValor" class="text-white font-medium">R$ 0,00</span>
               </div>
+              <div class="flex justify-between border-t border-white/10 pt-3">
+                <span class="text-gray-300">Valor de Venda da Peça</span>
+                <span id="valorVenda" class="text-white font-semibold">R$ 0,00</span>
+              </div>
             </div>
-          </div>
-          <div class="flex items-end justify-end">
-            <button id="registrarNovoProduto" class="btn-success px-8 py-4 rounded-xl font-semibold text-lg">
-              Registrar
-            </button>
           </div>
         </div>
       </div>
       <div class="px-8 py-6 border-t border-white/10">
         <div class="bg-surface/40 rounded-xl p-6 border border-white/10">
-          <h3 class="text-lg font-semibold mb-4 text-white">ITENS</h3>
-          <div class="overflow-x-auto">
-            <div class="max-h-64 overflow-y-auto">
-              <table id="itensTabela" class="w-full text-sm">
-                <thead class="sticky top-0 bg-surface/60 backdrop-blur-sm">
-                  <tr class="border-b border-white/10">
-                    <th class="text-left py-3 px-2 text-gray-300 font-medium">NOME DO ITEM</th>
-                    <th class="text-center py-3 px-2 text-gray-300 font-medium">QUANTIDADE</th>
-                    <th class="text-right py-3 px-2 text-gray-300 font-medium">VALOR TOTAL</th>
-                    <th class="text-center py-3 px-2 text-gray-300 font-medium">AÇÃO</th>
-                  </tr>
-                </thead>
-                <tbody></tbody>
-              </table>
+          <div class="flex items-center justify-between mb-4">
+            <h3 class="text-lg font-semibold text-white">ITENS</h3>
+            <span id="totalInsumosTitulo" class="flex flex-wrap justify-end gap-2"></span>
+          </div>
+          <div class="glass-surface rounded-xl shadow-lg animate-fade-in-up mt-6 overflow-hidden">
+            <div class="overflow-x-auto">
+              <div class="max-h-64 overflow-y-auto">
+                <table id="itensTabela" class="w-full text-sm">
+                  <thead class="bg-gray-50 sticky top-0">
+                    <tr class="border-b border-gray-200">
+                      <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">NOME DO ITEM</th>
+                      <th class="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">QUANTIDADE</th>
+                      <th class="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">UNIDADE</th>
+                      <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">VALOR TOTAL</th>
+                      <th class="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">AÇÃO</th>
+                    </tr>
+                  </thead>
+                  <tbody></tbody>
+                </table>
+              </div>
             </div>
           </div>
           <!-- Observações removidas -->

--- a/src/js/modals/produto-editar.js
+++ b/src/js/modals/produto-editar.js
@@ -417,6 +417,7 @@
           pct_imposto:    parseFloat(taxInput && taxInput.value) || 0,
           preco_base:     totals.totalInsumos || 0,
           preco_venda:    totals.valorVenda   || 0,
+          status: produtoSelecionado.status,
           data: new Date().toISOString()
         };
         if(editarRegistroToggle && editarRegistroToggle.checked){
@@ -426,8 +427,6 @@
           }
           if (codigoInput) produto.codigo = codigoInput.value;
           if (ncmInput)    produto.ncm    = ncmInput.value.slice(0,8);
-          const st = statusRadios.find(r => r.checked);
-          if(st) produto.status = st.value;
         }
         const itensPayload = {
           inseridos: itens
@@ -453,7 +452,7 @@
             nome:   nomeInput ? nomeInput.value   : '',
             codigo: codigoInput ? codigoInput.value : '',
             ncm:    ncmInput ? ncmInput.value    : '',
-            status: (statusRadios.find(r => r.checked)?.value) || ''
+            status: produto.status
           };
           if(typeof carregarProdutos === 'function') await carregarProdutos();
           showToast('Peça alterada com sucesso!', 'success');


### PR DESCRIPTION
## Summary
- Move "Registrar" to header, align totals with percentages, and extend item table with unit column and tags
- Simplify edit product modal by removing update and status options and aligning layout
- Preserve product status when saving edits and ensure process select defaults to first option

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f93013d688322b09a713b26d063ab