### PR TITLE
Padronizar os modais de Editar Orçamento e Novo Orçamento

### DIFF
--- a/src/html/modals/orcamentos/editar.html
+++ b/src/html/modals/orcamentos/editar.html
@@ -2,97 +2,108 @@
   <div role="dialog" aria-modal="true" tabindex="0" class="w-full max-w-5xl max-h-[90vh] glass-surface backdrop-blur-xl rounded-3xl border border-white/10 ring-1 ring-white/5 shadow-2xl/40 animate-modalFade slide-in overflow-hidden flex flex-col">
     <header class="flex items-center justify-between px-8 py-5 border-b border-white/10 flex-shrink-0">
       <button id="voltarEditarOrcamento" class="btn-neutral px-4 py-2 rounded-lg text-white font-medium flex items-center gap-2">← Voltar</button>
-      <h2 id="tituloEditarOrcamento" class="text-lg font-semibold text-white">EDITAR ORÇAMENTO</h2>
+      <h2 id="tituloEditarOrcamento" class="flex-1 text-lg font-semibold text-white text-center mx-4">EDITAR ORÇAMENTO</h2>
       <div class="flex items-center gap-3">
-        <button id="salvarOrcamento" class="btn-success px-4 py-2 rounded-lg text-white font-medium">Salvar</button>
-        <button id="salvarFecharOrcamento" class="btn-secondary px-4 py-2 rounded-lg text-white font-medium">Salvar e Fechar</button>
-        <button id="converterOrcamento" class="btn-success px-4 py-2 rounded-lg font-medium">Converter em Pedido</button>
-        <button id="cancelarOrcamento" class="btn-neutral px-4 py-2 rounded-lg text-white font-medium">Cancelar</button>
+        <button id="salvarOrcamento" class="btn-primary px-4 py-2 rounded-lg text-white font-medium">Salvar</button>
+        <button id="fecharEditarOrcamento" class="btn-neutral icon-only text-white" aria-label="Fechar">✕</button>
       </div>
     </header>
