### PR TITLE
Default NoUpdate for Fixed Table and decouple from edit toggle

### DIFF
--- a/src/html/modals/produtos/editar.html
+++ b/src/html/modals/produtos/editar.html
@@ -16,11 +16,11 @@
             <p class="text-sm text-gray-400 mb-3">Opções de Atualização</p>
             <div class="space-y-2">
               <label class="flex items-center gap-2 text-sm text-gray-300">
-                <input type="radio" name="updateOption" value="update" checked class="text-primary focus:ring-primary/50" />
+                <input type="radio" name="updateOption" value="update" class="text-primary focus:ring-primary/50" />
                 Atualizar Tabela Fixa
               </label>
               <label class="flex items-center gap-2 text-sm text-gray-300">
-                <input type="radio" name="updateOption" value="noUpdate" class="text-primary focus:ring-primary/50" />
+                <input type="radio" name="updateOption" value="noUpdate" checked class="text-primary focus:ring-primary/50" />
                 Não Atualizar Tabela Fixa
               </label>
             </div>

--- a/src/js/modals/produto-editar.js
+++ b/src/js/modals/produto-editar.js
@@ -127,7 +127,6 @@
       const editable = editarRegistroToggle && editarRegistroToggle.checked;
       [nomeInput, codigoInput, ncmInput].forEach(el => { if (el) el.disabled = !editable; });
       statusRadios.forEach(r => r.disabled = !editable);
-      updateRadios.forEach(r => r.disabled = !editable);
       if(!editable){
         if (nomeInput)   nomeInput.value   = registroOriginal.nome;
         if (codigoInput) codigoInput.value = registroOriginal.codigo;


### PR DESCRIPTION
## Summary
- Set 'Não Atualizar Tabela Fixa' as default option
- Keep update option active regardless of 'Editar Dados de Registro'

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f9de3449c83229a409ba91c19125b