### PR TITLE
Improve Budget Modal Styles

### DIFF
--- a/src/css/orcamentos.css
+++ b/src/css/orcamentos.css
@@ -10,6 +10,8 @@
     --color-green: #a2ffa6;
     --color-red: #ff5858;
     --color-blue: #8aa7f3;
+    --color-input: rgba(0,0,0,0.3);
+    --color-inputBorder: rgba(255,255,255,0.15);
     --neutral-100: #f9fafb;
     --neutral-500: #6b7280;
 }
@@ -52,6 +54,72 @@ body {
 .btn-warning:hover {
     background: rgba(106, 21, 44, 0.8);
     transform: scale(1.05);
+}
+
+.btn-danger {
+    background: var(--color-red);
+    transition: all 150ms ease;
+}
+
+.btn-danger:hover {
+    background: rgba(255,88,88,0.8);
+    transform: scale(1.1);
+}
+
+.btn-danger-light {
+    background: rgba(255,88,88,0.2);
+    color: var(--color-red);
+    transition: all 150ms ease;
+}
+
+.btn-danger-light:hover {
+    background: rgba(255,88,88,0.3);
+    transform: scale(1.05);
+}
+
+.btn-neutral {
+    background: rgba(255,255,255,0.1);
+    transition: all 150ms ease;
+}
+
+.btn-neutral:hover {
+    background: rgba(255,255,255,0.15);
+    transform: scale(1.05);
+}
+
+.btn-success {
+    background: var(--color-green);
+    color: #000;
+    transition: all 150ms ease;
+}
+
+.btn-success:hover {
+    background: rgba(162,255,166,0.8);
+    transform: scale(1.05);
+}
+
+.icon-only {
+    width: 32px;
+    height: 32px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 8px;
+    font-size: 16px;
+}
+
+.bg-input { background: var(--color-input); }
+.border-inputBorder { border-color: var(--color-inputBorder); }
+.focus\:border-primary:focus { border-color: var(--color-primary); }
+.focus\:ring-primary\/50:focus { box-shadow: 0 0 0 2px rgba(182,160,62,0.5); }
+.appearance-none { appearance: none; }
+
+.select-arrow {
+    background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 20 20'%3e%3cpath stroke='%236b7280' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='m6 8 4 4 4-4'/%3e%3c/svg%3e");
+    background-position: right 0.5rem center;
+    background-repeat: no-repeat;
+    background-size: 1.5em 1.5em;
+    padding-right: 2.5rem;
 }
 
 .badge-success {

--- a/src/html/modals/orcamentos/editar.html
+++ b/src/html/modals/orcamentos/editar.html
@@ -1,9 +1,9 @@
 <div id="editarOrcamentoOverlay" class="fixed inset-0 bg-black/50 flex items-center justify-center p-4">
   <div role="dialog" aria-modal="true" tabindex="0" class="w-full max-w-5xl max-h-[90vh] glass-surface backdrop-blur-xl rounded-3xl border border-white/10 ring-1 ring-white/5 shadow-2xl/40 animate-modalFade slide-in overflow-hidden flex flex-col">
-    <header class="flex items-center justify-between px-8 py-5 border-b border-white/10 flex-shrink-0">
-      <button id="voltarEditarOrcamento" class="btn-neutral px-4 py-2 rounded-lg text-white font-medium flex items-center gap-2">← Voltar</button>
-      <h2 id="tituloEditarOrcamento" class="flex-1 text-lg font-semibold text-white text-center mx-4">EDITAR ORÇAMENTO</h2>
-      <div class="flex items-center gap-3">
+    <header class="relative px-8 py-5 border-b border-white/10 flex-shrink-0">
+      <button id="voltarEditarOrcamento" class="btn-neutral px-4 py-2 rounded-lg text-white font-medium flex items-center gap-2 absolute left-8 top-1/2 -translate-y-1/2">← Voltar</button>
+      <h2 id="tituloEditarOrcamento" class="text-lg font-semibold text-white text-center">EDITAR ORÇAMENTO</h2>
+      <div class="flex items-center gap-3 absolute right-8 top-1/2 -translate-y-1/2">
         <button id="salvarOrcamento" class="btn-primary px-4 py-2 rounded-lg text-white font-medium">Salvar</button>
         <button id="fecharEditarOrcamento" class="btn-neutral icon-only text-white" aria-label="Fechar">✕</button>
       </div>
@@ -53,7 +53,8 @@
           <h3 class="text-lg font-semibold mb-4 text-white">Itens</h3>
           <div class="grid grid-cols-1 lg:grid-cols-5 gap-4 mb-4 items-end">
             <div class="lg:col-span-2 relative">
-              <input id="novoItemNome" type="text" placeholder="Produto" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+              <input id="novoItemNome" type="text" placeholder=" " class="peer w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-transparent focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+              <label for="novoItemNome" class="absolute left-4 top-1/2 -translate-y-1/2 text-base text-gray-300 pointer-events-none transition-all duration-150 peer-placeholder-shown:top-1/2 peer-placeholder-shown:-translate-y-1/2 peer-placeholder-shown:text-base peer-focus:top-0 peer-focus:-translate-y-full peer-focus:text-xs peer-focus:text-primary peer-valid:top-0 peer-valid:-translate-y-full peer-valid:text-xs">Produto</label>
             </div>
             <div class="relative">
               <input id="novoItemQtd" type="number" min="1" value="1" placeholder=" " class="peer w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-transparent focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
@@ -76,14 +77,14 @@
             <div class="overflow-x-auto">
               <div class="max-h-64 overflow-y-auto">
                 <table id="orcamentoItens" class="w-full text-sm">
-                  <thead class="sticky top-0 bg-surface/60 backdrop-blur-sm">
-                    <tr class="border-b border-white/10">
-                      <th class="py-3 px-2 text-left text-gray-300 font-medium">ITEM</th>
-                      <th class="py-3 px-2 text-center text-gray-300 font-medium">QTD</th>
-                      <th class="py-3 px-2 text-right text-gray-300 font-medium">VALOR UNIT. (R$)</th>
-                      <th class="py-3 px-2 text-center text-gray-300 font-medium">DESC. %</th>
-                      <th class="py-3 px-2 text-right text-gray-300 font-medium">TOTAL (R$)</th>
-                      <th class="py-3 px-2 text-center text-gray-300 font-medium">AÇÕES</th>
+                  <thead class="bg-gray-50 sticky top-0">
+                    <tr class="border-b border-gray-200">
+                      <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">ITEM</th>
+                      <th class="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">QTD</th>
+                      <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">VALOR UNIT. (R$)</th>
+                      <th class="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">DESC. %</th>
+                      <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">TOTAL (R$)</th>
+                      <th class="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">AÇÕES</th>
                     </tr>
                   </thead>
                   <tbody></tbody>

--- a/src/html/modals/orcamentos/novo.html
+++ b/src/html/modals/orcamentos/novo.html
@@ -1,9 +1,9 @@
 <div id="novoOrcamentoOverlay" class="fixed inset-0 bg-black/50 flex items-center justify-center p-4">
   <div role="dialog" aria-modal="true" tabindex="0" class="w-full max-w-5xl max-h-[90vh] glass-surface backdrop-blur-xl rounded-3xl border border-white/10 ring-1 ring-white/5 shadow-2xl/40 animate-modalFade slide-in overflow-hidden flex flex-col">
-    <header class="flex items-center justify-between px-8 py-5 border-b border-white/10 flex-shrink-0">
-      <button id="voltarNovoOrcamento" class="btn-neutral px-4 py-2 rounded-lg text-white font-medium flex items-center gap-2">← Voltar</button>
-      <h2 class="flex-1 text-lg font-semibold text-white text-center mx-4">NOVO ORÇAMENTO</h2>
-      <div class="flex items-center gap-3">
+    <header class="relative px-8 py-5 border-b border-white/10 flex-shrink-0">
+      <button id="voltarNovoOrcamento" class="btn-neutral px-4 py-2 rounded-lg text-white font-medium flex items-center gap-2 absolute left-8 top-1/2 -translate-y-1/2">← Voltar</button>
+      <h2 class="text-lg font-semibold text-white text-center">NOVO ORÇAMENTO</h2>
+      <div class="flex items-center gap-3 absolute right-8 top-1/2 -translate-y-1/2">
         <button id="salvarNovoOrcamento" class="btn-primary px-4 py-2 rounded-lg text-white font-medium">Salvar</button>
         <button id="limparNovoOrcamento" class="btn-danger-light px-4 py-2 rounded-lg font-medium">Limpar Tudo</button>
         <button id="fecharNovoOrcamento" class="btn-neutral icon-only text-white" aria-label="Fechar">✕</button>
@@ -80,14 +80,14 @@
             <div class="overflow-x-auto">
               <div class="max-h-64 overflow-y-auto">
                 <table id="novoItensTabela" class="w-full text-sm">
-                  <thead class="sticky top-0 bg-surface/60 backdrop-blur-sm">
-                    <tr class="border-b border-white/10">
-                      <th class="py-3 px-2 text-left text-gray-300 font-medium">ITEM</th>
-                      <th class="py-3 px-2 text-right text-gray-300 font-medium">VALOR UNIT. (R$)</th>
-                      <th class="py-3 px-2 text-center text-gray-300 font-medium">QTD</th>
-                      <th class="py-3 px-2 text-center text-gray-300 font-medium">DESC. %</th>
-                      <th class="py-3 px-2 text-right text-gray-300 font-medium">TOTAL (R$)</th>
-                      <th class="py-3 px-2 text-center text-gray-300 font-medium">AÇÕES</th>
+                  <thead class="bg-gray-50 sticky top-0">
+                    <tr class="border-b border-gray-200">
+                      <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">ITEM</th>
+                      <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">VALOR UNIT. (R$)</th>
+                      <th class="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">QTD</th>
+                      <th class="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">DESC. %</th>
+                      <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">TOTAL (R$)</th>
+                      <th class="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">AÇÕES</th>
                     </tr>
                   </thead>
                   <tbody></tbody>


### PR DESCRIPTION
## Summary
- apply consistent button and input styling to budget module
- center budget modal headers and add floating labels
- align budget item tables with product editor

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f97adf2048322a63fc1378874b9f9