-    <div class="flex-1 overflow-y-auto p-8 space-y-6">
-      <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-        <div>
-          <label class="block text-sm font-medium text-gray-300 mb-2">Cliente</label>
-          <input id="editarCliente" type="text" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+    <div class="flex-1 overflow-y-auto">
+      <div class="px-8 py-6 space-y-6">
+        <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+          <div class="relative">
+            <input id="editarCliente" type="text" placeholder=" " class="peer w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-transparent focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+            <label for="editarCliente" class="absolute left-4 top-1/2 -translate-y-1/2 text-base text-gray-300 pointer-events-none transition-all duration-150 peer-placeholder-shown:top-1/2 peer-placeholder-shown:-translate-y-1/2 peer-placeholder-shown:text-base peer-focus:top-0 peer-focus:-translate-y-full peer-focus:text-xs peer-focus:text-primary peer-valid:top-0 peer-valid:-translate-y-full peer-valid:text-xs">Cliente</label>
+          </div>
+          <div class="relative">
+            <input id="editarContato" type="text" placeholder=" " class="peer w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-transparent focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+            <label for="editarContato" class="absolute left-4 top-1/2 -translate-y-1/2 text-base text-gray-300 pointer-events-none transition-all duration-150 peer-placeholder-shown:top-1/2 peer-placeholder-shown:-translate-y-1/2 peer-placeholder-shown:text-base peer-focus:top-0 peer-focus:-translate-y-full peer-focus:text-xs peer-focus:text-primary peer-valid:top-0 peer-valid:-translate-y-full peer-valid:text-xs">Contato</label>
+          </div>
+          <div class="relative">
+            <input id="editarValidade" type="date" placeholder=" " class="peer w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+            <label for="editarValidade" class="absolute left-4 top-1/2 -translate-y-1/2 text-base text-gray-300 pointer-events-none transition-all duration-150 peer-focus:top-0 peer-focus:-translate-y-full peer-focus:text-xs peer-focus:text-primary peer-valid:top-0 peer-valid:-translate-y-full peer-valid:text-xs">Validade</label>
+            <i class="fas fa-calendar-alt absolute right-4 top-1/2 -translate-y-1/2 text-gray-300 pointer-events-none"></i>
+          </div>
+          <div class="relative">
+            <select id="editarCondicao" class="peer w-full appearance-none bg-input border border-inputBorder rounded-lg px-4 pr-12 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition" data-filled="false">
+              <option value="vista">À vista</option>
+              <option value="prazo">À prazo</option>
+            </select>
+            <label for="editarCondicao" class="absolute left-4 top-1/2 -translate-y-1/2 text-base text-gray-300 pointer-events-none transition-all duration-150 peer-focus:top-0 peer-focus:-translate-y-full peer-focus:text-xs peer-focus:text-primary peer-data-[filled=true]:top-0 peer-data-[filled=true]:-translate-y-full peer-data-[filled=true]:text-xs">Condição de pagamento</label>
+            <i class="fas fa-chevron-down absolute right-4 top-1/2 -translate-y-1/2 text-gray-300 pointer-events-none"></i>
+          </div>
+          <div class="relative">
+            <select id="editarStatus" class="peer w-full appearance-none bg-input border border-inputBorder rounded-lg px-4 pr-12 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition" data-filled="false">
+              <option value="rascunho">Rascunho</option>
+              <option value="aberto">Aberto</option>
+              <option value="enviado">Enviado</option>
+              <option value="aprovado">Aprovado</option>
+              <option value="recusado">Recusado</option>
+            </select>
+            <label for="editarStatus" class="absolute left-4 top-1/2 -translate-y-1/2 text-base text-gray-300 pointer-events-none transition-all duration-150 peer-focus:top-0 peer-focus:-translate-y-full peer-focus:text-xs peer-focus:text-primary peer-data-[filled=true]:top-0 peer-data-[filled=true]:-translate-y-full peer-data-[filled=true]:text-xs">Status</label>
+            <i class="fas fa-chevron-down absolute right-4 top-1/2 -translate-y-1/2 text-gray-300 pointer-events-none"></i>
+          </div>
+          <div class="relative lg:col-span-2">
+            <textarea id="editarObservacoes" rows="2" placeholder=" " class="peer w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-transparent focus:border-primary focus:ring-2 focus:ring-primary/50 transition"></textarea>
+            <label for="editarObservacoes" class="absolute left-4 top-3 text-base text-gray-300 pointer-events-none transition-all duration-150 peer-placeholder-shown:top-3 peer-placeholder-shown:text-base peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary peer-valid:-top-2 peer-valid:text-xs">Observações</label>
+          </div>
         </div>
-        <div>
-          <label class="block text-sm font-medium text-gray-300 mb-2">Contato</label>
-          <input id="editarContato" type="text" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
-        </div>
-        <div>
-          <label class="block text-sm font-medium text-gray-300 mb-2">Validade</label>
-          <input id="editarValidade" type="date" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
-        </div>
-        <div>
-          <label class="block text-sm font-medium text-gray-300 mb-2">Condição de pagamento</label>
-          <select id="editarCondicao" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition select-arrow appearance-none">
-            <option value="vista">À vista</option>
-            <option value="prazo">À prazo</option>
-          </select>
-        </div>
-        <div>
-          <label class="block text-sm font-medium text-gray-300 mb-2">Status</label>
-          <select id="editarStatus" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition select-arrow appearance-none">
-            <option value="rascunho">Rascunho</option>
-            <option value="aberto">Aberto</option>
-            <option value="enviado">Enviado</option>
-            <option value="aprovado">Aprovado</option>
-            <option value="recusado">Recusado</option>
-          </select>
-        </div>
-        <div class="md:col-span-2">
-          <label class="block text-sm font-medium text-gray-300 mb-2">Observações</label>
-          <textarea id="editarObservacoes" rows="2" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition"></textarea>
-        </div>
-      </div>
 
