### PR TITLE
Fetch user profile for header from usuarios table

### DIFF
--- a/backend/usuariosController.js
+++ b/backend/usuariosController.js
@@ -23,4 +23,22 @@ router.get('/lista', async (_req, res) => {
   }
 });
 
+// GET /api/usuarios/:id
+router.get('/:id', async (req, res) => {
+  try {
+    const { id } = req.params;
+    const result = await pool.query(
+      'SELECT perfil FROM usuarios WHERE id = $1',
+      [id]
+    );
+    if (result.rows.length === 0) {
+      return res.status(404).json({ error: 'Usuário não encontrado' });
+    }
+    res.json({ perfil: result.rows[0].perfil });
+  } catch (err) {
+    console.error('Erro ao obter perfil do usuário:', err);
+    res.status(500).json({ error: 'Erro ao obter perfil do usuário' });
+  }
+});
+
 module.exports = router;

--- a/src/utils/userActions.js
+++ b/src/utils/userActions.js
@@ -1,3 +1,5 @@
+const API_URL = 'http://localhost:3000';
+
 window.addEventListener('DOMContentLoaded', () => {
   const nameEl = document.getElementById('userName');
   const profileEl = document.getElementById('userProfile');
@@ -6,6 +8,16 @@ window.addEventListener('DOMContentLoaded', () => {
     const user = stored ? JSON.parse(stored) : {};
     if (nameEl) nameEl.textContent = user.nome || '';
     if (profileEl) profileEl.textContent = user.perfil || 'Sem Perfil';
+    if (user.id) {
+      fetch(`${API_URL}/api/usuarios/${user.id}`)
+        .then((r) => (r.ok ? r.json() : null))
+        .then((data) => {
+          if (profileEl) profileEl.textContent = data?.perfil || user.perfil || 'Sem Perfil';
+        })
+        .catch(() => {
+          if (profileEl) profileEl.textContent = user.perfil || 'Sem Perfil';
+        });
+    }
   } catch (e) {
     /* ignore */
   }


### PR DESCRIPTION
## Summary
- add backend endpoint to retrieve user's perfil by id
- fetch user perfil on load to update header display

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a380cf1038832296fc0e0a7208ce7f