### PR TITLE
Save With Option Checked Does Not Change Status

### DIFF
--- a/src/js/modals/produto-editar.js
+++ b/src/js/modals/produto-editar.js
@@ -429,6 +429,8 @@
           }
           if (codigoInput) produto.codigo = codigoInput.value;
           if (ncmInput)    produto.ncm    = ncmInput.value.slice(0,8);
+          const statusSelecionado = statusRadios.find(r => r.checked);
+          if (statusSelecionado) produto.status = statusSelecionado.value;
         }
         const itensPayload = {
           inseridos: itens


### PR DESCRIPTION
## Summary
- read selected status radio button when saving product edits so status updates correctly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f9e1386148322bcf167a593886c72