-      <div>
-        <h3 class="text-lg font-semibold mb-4 text-white">Itens</h3>
-        <!-- manipulação de itens -->
-        <div class="grid grid-cols-1 md:grid-cols-5 gap-4 mb-4 items-end">
-          <div class="md:col-span-2">
-            <input id="novoItemNome" type="text" placeholder="Produto" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+        <div>
+          <h3 class="text-lg font-semibold mb-4 text-white">Itens</h3>
+          <div class="grid grid-cols-1 lg:grid-cols-5 gap-4 mb-4 items-end">
+            <div class="lg:col-span-2 relative">
+              <input id="novoItemNome" type="text" placeholder="Produto" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+            </div>
+            <div class="relative">
+              <input id="novoItemQtd" type="number" min="1" value="1" placeholder=" " class="peer w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-transparent focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+              <label for="novoItemQtd" class="absolute left-4 top-1/2 -translate-y-1/2 text-base text-gray-300 pointer-events-none transition-all duration-150 peer-placeholder-shown:top-1/2 peer-placeholder-shown:-translate-y-1/2 peer-placeholder-shown:text-base peer-focus:top-0 peer-focus:-translate-y-full peer-focus:text-xs peer-focus:text-primary peer-valid:top-0 peer-valid:-translate-y-full peer-valid:text-xs">Quantidade</label>
+            </div>
+            <div class="relative">
+              <input id="novoItemValor" type="number" min="0" step="0.01" placeholder=" " class="peer w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-transparent text-right focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+              <label for="novoItemValor" class="absolute left-4 top-1/2 -translate-y-1/2 text-base text-gray-300 pointer-events-none transition-all duration-150 peer-placeholder-shown:top-1/2 peer-placeholder-shown:-translate-y-1/2 peer-placeholder-shown:text-base peer-focus:top-0 peer-focus:-translate-y-full peer-focus:text-xs peer-focus:text-primary peer-valid:top-0 peer-valid:-translate-y-full peer-valid:text-xs">Valor Unit. (R$)</label>
+            </div>
+            <div class="relative">
+              <input id="novoItemDesc" type="number" min="0" value="0" placeholder=" " class="peer w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-transparent text-right focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+              <label for="novoItemDesc" class="absolute left-4 top-1/2 -translate-y-1/2 text-base text-gray-300 pointer-events-none transition-all duration-150 peer-placeholder-shown:top-1/2 peer-placeholder-shown:-translate-y-1/2 peer-placeholder-shown:text-base peer-focus:top-0 peer-focus:-translate-y-full peer-focus:text-xs peer-focus:text-primary peer-valid:top-0 peer-valid:-translate-y-full peer-valid:text-xs">Desc. %</label>
+            </div>
+            <div>
+              <button id="adicionarItem" class="w-full btn-primary px-4 py-3 rounded-lg font-medium">+ Inserir</button>
+            </div>
           </div>
-          <div>
-            <input id="novoItemQtd" type="number" min="1" value="1" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
-          </div>
-          <div>
-            <input id="novoItemValor" type="number" min="0" step="0.01" placeholder="0,00" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
-          </div>
-          <div>
-            <input id="novoItemDesc" type="number" min="0" value="0" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
-          </div>
-          <div>
-            <button id="adicionarItem" class="w-full btn-success px-4 py-3 rounded-lg font-medium">+ Inserir</button>
-          </div>
-        </div>
 
           <div class="glass-surface rounded-xl shadow-lg animate-fade-in-up overflow-hidden">
             <div class="overflow-x-auto">
               <div class="max-h-64 overflow-y-auto">
                 <table id="orcamentoItens" class="w-full text-sm">
-                  <thead class="bg-gray-50 sticky top-0">
-                    <tr class="border-b border-gray-200">
-                      <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">ITEM</th>
-                      <th class="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">QTD</th>
-                      <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">VALOR UNIT. (R$)</th>
-                      <th class="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">DESC. %</th>
-                      <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">TOTAL (R$)</th>
-                      <th class="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">AÇÕES</th>
+                  <thead class="sticky top-0 bg-surface/60 backdrop-blur-sm">
+                    <tr class="border-b border-white/10">
+                      <th class="py-3 px-2 text-left text-gray-300 font-medium">ITEM</th>
+                      <th class="py-3 px-2 text-center text-gray-300 font-medium">QTD</th>
+                      <th class="py-3 px-2 text-right text-gray-300 font-medium">VALOR UNIT. (R$)</th>
+                      <th class="py-3 px-2 text-center text-gray-300 font-medium">DESC. %</th>
+                      <th class="py-3 px-2 text-right text-gray-300 font-medium">TOTAL (R$)</th>
+                      <th class="py-3 px-2 text-center text-gray-300 font-medium">AÇÕES</th>
                     </tr>
                   </thead>
                   <tbody></tbody>
                 </table>
               </div>
             </div>
