### PR TITLE
Padronizar Modais De Orçamento

### DIFF
--- a/src/html/modals/orcamentos/editar.html
+++ b/src/html/modals/orcamentos/editar.html
@@ -1,11 +1,19 @@
 <div id="editarOrcamentoOverlay" class="fixed inset-0 bg-black/50 flex items-center justify-center p-4">
   <div role="dialog" aria-modal="true" tabindex="0" class="w-full max-w-5xl max-h-[90vh] glass-surface backdrop-blur-xl rounded-3xl border border-white/10 ring-1 ring-white/5 shadow-2xl/40 animate-modalFade slide-in overflow-hidden flex flex-col">
-    <header class="relative px-8 py-5 border-b border-white/10 flex-shrink-0">
-      <button id="voltarEditarOrcamento" class="btn-neutral px-4 py-2 rounded-lg text-white font-medium flex items-center gap-2 absolute left-8 top-1/2 -translate-y-1/2">← Voltar</button>
-      <h2 id="tituloEditarOrcamento" class="text-lg font-semibold text-white text-center">EDITAR ORÇAMENTO</h2>
-      <div class="flex items-center gap-3 absolute right-8 top-1/2 -translate-y-1/2">
-        <button id="salvarOrcamento" class="btn-primary px-4 py-2 rounded-lg text-white font-medium">Salvar</button>
-        <button id="fecharEditarOrcamento" class="btn-neutral icon-only text-white" aria-label="Fechar">✕</button>
+    <header class="flex items-center justify-between px-8 py-5 border-b border-white/10 flex-shrink-0">
+      <button id="voltarEditarOrcamento" class="btn-neutral px-4 py-2 rounded-lg text-white font-medium flex items-center gap-2">← Voltar</button>
+      <h2 id="tituloEditarOrcamento" class="text-lg font-semibold text-white">EDITAR ORÇAMENTO</h2>
+      <div class="flex items-center gap-3">
+        <button id="salvarOrcamento" class="btn-success px-4 py-2 rounded-lg text-white font-medium">Salvar</button>
+        <div class="relative">
+          <button id="statusTag" class="badge-warning px-3 py-1 rounded-full text-xs font-medium cursor-pointer">Pendente</button>
+          <div id="statusOptions" class="hidden absolute right-0 mt-2 w-32 glass-surface rounded-xl border border-white/10 shadow-lg">
+            <button data-status="Pendente" class="block w-full text-left px-4 py-2 hover:bg-white/10">Pendente</button>
+            <button data-status="Aprovado" class="block w-full text-left px-4 py-2 hover:bg-white/10">Aprovado</button>
+            <button data-status="Rejeitado" class="block w-full text-left px-4 py-2 hover:bg-white/10">Rejeitado</button>
+            <button data-status="Expirado" class="block w-full text-left px-4 py-2 hover:bg-white/10">Expirado</button>
+          </div>
+        </div>
       </div>
     </header>
     <div class="flex-1 overflow-y-auto">
@@ -30,17 +38,6 @@
               <option value="prazo">À prazo</option>
             </select>
             <label for="editarCondicao" class="absolute left-4 top-1/2 -translate-y-1/2 text-base text-gray-300 pointer-events-none transition-all duration-150 peer-focus:top-0 peer-focus:-translate-y-full peer-focus:text-xs peer-focus:text-primary peer-data-[filled=true]:top-0 peer-data-[filled=true]:-translate-y-full peer-data-[filled=true]:text-xs">Condição de pagamento</label>
-            <i class="fas fa-chevron-down absolute right-4 top-1/2 -translate-y-1/2 text-gray-300 pointer-events-none"></i>
-          </div>
-          <div class="relative">
-            <select id="editarStatus" class="peer w-full appearance-none bg-input border border-inputBorder rounded-lg px-4 pr-12 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition" data-filled="false">
-              <option value="rascunho">Rascunho</option>
-              <option value="aberto">Aberto</option>
-              <option value="enviado">Enviado</option>
-              <option value="aprovado">Aprovado</option>
-              <option value="recusado">Recusado</option>
-            </select>
-            <label for="editarStatus" class="absolute left-4 top-1/2 -translate-y-1/2 text-base text-gray-300 pointer-events-none transition-all duration-150 peer-focus:top-0 peer-focus:-translate-y-full peer-focus:text-xs peer-focus:text-primary peer-data-[filled=true]:top-0 peer-data-[filled=true]:-translate-y-full peer-data-[filled=true]:text-xs">Status</label>
             <i class="fas fa-chevron-down absolute right-4 top-1/2 -translate-y-1/2 text-gray-300 pointer-events-none"></i>
           </div>
           <div class="relative lg:col-span-2">

--- a/src/html/modals/orcamentos/novo.html
+++ b/src/html/modals/orcamentos/novo.html
@@ -1,12 +1,11 @@
 <div id="novoOrcamentoOverlay" class="fixed inset-0 bg-black/50 flex items-center justify-center p-4">
   <div role="dialog" aria-modal="true" tabindex="0" class="w-full max-w-5xl max-h-[90vh] glass-surface backdrop-blur-xl rounded-3xl border border-white/10 ring-1 ring-white/5 shadow-2xl/40 animate-modalFade slide-in overflow-hidden flex flex-col">
