### PR TITLE
Prevenir Registro De Peças Duplicadas Em Novo Produto

### DIFF
--- a/backend/produtos.js
+++ b/backend/produtos.js
@@ -449,6 +449,18 @@ async function salvarProdutoDetalhado(codigoOriginal, produto, itens) {
       }
     }
 
+    // Verifica se há insumos duplicados no payload
+    const insumosInseridos = itens?.inseridos || [];
+    const insumoIds = new Set();
+    for (const ins of insumosInseridos) {
+      if (insumoIds.has(ins.insumo_id)) {
+        const err = new Error('Insumo duplicado');
+        err.code = 'INSUMO_DUPLICADO';
+        throw err;
+      }
+      insumoIds.add(ins.insumo_id);
+    }
+
     if (codigo !== undefined && codigo !== codigoOriginal) {
       const { rows } = await client.query(
         'SELECT * FROM produtos WHERE codigo=$1',

--- a/src/js/modals/produto-novo.js
+++ b/src/js/modals/produto-novo.js
@@ -122,8 +122,19 @@
   }
 
   function startDelete(item){
-    itens = itens.filter(i => i !== item);
-    renderItens();
+    const cell = item.row.querySelector('.action-cell');
+    cell.innerHTML = `
+      <div class="flex items-center justify-center space-x-2">
+        <i class="fas fa-check w-5 h-5 cursor-pointer p-1 rounded text-green-400 confirm-delete"></i>
+        <i class="fas fa-times w-5 h-5 cursor-pointer p-1 rounded text-red-400 cancel-delete"></i>
+      </div>`;
+    cell.querySelector('.confirm-delete').addEventListener('click', () => {
+      itens = itens.filter(i => i !== item);
+      renderItens();
+    });
+    cell.querySelector('.cancel-delete').addEventListener('click', () => {
+      renderItens();
+    });
   }
 
   function renderItens(){
@@ -183,7 +194,14 @@
       }
     },
     adicionarProcessoItens(novos){
-      novos.forEach(n => itens.push(n));
+      novos.forEach(n => {
+        const exists = itens.some(it => String(it.nome).trim().toLowerCase() === String(n.nome).trim().toLowerCase());
+        if(exists){
+          if(typeof showToast === 'function') showToast('Item já adicionado', 'error');
+        } else {
+          itens.push(n);
+        }
+      });
       renderItens();
     }
   };
@@ -265,6 +283,11 @@
           status: 'Em linha'
         });
 
+        const itensPayload = itens.map(i => ({
+          insumo_id: i.insumo_id ?? i.id,
+          quantidade: i.quantidade
+        }));
+
         await window.electronAPI.salvarProdutoDetalhado(codigo, {
           pct_fabricacao: parseFloat(fabricacaoInput?.value) || 0,
           pct_acabamento: parseFloat(acabamentoInput?.value) || 0,
@@ -280,7 +303,7 @@
           ncm,
           categoria: nome.split(' ')[0] || '',
           status: 'Em linha'
-        }, { inseridos: [], atualizados: [], deletados: [] });
+        }, { inseridos: itensPayload, atualizados: [], deletados: [] });
 
         showToast('Peça criada com sucesso!', 'success');
         close();


### PR DESCRIPTION
## Summary
- Bloqueia salvamento de insumos duplicados no backend
- Impede adição de itens repetidos e confirma exclusão na tela de novo produto
- Envia itens inseridos para o backend ao registrar um produto

## Testing
- `node --test backend/*.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a36d13879883228a703cdfbbf2d7a7