### PR TITLE
Ajustes em novo e editar orçamento

### DIFF
--- a/src/css/orcamentos.css
+++ b/src/css/orcamentos.css
@@ -8,6 +8,7 @@
     --color-bg-deep: #310017;
     --color-surface: rgba(255,255,255,0.08);
     --color-green: #a2ffa6;
+    --color-green-dark: #065f46;
     --color-red: #ff5858;
     --color-blue: #8aa7f3;
     --color-input: rgba(0,0,0,0.3);
@@ -95,6 +96,27 @@ body {
 
 .btn-success:hover {
     background: rgba(162,255,166,0.8);
+    transform: scale(1.05);
+}
+
+.btn-purple {
+    background: var(--color-violet);
+    color: #fff;
+    transition: all 150ms ease;
+}
+
+.btn-purple:hover {
+    background: rgba(163,148,167,0.9);
+}
+
+.btn-dark-green {
+    background: var(--color-green-dark);
+    color: #fff;
+    transition: all 150ms ease;
+}
+
+.btn-dark-green:hover {
+    background: rgba(6,95,70,0.9);
     transform: scale(1.05);
 }
 

--- a/src/html/modals/orcamentos/editar.html
+++ b/src/html/modals/orcamentos/editar.html
@@ -61,9 +61,9 @@
         </div>
 
         <div>
-          <div class="flex items-center justify-between mb-4">
+          <div class="flex items-center justify-between mb-6">
             <h3 class="text-lg font-semibold text-white">Itens</h3>
-            <div class="flex flex-1 flex-wrap justify-between gap-2 text-sm ml-4">
+            <div class="flex flex-wrap gap-2 text-sm ml-4">
               <span class="badge-neutral px-3 py-1 rounded-full font-medium">Subtotal: <span id="subtotalOrcamento">R$ 0,00</span></span>
               <span class="badge-danger px-3 py-1 rounded-full font-medium">Desconto: <span id="descontoOrcamento">R$ 0,00</span></span>
               <span class="badge-success px-3 py-1 rounded-full font-medium">Total: <span id="totalOrcamento">R$ 0,00</span></span>
@@ -113,8 +113,9 @@
       </div>
     </div>
     <footer class="flex justify-end gap-3 px-8 py-6 border-t border-white/10 flex-shrink-0">
-      <button id="salvarFecharOrcamento" class="btn-neutral px-4 py-2 rounded-lg text-white font-medium">Salvar e Fechar</button>
-      <button id="converterOrcamento" class="btn-secondary px-4 py-2 rounded-lg text-white font-medium">Converter em Pedido</button>
+      <button id="clonarOrcamento" class="btn-secondary px-4 py-2 rounded-lg text-white font-medium">Clonar</button>
+      <button id="salvarFecharOrcamento" class="btn-dark-green px-4 py-2 rounded-lg text-white font-medium">Salvar e Fechar</button>
+      <button id="converterOrcamento" class="btn-purple px-4 py-2 rounded-lg text-white font-medium">Converter em Pedido</button>
       <button id="cancelarOrcamento" class="btn-danger-light px-4 py-2 rounded-lg font-medium">Cancelar</button>
     </footer>
   </div>

--- a/src/html/modals/orcamentos/novo.html
+++ b/src/html/modals/orcamentos/novo.html
@@ -49,9 +49,9 @@
         </div>
 
         <div>
-          <div class="flex items-center justify-between mb-4">
+          <div class="flex items-center justify-between mb-6">
             <h3 class="text-lg font-semibold text-white">Itens</h3>
-            <div class="flex flex-1 flex-wrap justify-between gap-2 text-sm ml-4">
+            <div class="flex flex-wrap gap-2 text-sm ml-4">
               <span class="badge-neutral px-3 py-1 rounded-full font-medium">Subtotal: <span id="novoSubtotal">R$ 0,00</span></span>
               <span class="badge-danger px-3 py-1 rounded-full font-medium">Desconto: <span id="novoDesconto">R$ 0,00</span></span>
               <span class="badge-success px-3 py-1 rounded-full font-medium">Total: <span id="novoTotal">R$ 0,00</span></span>

--- a/src/js/modals/orcamento-editar.js
+++ b/src/js/modals/orcamento-editar.js
@@ -79,14 +79,14 @@
       const overlay = document.createElement('div');
       overlay.className = 'fixed inset-0 bg-black/50 flex items-center justify-center p-4';
       overlay.innerHTML = `
-        <div class="max-w-sm w-full glass-surface backdrop-blur-xl rounded-2xl border border-white/10 ring-1 ring-white/5 shadow-2xl/40 animate-modalFade">
+        <div class="max-w-lg w-full glass-surface backdrop-blur-xl rounded-2xl border border-white/10 ring-1 ring-white/5 shadow-2xl/40 animate-modalFade">
           <div class="p-6 text-center">
             <h3 class="text-lg font-semibold mb-4 text-white">Item já adicionado</h3>
             <p class="text-sm text-gray-300 mb-6">O item selecionado já está na lista. O que deseja fazer?</p>
             <div class="flex justify-center gap-4">
-              <button id="dupSomar" class="btn-warning px-4 py-2 rounded-lg text-white font-medium flex items-center gap-2" title="Somar à quantidade existente">Somar <span class="info-icon"></span></button>
-              <button id="dupSubstituir" class="btn-danger px-4 py-2 rounded-lg text-white font-medium flex items-center gap-2" title="Substituir o item existente">Substituir <span class="info-icon"></span></button>
-              <button id="dupManter" class="btn-neutral px-4 py-2 rounded-lg text-white font-medium flex items-center gap-2" title="Manter o item atual">Manter <span class="info-icon"></span></button>
+              <button id="dupSomar" class="btn-warning px-4 py-2 rounded-lg text-white font-medium">Somar</button>
+              <button id="dupSubstituir" class="btn-danger px-4 py-2 rounded-lg text-white font-medium">Substituir</button>
+              <button id="dupManter" class="btn-neutral px-4 py-2 rounded-lg text-white font-medium">Manter</button>
             </div>
           </div>
         </div>`;
@@ -192,7 +192,7 @@
       tr.className = 'border-b border-white/10';
       if (item.id) tr.dataset.id = item.id;
       tr.innerHTML = `
-        <td class="px-6 py-4 text-sm text-white">${item.nome}<i class="info-icon ml-2" data-id="${item.id}"></i></td>
+        <td class="px-6 py-4 text-sm text-white">${item.nome}</td>
         <td class="px-6 py-4 text-center text-sm text-white">${item.qtd}</td>
         <td class="px-6 py-4 text-right text-sm text-white">${item.valor.toFixed(2)}</td>
         <td class="px-6 py-4 text-center text-sm text-white">${item.desc}</td>
@@ -206,11 +206,9 @@
       updateLineTotal(tr);
       attachRowEvents(tr);
       recalcTotals();
-      attachProductInfoEvents();
     }
 
     (data.items || [{ id: 'mesa-paris', nome: 'Mesa de Jantar Modelo Paris', qtd: 1, valor: 1500, desc: 0 }]).forEach(addItem);
-    attachProductInfoEvents();
 
     document.getElementById('adicionarItem').addEventListener('click', () => {
       const prodId = produtoSelect.value;

--- a/src/js/modals/orcamento-novo.js
+++ b/src/js/modals/orcamento-novo.js
@@ -152,14 +152,14 @@
     const overlay = document.createElement('div');
     overlay.className = 'fixed inset-0 bg-black/50 flex items-center justify-center p-4';
     overlay.innerHTML = `
-      <div class="max-w-sm w-full glass-surface backdrop-blur-xl rounded-2xl border border-white/10 ring-1 ring-white/5 shadow-2xl/40 animate-modalFade">
+      <div class="max-w-lg w-full glass-surface backdrop-blur-xl rounded-2xl border border-white/10 ring-1 ring-white/5 shadow-2xl/40 animate-modalFade">
         <div class="p-6 text-center">
           <h3 class="text-lg font-semibold mb-4 text-white">Item já adicionado</h3>
           <p class="text-sm text-gray-300 mb-6">O item selecionado já está na lista. O que deseja fazer?</p>
           <div class="flex justify-center gap-4">
-            <button id="dupSomar" class="btn-warning px-4 py-2 rounded-lg text-white font-medium flex items-center gap-2" title="Somar à quantidade existente">Somar <span class="info-icon"></span></button>
-            <button id="dupSubstituir" class="btn-danger px-4 py-2 rounded-lg text-white font-medium flex items-center gap-2" title="Substituir o item existente">Substituir <span class="info-icon"></span></button>
-            <button id="dupManter" class="btn-neutral px-4 py-2 rounded-lg text-white font-medium flex items-center gap-2" title="Manter o item atual">Manter <span class="info-icon"></span></button>
+            <button id="dupSomar" class="btn-warning px-4 py-2 rounded-lg text-white font-medium">Somar</button>
+            <button id="dupSubstituir" class="btn-danger px-4 py-2 rounded-lg text-white font-medium">Substituir</button>
+            <button id="dupManter" class="btn-neutral px-4 py-2 rounded-lg text-white font-medium">Manter</button>
           </div>
         </div>
       </div>`;
@@ -193,7 +193,7 @@
     tr.dataset.id = prodId;
     tr.className = 'border-b border-white/10';
       tr.innerHTML = `
-        <td class="px-6 py-4 text-sm text-white">${product.nome}<i class="info-icon ml-2" data-id="${prodId}"></i></td>
+        <td class="px-6 py-4 text-sm text-white">${product.nome}</td>
         <td class="px-6 py-4 text-center text-sm text-white">${qtd}</td>
         <td class="px-6 py-4 text-right text-sm text-white">${product.valor.toFixed(2)}</td>
         <td class="px-6 py-4 text-center text-sm text-white">0</td>
@@ -206,7 +206,6 @@
       updateLineTotal(tr);
       attachRowEvents(tr);
       recalcTotals();
-      attachProductInfoEvents();
     }
 
   document.getElementById('adicionarItemNovo').addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- Corrige espaçamento e agrupamento das tags de totais nos modais de novo e editar orçamento
- Remove ícones de informação e amplia o diálogo de itens duplicados
- Adiciona botão **Clonar** e redefine cores dos botões de ações no modal de edição

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a374de7cb083228f0477588f9d06a4