### PR TITLE
Adicionar Icone De Notificacao E Dados Do Usuario No Cabecalho

### DIFF
--- a/backend/backend.js
+++ b/backend/backend.js
@@ -94,7 +94,7 @@ async function loginUsuario(email, senha, pin) {
     if (!senhaCorreta) throw new Error('Senha incorreta');
 
     pinErrorAttempts = 0; // reset after successful login
-    return { id: usuario.id, nome: usuario.nome };
+    return { id: usuario.id, nome: usuario.nome, perfil: usuario.perfil };
   } catch (err) {
     if (isNetworkError(err)) {
       throw new Error('Sem conexão com internet');

--- a/src/html/menu.html
+++ b/src/html/menu.html
@@ -32,8 +32,8 @@
             <!-- User Info & Actions -->
             <div class="flex items-center space-x-4">
                 <div class="text-right hidden sm:block">
-                    <div class="text-sm font-medium">Henrique Viana Abade</div>
-                    <div class="text-xs" style="color: var(--color-violet)">Administrador</div>
+                    <div id="userName" class="text-sm font-medium"></div>
+                    <div id="userProfile" class="text-xs" style="color: var(--color-violet)"></div>
                 </div>
 
                 <div class="flex items-center space-x-2 relative">
@@ -62,9 +62,9 @@
                         <i class="fas fa-sync-alt w-4 h-4 rotating"></i>
                     </button>
 
-                    <button class="p-2 rounded-lg transition-colors duration-150 hover:bg-white/10 relative" style="color: var(--color-violet)" onmouseover="this.style.color='var(--color-primary-light)'" onmouseout="this.style.color='var(--color-violet)'>
+                    <button id="notificationBtn" class="p-2 rounded-lg transition-colors duration-150 hover:bg-white/10 relative" style="color: white" onmouseover="this.style.color='var(--color-primary-light)'" onmouseout="updateNotificationColor()">
                         <i class="fas fa-bell w-5 h-5"></i>
-                        <span class="absolute -top-1 -right-1 w-3 h-3 rounded-full" style="background: var(--color-red)"></span>
+                        <span id="notificationBadge" class="hidden absolute -top-1 -right-1 w-3 h-3 rounded-full" style="background: var(--color-red)"></span>
                     </button>
                 </div>
             </div>
@@ -372,6 +372,7 @@
     <script src="../utils/colorParser.js"></script>
     <script src="../utils/colors.js"></script>
     <script src="../js/utils/notifications.js"></script>
+    <script src="../js/notifications.js"></script>
     <script src="../js/menu.js"></script>
     <script src="../js/scroll-handler.js"></script>
     <script src="../utils/userActions.js"></script>

--- a/src/js/notifications.js
+++ b/src/js/notifications.js
@@ -1,0 +1,67 @@
+window.addEventListener('DOMContentLoaded', () => {
+  const btn = document.getElementById('notificationBtn');
+  const badge = document.getElementById('notificationBadge');
+  if (!btn || !badge) return;
+
+  let currentUser = {};
+  try {
+    currentUser = JSON.parse(sessionStorage.getItem('currentUser') || localStorage.getItem('user') || '{}');
+  } catch (e) {
+    currentUser = {};
+  }
+
+  const notifications = [
+    {
+      user: currentUser.nome || 'Sistema',
+      message: 'Bem-vindo ao painel!'
+        + (currentUser.perfil ? ` Perfil: ${currentUser.perfil}.` : ''),
+      date: new Date()
+    },
+    {
+      user: 'Suporte',
+      message: 'Sua conta foi verificada com sucesso.',
+      date: new Date(Date.now() - 3600000)
+    }
+  ];
+
+  function formatDate(d) {
+    try {
+      return new Date(d).toLocaleString('pt-BR');
+    } catch (e) {
+      return '';
+    }
+  }
+
+  function updateIcon() {
+    if (notifications.length > 0) {
+      btn.style.color = 'var(--color-primary)';
+      badge.classList.remove('hidden');
+    } else {
+      btn.style.color = 'white';
+      badge.classList.add('hidden');
+    }
+  }
+
+  window.updateNotificationColor = updateIcon;
+
+  btn.addEventListener('click', () => {
+    const items = notifications
+      .map(
+        n => `
+        <div class="px-4 py-2 border-b last:border-0 border-gray-100">
+          <div class="font-semibold">${n.user}</div>
+          <div class="text-xs text-gray-500">${formatDate(n.date)}</div>
+          <div class="text-sm">${n.message}</div>
+        </div>`
+      )
+      .join('');
+    const content = `<div class="w-72 bg-white rounded-md shadow-lg text-gray-800">${
+      items || '<div class="p-4 text-sm text-gray-600">Sem notificações</div>'
+    }</div>`;
+    const { popup } = createPopup(btn, content, {
+      onHide: () => popup.remove()
+    });
+  });
+
+  updateIcon();
+});

--- a/src/login/loginRenderer.js
+++ b/src/login/loginRenderer.js
@@ -170,6 +170,7 @@ if (intro) {
 
     const result = await window.electronAPI.autoLogin(storedPin);
     if (result && result.success) {
+      if (storedUser) sessionStorage.setItem('currentUser', storedUser);
       return;
     }
     localStorage.removeItem('user');
@@ -352,6 +353,7 @@ if (intro) {
       if (remember && result.user) localStorage.setItem('user', JSON.stringify(result.user));
       else                         localStorage.removeItem('user');
       localStorage.setItem('pin', pin);
+      sessionStorage.setItem('currentUser', JSON.stringify(result.user));
 
       if (pinInput) {
         pinInput.value = pin;

--- a/src/utils/userActions.js
+++ b/src/utils/userActions.js
@@ -3,6 +3,19 @@ window.addEventListener('DOMContentLoaded', () => {
   const menu = document.getElementById('user-actions-menu');
   if (!btn || !menu) return;
 
+  const nameEl = document.getElementById('userName');
+  const profileEl = document.getElementById('userProfile');
+  try {
+    const stored = sessionStorage.getItem('currentUser') || localStorage.getItem('user');
+    if (stored) {
+      const user = JSON.parse(stored);
+      if (nameEl) nameEl.textContent = user.nome || '';
+      if (profileEl) profileEl.textContent = user.perfil || '';
+    }
+  } catch (e) {
+    /* ignore */
+  }
+
   const positionMenu = () => {
     const margin = 8; // 0.5rem
     const btnRect = btn.getBoundingClientRect();


### PR DESCRIPTION
## Summary
- Exibir nome e perfil reais do usuário logado com suporte a sessão
- Incluir ícone de notificação com popup de avisos demonstrativos

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a37ae7d13c83229acbb8ad615b6389