### PR TITLE
Add Clone Button to Product Editor

### DIFF
--- a/src/html/modals/produtos/editar.html
+++ b/src/html/modals/produtos/editar.html
@@ -5,6 +5,7 @@
       <h2 class="text-lg font-semibold text-white">EDITAR PRODUTO</h2>
       <div class="flex items-center gap-3">
         <button id="salvarEditarProduto" class="btn-success px-4 py-2 rounded-lg text-white font-medium flex items-center gap-2">Salvar</button>
+          <button id="clonarProduto" class="btn-secondary px-4 py-2 rounded-lg text-white font-medium">Clonar</button>
           <button id="limparTudo" class="btn-danger px-4 py-2 rounded-lg text-white font-medium">Limpar Tudo</button>
       </div>
     </header>


### PR DESCRIPTION
## Summary
- add blue "Clonar" button to product editor dialog
- implement logic to duplicate a product, appending `- Copiado` and `COPIA`
- prevent cloning when an identical copy already exists

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a371e62ddc8322bd1deee5e0511837