-            <div class="flex justify-end gap-8 mt-4 text-sm p-4">
-              <div class="text-gray-300">Subtotal: <span id="subtotalOrcamento">R$ 0,00</span></div>
-              <div class="text-gray-300">Desconto: <span id="descontoOrcamento">R$ 0,00</span></div>
-              <div class="text-white font-semibold">Total: <span id="totalOrcamento">R$ 0,00</span></div>
+            <div class="flex flex-wrap justify-end gap-2 mt-4 p-4 text-sm">
+              <span class="badge-neutral px-3 py-1 rounded-full font-medium">Subtotal: <span id="subtotalOrcamento">R$ 0,00</span></span>
+              <span class="badge-danger px-3 py-1 rounded-full font-medium">Desconto: <span id="descontoOrcamento">R$ 0,00</span></span>
+              <span class="badge-success px-3 py-1 rounded-full font-medium">Total: <span id="totalOrcamento">R$ 0,00</span></span>
             </div>
           </div>
+        </div>
       </div>
     </div>
+    <footer class="flex justify-end gap-3 px-8 py-6 border-t border-white/10 flex-shrink-0">
+      <button id="salvarFecharOrcamento" class="btn-neutral px-4 py-2 rounded-lg text-white font-medium">Salvar e Fechar</button>
+      <button id="converterOrcamento" class="btn-secondary px-4 py-2 rounded-lg text-white font-medium">Converter em Pedido</button>
+      <button id="cancelarOrcamento" class="btn-danger-light px-4 py-2 rounded-lg font-medium">Cancelar</button>
+    </footer>
   </div>
 </div>
+

--- a/src/html/modals/orcamentos/novo.html
+++ b/src/html/modals/orcamentos/novo.html
@@ -2,95 +2,111 @@
   <div role="dialog" aria-modal="true" tabindex="0" class="w-full max-w-5xl max-h-[90vh] glass-surface backdrop-blur-xl rounded-3xl border border-white/10 ring-1 ring-white/5 shadow-2xl/40 animate-modalFade slide-in overflow-hidden flex flex-col">
     <header class="flex items-center justify-between px-8 py-5 border-b border-white/10 flex-shrink-0">
       <button id="voltarNovoOrcamento" class="btn-neutral px-4 py-2 rounded-lg text-white font-medium flex items-center gap-2">← Voltar</button>
-      <h2 class="text-lg font-semibold text-white">NOVO ORÇAMENTO</h2>
+      <h2 class="flex-1 text-lg font-semibold text-white text-center mx-4">NOVO ORÇAMENTO</h2>
       <div class="flex items-center gap-3">
-        <button id="salvarNovoOrcamento" class="btn-success px-4 py-2 rounded-lg text-white font-medium">Salvar</button>
-        <button id="enviarNovoOrcamento" class="btn-secondary px-4 py-2 rounded-lg text-white font-medium">Salvar e Enviar</button>
-        <button id="cancelarNovoOrcamento" class="btn-neutral px-4 py-2 rounded-lg text-white font-medium">Cancelar</button>
-        <button id="limparNovoOrcamento" class="btn-danger px-4 py-2 rounded-lg text-white font-medium">Limpar Tudo</button>
+        <button id="salvarNovoOrcamento" class="btn-primary px-4 py-2 rounded-lg text-white font-medium">Salvar</button>
+        <button id="limparNovoOrcamento" class="btn-danger-light px-4 py-2 rounded-lg font-medium">Limpar Tudo</button>
+        <button id="fecharNovoOrcamento" class="btn-neutral icon-only text-white" aria-label="Fechar">✕</button>
       </div>
     </header>
