### PR TITLE
Reposition budget button and standardize filters

### DIFF
--- a/src/css/orcamentos.css
+++ b/src/css/orcamentos.css
@@ -35,6 +35,25 @@ body {
     transform: scale(1.05);
 }
 
+.btn-secondary {
+    background: var(--color-blue);
+    transition: all 150ms ease;
+}
+
+.btn-secondary:hover {
+    background: rgba(138, 167, 243, 0.9);
+}
+
+.btn-warning {
+    background: var(--color-bordeaux);
+    transition: all 150ms ease;
+}
+
+.btn-warning:hover {
+    background: rgba(106, 21, 44, 0.8);
+    transform: scale(1.05);
+}
+
 .badge-success {
     background: rgba(162, 255, 166, 0.2);
     color: var(--color-green);
@@ -84,30 +103,25 @@ body {
     }
 }
 
-/* Agrupamento vendedor/botão */
-.seller-actions {
-    display: flex;
-    align-items: center;
+/* Barra de filtros responsiva */
+.filter-bar {
     gap: 24px;
+    flex-wrap: nowrap;
 }
 
-.seller-actions select,
-.seller-actions button {
-    height: 48px;
-    box-sizing: border-box;
-}
-
-.seller-actions button {
-    margin-left: auto;
-}
-
-@media (max-width: 600px) {
-    .seller-actions { /* empilhamento mobile */
+@media (max-width: 767px) {
+    .filter-bar {
         flex-direction: column;
         align-items: stretch;
     }
-    .seller-actions button {
-        margin-left: 0;
-        width: 100%;
-    }
 }
+
+/* Ajusta altura da tabela e ações de filtro */
+.table-scroll {
+    max-height: calc(var(--module-height) - 260px) !important;
+}
+
+#bt-actions {
+    margin-top: 1vw;
+}
+

--- a/src/html/orcamentos.html
+++ b/src/html/orcamentos.html
@@ -1,51 +1,70 @@
 <!-- Página de orçamentos: lista e filtros -->
 <div>
     <!-- Header -->
-    <div class="mb-8 animate-fade-in-up">
-        <h1 class="text-2xl font-semibold mb-2">Orçamentos</h1>
-        <p style="color: var(--color-violet)">Gerencie propostas comerciais e acompanhe negociações</p>
+    <div class="flex justify-between items-center mb-8 animate-fade-in-up">
+        <div>
+            <h1 class="text-2xl font-semibold mb-2">Orçamentos</h1>
+            <p style="color: var(--color-violet)">Gerencie propostas comerciais e acompanhe negociações</p>
+        </div>
+        <button id="novoOrcamentoBtn" class="btn-primary text-white rounded-md px-6 py-3 font-medium">
+            <i class="fas fa-plus mr-2"></i>Novo Orçamento
+        </button>
     </div>
 
     <!-- Filters -->
     <div class="glass-surface rounded-xl p-6 mb-6 animate-fade-in-up">
-        <div class="flex flex-wrap xl:flex-nowrap items-center gap-4">
+        <div class="filter-bar flex flex-col md:flex-row md:flex-nowrap items-center">
             <!-- Status Filter -->
-            <div class="flex-1 min-w-[180px]">
+            <div class="flex-1 min-w-0">
                 <label class="block text-sm font-medium mb-2 text-white">Status</label>
-                <select class="input-glass text-white rounded-md px-4 py-3 w-full">
-                    <option>Todos os Status</option>
-                    <option>Pendente</option>
-                    <option>Aprovado</option>
-                    <option>Rejeitado</option>
-                    <option>Expirado</option>
+                <select id="filterStatus" class="input-glass text-white rounded-md px-4 py-3 w-full">
+                    <option value="">Todos os Status</option>
+                    <option value="Pendente">Pendente</option>
+                    <option value="Aprovado">Aprovado</option>
+                    <option value="Rejeitado">Rejeitado</option>
+                    <option value="Expirado">Expirado</option>
                 </select>
             </div>
 
             <!-- Period Filter -->
-            <div class="flex-1 min-w-[150px]">
+            <div class="flex-1 min-w-0">
                 <label class="block text-sm font-medium mb-2 text-white">Período</label>
-                <select class="input-glass text-white rounded-md px-4 py-3 w-full">
-                    <option>Mês</option>
-                    <option>Semana</option>
-                    <option>Trimestre</option>
-                    <option>Ano</option>
+                <select id="filterPeriod" class="input-glass text-white rounded-md px-4 py-3 w-full">
+                    <option value="">Todos os Períodos</option>
+                    <option value="Semana">Semana</option>
+                    <option value="Mês">Mês</option>
+                    <option value="Trimestre">Trimestre</option>
+                    <option value="Ano">Ano</option>
                 </select>
             </div>
 
-            <!-- Salesperson Filter + New Quote -->
-            <div class="flex-1 min-w-[200px] seller-actions"><!-- agrupamento vendedor/botão -->
-                <div class="flex-1 min-w-[200px]">
-                    <label class="block text-sm font-medium mb-2 text-white">Vendedor</label>
-                    <select class="input-glass text-white rounded-md px-4 py-3 w-full">
-                        <option>Todos os Vendedores</option>
-                        <option>João Silva</option>
-                        <option>Maria Santos</option>
-                        <option>Pedro Costa</option>
-                    </select>
-                </div>
-                    <button id="novoOrcamentoBtn" class="self-end btn-primary text-white rounded-md px-3 py-3 font-medium whitespace-nowrap">
-                        <i class="fas fa-plus mr-2"></i>Novo Orçamento
-                    </button>
+            <!-- Salesperson Filter -->
+            <div class="flex-1 min-w-0">
+                <label class="block text-sm font-medium mb-2 text-white">Vendedor</label>
+                <select id="filterSeller" class="input-glass text-white rounded-md px-4 py-3 w-full">
+                    <option value="">Todos os Vendedores</option>
+                    <option value="João Silva">João Silva</option>
+                    <option value="Maria Santos">Maria Santos</option>
+                    <option value="Pedro Costa">Pedro Costa</option>
+                </select>
+            </div>
+
+            <!-- Client Filter -->
+            <div class="flex-1 min-w-0">
+                <label class="block text-sm font-medium mb-2 text-white">Cliente</label>
+                <select id="filterClient" class="input-glass text-white rounded-md px-4 py-3 w-full">
+                    <option value="">Todos os Clientes</option>
+                </select>
+            </div>
+
+            <!-- Action Buttons -->
+            <div id="bt-actions" class="flex items-center gap-2 flex-shrink-0">
+                <button id="btnFiltrar" class="btn-secondary text-white rounded-md px-4 py-3 text-sm font-medium">
+                    Filtrar
+                </button>
+                <button id="btnLimpar" class="btn-warning text-white rounded-md px-4 py-3 text-sm font-medium">
+                    Limpar
+                </button>
             </div>
         </div>
     </div>
@@ -66,7 +85,7 @@
             </thead>
             <tbody id="orcamentosTabela" class="divide-y divide-white/10">
                     <!-- Quote 1 -->
-                    <tr class="transition-colors duration-150" style="cursor: pointer;" onmouseover="this.style.background='rgba(163, 148, 167, 0.05)'" onmouseout="this.style.background='transparent'">
+                    <tr data-vendedor="João Silva" class="transition-colors duration-150" style="cursor: pointer;" onmouseover="this.style.background='rgba(163, 148, 167, 0.05)'" onmouseout="this.style.background='transparent'">
                         <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-white">ORC001</td>
                         <td class="px-6 py-4 whitespace-nowrap text-sm text-white">Ana Carolina Mendes</td>
                         <td class="px-6 py-4 whitespace-nowrap text-sm" style="color: var(--color-violet)">15/03/2024</td>
@@ -84,7 +103,7 @@
                         </td>
                     </tr>
                     <!-- Quote 2 -->
-                    <tr class="transition-colors duration-150" style="cursor: pointer;" onmouseover="this.style.background='rgba(163, 148, 167, 0.05)'" onmouseout="this.style.background='transparent'">
+                    <tr data-vendedor="Maria Santos" class="transition-colors duration-150" style="cursor: pointer;" onmouseover="this.style.background='rgba(163, 148, 167, 0.05)'" onmouseout="this.style.background='transparent'">
                         <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-white">ORC002</td>
                         <td class="px-6 py-4 whitespace-nowrap text-sm text-white">Roberto Silva Santos</td>
                         <td class="px-6 py-4 whitespace-nowrap text-sm" style="color: var(--color-violet)">14/03/2024</td>
@@ -102,7 +121,7 @@
                         </td>
                     </tr>
                     <!-- Quote 3 -->
-                    <tr class="transition-colors duration-150" style="cursor: pointer;" onmouseover="this.style.background='rgba(163, 148, 167, 0.05)'" onmouseout="this.style.background='transparent'">
+                    <tr data-vendedor="Pedro Costa" class="transition-colors duration-150" style="cursor: pointer;" onmouseover="this.style.background='rgba(163, 148, 167, 0.05)'" onmouseout="this.style.background='transparent'">
                         <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-white">ORC003</td>
                         <td class="px-6 py-4 whitespace-nowrap text-sm text-white">Empresa ABC Ltda</td>
                         <td class="px-6 py-4 whitespace-nowrap text-sm" style="color: var(--color-violet)">13/03/2024</td>
@@ -120,7 +139,7 @@
                         </td>
                     </tr>
                     <!-- Quote 4 -->
-                    <tr class="transition-colors duration-150" style="cursor: pointer;" onmouseover="this.style.background='rgba(163, 148, 167, 0.05)'" onmouseout="this.style.background='transparent'">
+                    <tr data-vendedor="João Silva" class="transition-colors duration-150" style="cursor: pointer;" onmouseover="this.style.background='rgba(163, 148, 167, 0.05)'" onmouseout="this.style.background='transparent'">
                         <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-white">ORC004</td>
                         <td class="px-6 py-4 whitespace-nowrap text-sm text-white">Mariana Costa Lima</td>
                         <td class="px-6 py-4 whitespace-nowrap text-sm" style="color: var(--color-violet)">12/03/2024</td>
@@ -138,7 +157,7 @@
                         </td>
                     </tr>
                     <!-- Quote 5 -->
-                    <tr class="transition-colors duration-150" style="cursor: pointer;" onmouseover="this.style.background='rgba(163, 148, 167, 0.05)'" onmouseout="this.style.background='transparent'">
+                    <tr data-vendedor="Maria Santos" class="transition-colors duration-150" style="cursor: pointer;" onmouseover="this.style.background='rgba(163, 148, 167, 0.05)'" onmouseout="this.style.background='transparent'">
                         <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-white">ORC005</td>
                         <td class="px-6 py-4 whitespace-nowrap text-sm text-white">Carlos Eduardo Rocha</td>
                         <td class="px-6 py-4 whitespace-nowrap text-sm" style="color: var(--color-violet)">11/03/2024</td>
@@ -156,7 +175,7 @@
                         </td>
                     </tr>
                     <!-- Quote 6 -->
-                    <tr class="transition-colors duration-150" style="cursor: pointer;" onmouseover="this.style.background='rgba(163, 148, 167, 0.05)'" onmouseout="this.style.background='transparent'">
+                    <tr data-vendedor="Pedro Costa" class="transition-colors duration-150" style="cursor: pointer;" onmouseover="this.style.background='rgba(163, 148, 167, 0.05)'" onmouseout="this.style.background='transparent'">
                         <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-white">ORC006</td>
                         <td class="px-6 py-4 whitespace-nowrap text-sm text-white">Fernanda Oliveira</td>
                         <td class="px-6 py-4 whitespace-nowrap text-sm" style="color: var(--color-violet)">10/03/2024</td>
@@ -174,7 +193,7 @@
                         </td>
                     </tr>
                     <!-- Quote 7 -->
-                    <tr class="transition-colors duration-150" style="cursor: pointer;" onmouseover="this.style.background='rgba(163, 148, 167, 0.05)'" onmouseout="this.style.background='transparent'">
+                    <tr data-vendedor="João Silva" class="transition-colors duration-150" style="cursor: pointer;" onmouseover="this.style.background='rgba(163, 148, 167, 0.05)'" onmouseout="this.style.background='transparent'">
                         <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-white">ORC007</td>
                         <td class="px-6 py-4 whitespace-nowrap text-sm text-white">Paulo Henrique Alves</td>
                         <td class="px-6 py-4 whitespace-nowrap text-sm" style="color: var(--color-violet)">09/03/2024</td>
@@ -192,7 +211,7 @@
                         </td>
                     </tr>
                     <!-- Quote 8 -->
-                    <tr class="transition-colors duration-150" style="cursor: pointer;" onmouseover="this.style.background='rgba(163, 148, 167, 0.05)'" onmouseout="this.style.background='transparent'">
+                    <tr data-vendedor="Maria Santos" class="transition-colors duration-150" style="cursor: pointer;" onmouseover="this.style.background='rgba(163, 148, 167, 0.05)'" onmouseout="this.style.background='transparent'">
                         <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-white">ORC008</td>
                         <td class="px-6 py-4 whitespace-nowrap text-sm text-white">Juliana Martins</td>
                         <td class="px-6 py-4 whitespace-nowrap text-sm" style="color: var(--color-violet)">08/03/2024</td>

--- a/src/js/orcamentos.js
+++ b/src/js/orcamentos.js
@@ -1,4 +1,52 @@
 // Lógica de interação para o módulo de Orçamentos
+function popularClientes() {
+    const select = document.getElementById('filterClient');
+    const rows = document.querySelectorAll('#orcamentosTabela tr');
+    const clientes = [...new Set(Array.from(rows).map(r => r.cells[1]?.textContent.trim()).filter(Boolean))];
+    if (select) {
+        select.innerHTML = '<option value="">Todos os Clientes</option>' +
+            clientes.map(c => `<option value="${c}">${c}</option>`).join('');
+    }
+}
+
+function aplicarFiltro() {
+    const status = document.getElementById('filterStatus')?.value || '';
+    const periodo = document.getElementById('filterPeriod')?.value || '';
+    const vendedor = document.getElementById('filterSeller')?.value || '';
+    const cliente = document.getElementById('filterClient')?.value.toLowerCase() || '';
+    const now = new Date();
+    document.querySelectorAll('#orcamentosTabela tr').forEach(row => {
+        const rowStatus = row.cells[5]?.innerText.trim() || '';
+        const rowCliente = row.cells[1]?.innerText.trim().toLowerCase() || '';
+        const rowVendedor = (row.dataset.vendedor || '').toLowerCase();
+        const dateText = row.cells[2]?.innerText.trim();
+        let show = true;
+
+        if (status) show &&= rowStatus === status;
+        if (vendedor) show &&= rowVendedor === vendedor.toLowerCase();
+        if (cliente) show &&= rowCliente === cliente;
+        if (periodo) {
+            const [d, m, y] = dateText.split('/').map(Number);
+            const rowDate = new Date(y, m - 1, d);
+            const diff = (now - rowDate) / (1000 * 60 * 60 * 24);
+            if (periodo === 'Semana') show &&= diff <= 7;
+            else if (periodo === 'Mês') show &&= diff <= 30;
+            else if (periodo === 'Trimestre') show &&= diff <= 90;
+            else if (periodo === 'Ano') show &&= diff <= 365;
+        }
+
+        row.style.display = show ? '' : 'none';
+    });
+}
+
+function limparFiltros() {
+    document.getElementById('filterStatus').value = '';
+    document.getElementById('filterPeriod').value = '';
+    document.getElementById('filterSeller').value = '';
+    document.getElementById('filterClient').value = '';
+    aplicarFiltro();
+}
+
 function initOrcamentos() {
     // Aplica animação de entrada nos elementos marcados
     document.querySelectorAll('.animate-fade-in-up').forEach((el, index) => {
@@ -27,6 +75,12 @@ function initOrcamentos() {
             Modal.open('modals/orcamentos/novo.html', '../js/modals/orcamento-novo.js', 'novoOrcamento');
         });
     }
+
+    const filtrar = document.getElementById('btnFiltrar');
+    const limpar = document.getElementById('btnLimpar');
+    if (filtrar) filtrar.addEventListener('click', aplicarFiltro);
+    if (limpar) limpar.addEventListener('click', limparFiltros);
+    popularClientes();
 }
 
 if (document.readyState === 'loading') {


### PR DESCRIPTION
## Summary
- Move "Novo Orçamento" button to page header
- Add responsive filter bar with client selector and action buttons
- Implement filtering logic for budgets

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f94d942b08322a5663c19fb7820f4