### PR TITLE
Corrigir carregamento do nome e perfil sem lembrar-me

### DIFF
--- a/src/login/loginRenderer.js
+++ b/src/login/loginRenderer.js
@@ -141,7 +141,8 @@ if (intro) {
 
   const storedPin = localStorage.getItem('pin');
   const storedUser = localStorage.getItem('user');
-  if (storedUser) {
+  const rememberUser = localStorage.getItem('rememberUser') === '1';
+  if (storedUser && rememberUser) {
     let saved = await window.electronAPI.loadState();
     if (saved) {
       try {
@@ -174,6 +175,7 @@ if (intro) {
       return;
     }
     localStorage.removeItem('user');
+    localStorage.removeItem('rememberUser');
     localStorage.removeItem('pin');
     if (result && result.reason === 'offline') {
       showOfflineError();
@@ -182,6 +184,9 @@ if (intro) {
     }
     localStorage.removeItem('pinChanged');
     localStorage.removeItem('offlineDisconnect');
+  } else if (storedUser && !rememberUser) {
+    localStorage.removeItem('user');
+    localStorage.removeItem('rememberUser');
   }
   if (localStorage.getItem('pinChanged')) {
     localStorage.removeItem('pinChanged');
@@ -350,8 +355,8 @@ if (intro) {
     else {
       showToast('Login realizado com sucesso!', 'success');
       const remember = document.getElementById('remember').checked;
-      if (remember && result.user) localStorage.setItem('user', JSON.stringify(result.user));
-      else                         localStorage.removeItem('user');
+      if (result.user) localStorage.setItem('user', JSON.stringify(result.user));
+      localStorage.setItem('rememberUser', remember ? '1' : '0');
       localStorage.setItem('pin', pin);
       sessionStorage.setItem('currentUser', JSON.stringify(result.user));
 

--- a/src/utils/userActions.js
+++ b/src/utils/userActions.js
@@ -2,7 +2,15 @@ window.addEventListener('DOMContentLoaded', () => {
   const nameEl = document.getElementById('userName');
   const profileEl = document.getElementById('userProfile');
   try {
-    const stored = sessionStorage.getItem('currentUser') || localStorage.getItem('user');
+    const storedSession = sessionStorage.getItem('currentUser');
+    let stored = storedSession || localStorage.getItem('user');
+    if (!storedSession && stored) {
+      sessionStorage.setItem('currentUser', stored);
+      if (localStorage.getItem('rememberUser') !== '1') {
+        localStorage.removeItem('user');
+        localStorage.removeItem('rememberUser');
+      }
+    }
     const user = stored ? JSON.parse(stored) : {};
     if (nameEl) nameEl.textContent = user.nome || '';
     if (profileEl) profileEl.textContent = user.perfil || 'Sem Perfil';
@@ -65,6 +73,7 @@ action('logout', () => {
     // Se existir, remove
     localStorage.removeItem('user');
   }
+  localStorage.removeItem('rememberUser');
 
   // 1) pré-carrega o login por trás
   setTimeout(() => {


### PR DESCRIPTION
## Summary
- Ensure auto-login runs only when user opted to be remembered
- Persist user data for the session and clean up when "Lembrar-me" is off

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a38347d63c83229dbf7107445985e8