-    <div class="flex-1 overflow-y-auto p-8 space-y-6">
-      <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-        <div>
-          <label class="block text-sm font-medium text-gray-300 mb-2">Cliente</label>
-          <select id="novoCliente" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition select-arrow appearance-none">
-            <option value="">Selecione um cliente</option>
-            <option value="joao-silva">João Silva</option>
-            <option value="maria-santos">Maria Santos</option>
-            <option value="pedro-oliveira">Pedro Oliveira</option>
-            <option value="ana-costa">Ana Costa</option>
-          </select>
-        </div>
-        <div>
-          <label class="block text-sm font-medium text-gray-300 mb-2">Contato</label>
-          <select id="novoContato" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition select-arrow appearance-none">
-            <option value="">Selecione um contato</option>
-          </select>
-        </div>
-        <div>
-          <label class="block text-sm font-medium text-gray-300 mb-2">Validade</label>
-          <input id="novoValidade" type="date" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
-        </div>
-        <div>
-          <label class="block text-sm font-medium text-gray-300 mb-2">Condição de pagamento</label>
-          <select id="novoCondicao" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition select-arrow appearance-none">
-            <option value="vista">À vista</option>
-            <option value="prazo">À prazo</option>
-          </select>
-        </div>
-        <div class="md:col-span-2">
-          <label class="block text-sm font-medium text-gray-300 mb-2">Observações</label>
-          <textarea id="novoObservacoes" rows="2" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition"></textarea>
-        </div>
-      </div>
-      <div>
-        <h3 class="text-lg font-semibold mb-4 text-white">Itens</h3>
-        <div class="grid grid-cols-1 md:grid-cols-5 gap-4 mb-4 items-end">
-          <div class="md:col-span-2">
-            <select id="itemProduto" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition select-arrow appearance-none">
-              <option value="">Selecione um produto</option>
-              <option value="mesa-paris">Mesa de Jantar Modelo Paris</option>
-              <option value="cadeira-colonial">Cadeira Colonial Estofada</option>
-              <option value="armario-rustico">Armário Rústico 6 Portas</option>
-              <option value="mesa-centro">Mesa de Centro Redonda</option>
+    <div class="flex-1 overflow-y-auto">
+      <div class="px-8 py-6 space-y-6">
+        <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+          <div class="relative">
+            <select id="novoCliente" class="peer w-full appearance-none bg-input border border-inputBorder rounded-lg px-4 pr-12 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition" data-filled="false">
+              <option value="" disabled selected hidden></option>
+              <option value="joao-silva">João Silva</option>
+              <option value="maria-santos">Maria Santos</option>
+              <option value="pedro-oliveira">Pedro Oliveira</option>
+              <option value="ana-costa">Ana Costa</option>
             </select>
+            <label for="novoCliente" class="absolute left-4 top-1/2 -translate-y-1/2 text-base text-gray-300 pointer-events-none transition-all duration-150 peer-focus:top-0 peer-focus:-translate-y-full peer-focus:text-xs peer-focus:text-primary peer-data-[filled=true]:top-0 peer-data-[filled=true]:-translate-y-full peer-data-[filled=true]:text-xs">Cliente</label>
+            <i class="fas fa-chevron-down absolute right-4 top-1/2 -translate-y-1/2 text-gray-300 pointer-events-none"></i>
           </div>
-          <div>
-            <input id="itemQtd" type="number" min="1" value="1" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+          <div class="relative">
+            <select id="novoContato" class="peer w-full appearance-none bg-input border border-inputBorder rounded-lg px-4 pr-12 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition" data-filled="false">
+              <option value="" disabled selected hidden></option>
+            </select>
+            <label for="novoContato" class="absolute left-4 top-1/2 -translate-y-1/2 text-base text-gray-300 pointer-events-none transition-all duration-150 peer-focus:top-0 peer-focus:-translate-y-full peer-focus:text-xs peer-focus:text-primary peer-data-[filled=true]:top-0 peer-data-[filled=true]:-translate-y-full peer-data-[filled=true]:text-xs">Contato</label>
+            <i class="fas fa-chevron-down absolute right-4 top-1/2 -translate-y-1/2 text-gray-300 pointer-events-none"></i>
           </div>