-    <header class="relative px-8 py-5 border-b border-white/10 flex-shrink-0">
-      <button id="voltarNovoOrcamento" class="btn-neutral px-4 py-2 rounded-lg text-white font-medium flex items-center gap-2 absolute left-8 top-1/2 -translate-y-1/2">← Voltar</button>
-      <h2 class="text-lg font-semibold text-white text-center">NOVO ORÇAMENTO</h2>
-      <div class="flex items-center gap-3 absolute right-8 top-1/2 -translate-y-1/2">
-        <button id="salvarNovoOrcamento" class="btn-primary px-4 py-2 rounded-lg text-white font-medium">Salvar</button>
-        <button id="limparNovoOrcamento" class="btn-danger-light px-4 py-2 rounded-lg font-medium">Limpar Tudo</button>
-        <button id="fecharNovoOrcamento" class="btn-neutral icon-only text-white" aria-label="Fechar">✕</button>
+    <header class="flex items-center justify-between px-8 py-5 border-b border-white/10 flex-shrink-0">
+      <button id="voltarNovoOrcamento" class="btn-neutral px-4 py-2 rounded-lg text-white font-medium flex items-center gap-2">← Voltar</button>
+      <h2 class="text-lg font-semibold text-white">NOVO ORÇAMENTO</h2>
+      <div class="flex items-center gap-3">
+        <button id="salvarNovoOrcamento" class="btn-success px-4 py-2 rounded-lg text-white font-medium">Salvar</button>
+        <button id="limparNovoOrcamento" class="btn-danger px-4 py-2 rounded-lg text-white font-medium">Limpar Tudo</button>
       </div>
     </header>
     <div class="flex-1 overflow-y-auto">

--- a/src/js/modals/orcamento-editar.js
+++ b/src/js/modals/orcamento-editar.js
@@ -13,7 +13,34 @@
   }
   document.getElementById('editarCliente').value = data.cliente || '';
   document.getElementById('editarCondicao').value = data.condicao || 'vista';
-  document.getElementById('editarStatus').value = (data.status || 'rascunho').toLowerCase();
+
+  const statusMap = {
+    'Rascunho': 'badge-neutral',
+    'Pendente': 'badge-warning',
+    'Aprovado': 'badge-success',
+    'Rejeitado': 'badge-danger',
+    'Expirado': 'badge-neutral'
+  };
+  let currentStatus = data.status || 'Rascunho';
+  const statusTag = document.getElementById('statusTag');
+  const statusOptions = document.getElementById('statusOptions');
+
+  function updateStatusTag() {
+    statusTag.className = `${statusMap[currentStatus] || 'badge-neutral'} px-3 py-1 rounded-full text-xs font-medium cursor-pointer`;
+    statusTag.textContent = currentStatus;
+  }
+  updateStatusTag();
+
+  statusTag.addEventListener('click', () => {
+    statusOptions.classList.toggle('hidden');
+  });
+  statusOptions.querySelectorAll('button').forEach(btn => {
+    btn.addEventListener('click', () => {
+      currentStatus = btn.dataset.status;
+      updateStatusTag();
+      statusOptions.classList.add('hidden');
+    });
+  });
 
   const itensTbody = document.querySelector('#orcamentoItens tbody');
 
@@ -95,11 +122,10 @@
       data.row.cells[3].textContent = document.getElementById('totalOrcamento').textContent;
       const statusCell = data.row.cells[5];
       statusCell.innerHTML = '';
-      const statusValue = document.getElementById('editarStatus').value;
-      const statusText = document.getElementById('editarStatus').options[document.getElementById('editarStatus').selectedIndex].textContent;
       const statusSpan = document.createElement('span');
-      statusSpan.className = `badge-${statusValue} px-3 py-1 rounded-full text-xs font-medium`;
-      statusSpan.textContent = statusText;
+      const cls = statusMap[currentStatus] || 'badge-neutral';
+      statusSpan.className = `${cls} px-3 py-1 rounded-full text-xs font-medium`;
+      statusSpan.textContent = currentStatus;
       statusCell.appendChild(statusSpan);
     }
     if (closeAfter) Modal.close(overlayId);

--- a/src/js/modals/orcamento-novo.js
+++ b/src/js/modals/orcamento-novo.js
@@ -141,7 +141,14 @@
     tr.style.cursor = 'pointer';
     tr.setAttribute('onmouseover', "this.style.background='rgba(163, 148, 167, 0.05)'");
     tr.setAttribute('onmouseout', "this.style.background='transparent'");
-    const badgeClass = status === 'Rascunho' ? 'badge-warning' : 'badge-success';
+    const statusClasses = {
+      'Rascunho': 'badge-neutral',
+      'Pendente': 'badge-warning',
+      'Aprovado': 'badge-success',
+      'Rejeitado': 'badge-danger',
+      'Expirado': 'badge-neutral'
+    };
+    const badgeClass = statusClasses[status] || 'badge-neutral';
     tr.innerHTML = `
       <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-white">${newId}</td>
       <td class="px-6 py-4 whitespace-nowrap text-sm text-white">${clienteText}</td>
@@ -170,7 +177,7 @@
   }
 
   document.getElementById('salvarNovoOrcamento').addEventListener('click', () => saveQuote('Rascunho'));
-  document.getElementById('enviarNovoOrcamento').addEventListener('click', () => saveQuote('Enviado'));
+  document.getElementById('enviarNovoOrcamento').addEventListener('click', () => saveQuote('Pendente'));
   document.getElementById('cancelarNovoOrcamento').addEventListener('click', close);
   document.getElementById('voltarNovoOrcamento').addEventListener('click', close);
 


### PR DESCRIPTION
## Summary
- Ajusta cabeçalhos dos modais de orçamento para seguir padrão dos modais de produto
- Implementa tag de status no modal de edição com opções clicáveis
- Define rascunho como status inicial ao salvar novo orçamento

## Testing
- `npm test` *(fails: Cannot find module '/workspace/App-Gestao/backend')*

------
https://chatgpt.com/codex/tasks/task_e_689f9f761c288322b03a28b03a9fea7e