### PR TITLE
Restaurar Campos De Atualizar Tabela E Status Em Editar Produto

### DIFF
--- a/src/html/modals/produtos/editar.html
+++ b/src/html/modals/produtos/editar.html
@@ -11,11 +11,37 @@
 
     <div class="flex-1 overflow-y-auto">
       <div class="px-8 py-6 border-b border-white/10">
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mb-6">
           <div>
+            <p class="text-sm text-gray-400 mb-3">Opções de Atualização</p>
+            <div class="space-y-2">
+              <label class="flex items-center gap-2 text-sm text-gray-300">
+                <input type="radio" name="updateOption" value="update" checked class="text-primary focus:ring-primary/50" />
+                Atualizar Tabela Fixa
+              </label>
+              <label class="flex items-center gap-2 text-sm text-gray-300">
+                <input type="radio" name="updateOption" value="noUpdate" class="text-primary focus:ring-primary/50" />
+                Não Atualizar Tabela Fixa
+              </label>
+            </div>
+            <p class="text-sm text-gray-400 mb-3 mt-6">Status</p>
+            <div class="space-y-2">
+              <label class="flex items-center gap-2 text-sm text-gray-300">
+                <input type="radio" name="statusOption" value="Em linha" class="text-primary focus:ring-primary/50" />
+                Em Linha
+              </label>
+              <label class="flex items-center gap-2 text-sm text-gray-300">
+                <input type="radio" name="statusOption" value="Fora de linha" class="text-primary focus:ring-primary/50" />
+                Fora de Linha
+              </label>
+            </div>
+          </div>
+
+          <div class="text-center">
             <p class="text-sm text-gray-400 mb-1">Preço de Venda</p>
             <p id="precoVenda" class="text-3xl font-bold text-white"></p>
           </div>
+
           <div class="text-right">
             <p class="text-sm text-gray-400 mb-1">Data Última Modificação</p>
             <p id="ultimaModificacaoData" class="text-sm text-gray-300"></p>

--- a/src/js/modals/produto-editar.js
+++ b/src/js/modals/produto-editar.js
@@ -70,6 +70,7 @@
     const nomeInput = document.getElementById('nomeInput');
     const codigoInput = document.getElementById('codigoInput');
     const ncmInput = document.getElementById('ncmInput');
+    const updateRadios = Array.from(document.querySelectorAll('input[name="updateOption"]'));
     const statusRadios = Array.from(document.querySelectorAll('input[name="statusOption"]'));
     const precoVendaEl = document.getElementById('precoVenda');
     const ultimaDataEl = document.getElementById('ultimaModificacaoData');
@@ -126,6 +127,7 @@
       const editable = editarRegistroToggle && editarRegistroToggle.checked;
       [nomeInput, codigoInput, ncmInput].forEach(el => { if (el) el.disabled = !editable; });
       statusRadios.forEach(r => r.disabled = !editable);
+      updateRadios.forEach(r => r.disabled = !editable);
       if(!editable){
         if (nomeInput)   nomeInput.value   = registroOriginal.nome;
         if (codigoInput) codigoInput.value = registroOriginal.codigo;


### PR DESCRIPTION
## Summary
- reintroduce update table and status options in Edit Product modal
- disable update and status radios when registration editing is locked

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f96a6c8988322be3d618e71adaa75