-          <div>
-            <input id="itemDesc" type="number" min="0" value="0" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+          <div class="relative">
+            <input id="novoValidade" type="date" placeholder=" " class="peer w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+            <label for="novoValidade" class="absolute left-4 top-1/2 -translate-y-1/2 text-base text-gray-300 pointer-events-none transition-all duration-150 peer-focus:top-0 peer-focus:-translate-y-full peer-focus:text-xs peer-focus:text-primary peer-valid:top-0 peer-valid:-translate-y-full peer-valid:text-xs">Validade</label>
+            <i class="fas fa-calendar-alt absolute right-4 top-1/2 -translate-y-1/2 text-gray-300 pointer-events-none"></i>
           </div>
-          <div>
-            <button id="adicionarItemNovo" class="w-full btn-success px-4 py-3 rounded-lg font-medium">+ Inserir</button>
+          <div class="relative">
+            <select id="novoCondicao" class="peer w-full appearance-none bg-input border border-inputBorder rounded-lg px-4 pr-12 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition" data-filled="false">
+              <option value="vista">À vista</option>
+              <option value="prazo">À prazo</option>
+            </select>
+            <label for="novoCondicao" class="absolute left-4 top-1/2 -translate-y-1/2 text-base text-gray-300 pointer-events-none transition-all duration-150 peer-focus:top-0 peer-focus:-translate-y-full peer-focus:text-xs peer-focus:text-primary peer-data-[filled=true]:top-0 peer-data-[filled=true]:-translate-y-full peer-data-[filled=true]:text-xs">Condição de pagamento</label>
+            <i class="fas fa-chevron-down absolute right-4 top-1/2 -translate-y-1/2 text-gray-300 pointer-events-none"></i>
+          </div>
+          <div class="relative lg:col-span-2">
+            <textarea id="novoObservacoes" rows="2" placeholder=" " class="peer w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-transparent focus:border-primary focus:ring-2 focus:ring-primary/50 transition"></textarea>
+            <label for="novoObservacoes" class="absolute left-4 top-3 text-base text-gray-300 pointer-events-none transition-all duration-150 peer-placeholder-shown:top-3 peer-placeholder-shown:text-base peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary peer-valid:-top-2 peer-valid:text-xs">Observações</label>
           </div>
         </div>
+
+        <div>
+          <h3 class="text-lg font-semibold mb-4 text-white">Itens</h3>
+          <div class="grid grid-cols-1 lg:grid-cols-5 gap-4 mb-4 items-end">
+            <div class="lg:col-span-2 relative">
+              <select id="itemProduto" class="peer w-full appearance-none bg-input border border-inputBorder rounded-lg px-4 pr-12 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition" data-filled="false">
+                <option value="" disabled selected hidden></option>
+                <option value="mesa-paris">Mesa de Jantar Modelo Paris</option>
+                <option value="cadeira-colonial">Cadeira Colonial Estofada</option>
+                <option value="armario-rustico">Armário Rústico 6 Portas</option>
+                <option value="mesa-centro">Mesa de Centro Redonda</option>
+              </select>
+              <label for="itemProduto" class="absolute left-4 top-1/2 -translate-y-1/2 text-base text-gray-300 pointer-events-none transition-all duration-150 peer-focus:top-0 peer-focus:-translate-y-full peer-focus:text-xs peer-focus:text-primary peer-data-[filled=true]:top-0 peer-data-[filled=true]:-translate-y-full peer-data-[filled=true]:text-xs">Produto</label>
+              <i class="fas fa-chevron-down absolute right-4 top-1/2 -translate-y-1/2 text-gray-300 pointer-events-none"></i>
+            </div>
+            <div class="relative">
+              <input id="itemQtd" type="number" min="1" value="1" placeholder=" " class="peer w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-transparent focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+              <label for="itemQtd" class="absolute left-4 top-1/2 -translate-y-1/2 text-base text-gray-300 pointer-events-none transition-all duration-150 peer-placeholder-shown:top-1/2 peer-placeholder-shown:-translate-y-1/2 peer-placeholder-shown:text-base peer-focus:top-0 peer-focus:-translate-y-full peer-focus:text-xs peer-focus:text-primary peer-valid:top-0 peer-valid:-translate-y-full peer-valid:text-xs">Quantidade</label>
+            </div>
+            <div class="relative">
+              <input id="itemDesc" type="number" min="0" value="0" placeholder=" " class="peer w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-transparent text-right focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+              <label for="itemDesc" class="absolute left-4 top-1/2 -translate-y-1/2 text-base text-gray-300 pointer-events-none transition-all duration-150 peer-placeholder-shown:top-1/2 peer-placeholder-shown:-translate-y-1/2 peer-placeholder-shown:text-base peer-focus:top-0 peer-focus:-translate-y-full peer-focus:text-xs peer-focus:text-primary peer-valid:top-0 peer-valid:-translate-y-full peer-valid:text-xs">Desc. %</label>
+            </div>
+            <div>
+              <button id="adicionarItemNovo" class="w-full btn-primary px-4 py-3 rounded-lg font-medium">+ Inserir</button>
+            </div>
+          </div>
+
           <div class="glass-surface rounded-xl shadow-lg animate-fade-in-up overflow-hidden">
             <div class="overflow-x-auto">
               <div class="max-h-64 overflow-y-auto">
                 <table id="novoItensTabela" class="w-full text-sm">
