### PR TITLE
Corrigir Novo Orçamento Tabela E Seletores

### DIFF
--- a/src/html/modals/orcamentos/novo.html
+++ b/src/html/modals/orcamentos/novo.html
@@ -50,7 +50,7 @@
 
         <div>
           <h3 class="text-lg font-semibold mb-4 text-white">Itens</h3>
-          <div class="grid grid-cols-1 lg:grid-cols-5 gap-4 mb-4 items-end">
+          <div class="grid grid-cols-1 lg:grid-cols-4 gap-4 mb-4 items-end">
             <div class="lg:col-span-2 relative">
               <select id="itemProduto" class="peer w-full appearance-none bg-input border border-inputBorder rounded-lg px-4 pr-12 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition" data-filled="false">
                 <option value="" disabled selected hidden></option>
@@ -66,10 +66,6 @@
               <input id="itemQtd" type="number" min="1" value="1" placeholder=" " class="peer w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-transparent focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
               <label for="itemQtd" class="absolute left-4 top-1/2 -translate-y-1/2 text-base text-gray-300 pointer-events-none transition-all duration-150 peer-placeholder-shown:top-1/2 peer-placeholder-shown:-translate-y-1/2 peer-placeholder-shown:text-base peer-focus:top-0 peer-focus:-translate-y-full peer-focus:text-xs peer-focus:text-primary peer-valid:top-0 peer-valid:-translate-y-full peer-valid:text-xs">Quantidade</label>
             </div>
-            <div class="relative">
-              <input id="itemDesc" type="number" min="0" value="0" placeholder=" " class="peer w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-transparent text-right focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
-              <label for="itemDesc" class="absolute left-4 top-1/2 -translate-y-1/2 text-base text-gray-300 pointer-events-none transition-all duration-150 peer-placeholder-shown:top-1/2 peer-placeholder-shown:-translate-y-1/2 peer-placeholder-shown:text-base peer-focus:top-0 peer-focus:-translate-y-full peer-focus:text-xs peer-focus:text-primary peer-valid:top-0 peer-valid:-translate-y-full peer-valid:text-xs">Desc. %</label>
-            </div>
             <div>
               <button id="adicionarItemNovo" class="w-full btn-primary px-4 py-3 rounded-lg font-medium">+ Inserir</button>
             </div>
@@ -82,8 +78,8 @@
                   <thead class="bg-gray-50 sticky top-0">
                     <tr class="border-b border-gray-200">
                       <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">ITEM</th>
-                      <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">VALOR UNIT. (R$)</th>
                       <th class="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">QTD</th>
+                      <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">VALOR UNIT. (R$)</th>
                       <th class="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">DESC. %</th>
                       <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">TOTAL (R$)</th>
                       <th class="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">AÇÕES</th>


### PR DESCRIPTION
## Summary
- Atualiza tabela de itens do novo orçamento para seguir o padrão de edição
- Remove campo de desconto da inclusão de itens e ajusta totais
- Corrige labels de selects que não subiam

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3679bdfcc832291a372d827221eed