### PR TITLE
Add Slide-In Effect To All Modules

### DIFF
--- a/src/js/menu.js
+++ b/src/js/menu.js
@@ -18,6 +18,13 @@ async function loadPage(page) {
     try {
         const resp = await fetch(`../html/${page}.html`);
         content.innerHTML = await resp.text();
+        const module = content.querySelector('.modulo-container');
+        if (module) {
+            module.classList.add('module-enter');
+            module.addEventListener('animationend', () => {
+                module.classList.remove('module-enter');
+            }, { once: true });
+        }
         document.dispatchEvent(new Event('module-change'));
 
         document.getElementById('page-style')?.remove();

--- a/src/styles/scroll.css
+++ b/src/styles/scroll.css
@@ -78,3 +78,17 @@ select option {
   color: #000;
   background: #fff;
 }
+
+/* Module entry animation */
+.module-enter {
+  animation: moduleFadeInUp 0.6s ease-out forwards;
+  opacity: 0;
+  transform: translateY(20px);
+}
+
+@keyframes moduleFadeInUp {
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}


### PR DESCRIPTION
## Summary
- add global module slide-in animation
- apply animation when loading modules for consistent transitions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a37e44523c8322b919987bc5080d98