-                  <thead class="bg-gray-50 sticky top-0">
-                    <tr class="border-b border-gray-200">
-                      <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">ITEM</th>
-                      <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">VALOR UNIT. (R$)</th>
-                      <th class="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">QTD</th>
-                      <th class="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">DESC. %</th>
-                      <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">TOTAL (R$)</th>
-                      <th class="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">AÇÕES</th>
+                  <thead class="sticky top-0 bg-surface/60 backdrop-blur-sm">
+                    <tr class="border-b border-white/10">
+                      <th class="py-3 px-2 text-left text-gray-300 font-medium">ITEM</th>
+                      <th class="py-3 px-2 text-right text-gray-300 font-medium">VALOR UNIT. (R$)</th>
+                      <th class="py-3 px-2 text-center text-gray-300 font-medium">QTD</th>
+                      <th class="py-3 px-2 text-center text-gray-300 font-medium">DESC. %</th>
+                      <th class="py-3 px-2 text-right text-gray-300 font-medium">TOTAL (R$)</th>
+                      <th class="py-3 px-2 text-center text-gray-300 font-medium">AÇÕES</th>
                     </tr>
                   </thead>
                   <tbody></tbody>
                 </table>
               </div>
             </div>
-            <div class="flex justify-end gap-8 mt-4 text-sm p-4">
-              <div class="text-gray-300">Subtotal: <span id="novoSubtotal">R$ 0,00</span></div>
-              <div class="text-gray-300">Desconto: <span id="novoDesconto">R$ 0,00</span></div>
-              <div class="text-white font-semibold">Total: <span id="novoTotal">R$ 0,00</span></div>
+            <div class="flex flex-wrap justify-end gap-2 mt-4 p-4 text-sm">
+              <span class="badge-neutral px-3 py-1 rounded-full font-medium">Subtotal: <span id="novoSubtotal">R$ 0,00</span></span>
+              <span class="badge-danger px-3 py-1 rounded-full font-medium">Desconto: <span id="novoDesconto">R$ 0,00</span></span>
+              <span class="badge-success px-3 py-1 rounded-full font-medium">Total: <span id="novoTotal">R$ 0,00</span></span>
             </div>
           </div>
+        </div>
       </div>
     </div>
+    <footer class="flex justify-end gap-3 px-8 py-6 border-t border-white/10 flex-shrink-0">
+      <button id="enviarNovoOrcamento" class="btn-secondary px-4 py-2 rounded-lg text-white font-medium">Salvar e Enviar</button>
+      <button id="cancelarNovoOrcamento" class="btn-danger-light px-4 py-2 rounded-lg font-medium">Cancelar</button>
+    </footer>
   </div>
 </div>
+


### PR DESCRIPTION
## Summary
- Padroniza modais de edição e criação de orçamentos com casca e componentes dos modais de produtos
- Ajusta layout de inputs, tabela de itens e chips de totais, adicionando footer fixo com ações

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f933530908322829e92d1bf56985f