### PR TITLE
Add Transportadora And Forma De Pagamento Selects To Orçamento Forms

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -8,6 +8,7 @@ const path                  = require('path');
 const clientesRouter        = require('./clientesController');
 const passwordResetRouter   = require('./passwordResetRoutes');
 const usuariosRouter        = require('./usuariosController');
+const transportadorasRouter = require('./transportadorasController');
 
 const app = express();
 app.use(cors());
@@ -15,6 +16,7 @@ app.use(express.json());
 
 app.use('/api/clientes', clientesRouter);
 app.use('/api/usuarios', usuariosRouter);
+app.use('/api/transportadoras', transportadorasRouter);
 app.use(passwordResetRouter);
 
 // Endpoint simples para verificar a disponibilidade do servidor

--- a/backend/transportadorasController.js
+++ b/backend/transportadorasController.js
@@ -1,0 +1,21 @@
+const express = require('express');
+const pool = require('./db');
+
+const router = express.Router();
+
+// GET /api/transportadoras/:clienteId
+router.get('/:clienteId', async (req, res) => {
+  const { clienteId } = req.params;
+  try {
+    const result = await pool.query(
+      'SELECT id, nome FROM transportadora WHERE id_cliente = $1 ORDER BY nome',
+      [clienteId]
+    );
+    res.json(result.rows);
+  } catch (err) {
+    console.error('Erro ao listar transportadoras:', err);
+    res.status(500).json({ error: 'Erro ao listar transportadoras' });
+  }
+});
+
+module.exports = router;

--- a/src/html/modals/orcamentos/editar.html
+++ b/src/html/modals/orcamentos/editar.html
@@ -48,6 +48,23 @@
             <label for="editarCondicao" class="absolute left-4 top-1/2 -translate-y-1/2 text-base text-gray-300 pointer-events-none transition-all duration-150 peer-focus:top-0 peer-focus:-translate-y-full peer-focus:text-xs peer-focus:text-primary peer-data-[filled=true]:top-0 peer-data-[filled=true]:-translate-y-full peer-data-[filled=true]:text-xs">Condição de pagamento</label>
             <i class="fas fa-chevron-down absolute right-4 top-1/2 -translate-y-1/2 text-gray-300 pointer-events-none"></i>
           </div>
+          <div class="relative">
+            <select id="editarTransportadora" class="peer w-full appearance-none bg-input border border-inputBorder rounded-lg px-4 pr-12 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition" data-filled="false">
+              <option value="" disabled selected hidden></option>
+            </select>
+            <label for="editarTransportadora" class="absolute left-4 top-1/2 -translate-y-1/2 text-base text-gray-300 pointer-events-none transition-all duration-150 peer-focus:top-0 peer-focus:-translate-y-full peer-focus:text-xs peer-focus:text-primary peer-data-[filled=true]:top-0 peer-data-[filled=true]:-translate-y-full peer-data-[filled=true]:text-xs">Transportadora</label>
+            <i class="fas fa-chevron-down absolute right-4 top-1/2 -translate-y-1/2 text-gray-300 pointer-events-none"></i>
+          </div>
+          <div class="relative">
+            <select id="editarFormaPagamento" class="peer w-full appearance-none bg-input border border-inputBorder rounded-lg px-4 pr-12 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition" data-filled="false">
+              <option value="" disabled selected hidden></option>
+              <option value="boleto">Boleto</option>
+              <option value="pix">Pix</option>
+              <option value="cartao">Cartão de Crédito</option>
+            </select>
+            <label for="editarFormaPagamento" class="absolute left-4 top-1/2 -translate-y-1/2 text-base text-gray-300 pointer-events-none transition-all duration-150 peer-focus:top-0 peer-focus:-translate-y-full peer-focus:text-xs peer-focus:text-primary peer-data-[filled=true]:top-0 peer-data-[filled=true]:-translate-y-full peer-data-[filled=true]:text-xs">Forma de Pagamento</label>
+            <i class="fas fa-chevron-down absolute right-4 top-1/2 -translate-y-1/2 text-gray-300 pointer-events-none"></i>
+          </div>
           <div class="relative lg:col-span-2">
             <textarea id="editarObservacoes" rows="2" placeholder=" " class="peer w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-transparent focus:border-primary focus:ring-2 focus:ring-primary/50 transition"></textarea>
             <label for="editarObservacoes" class="absolute left-4 top-3 text-base text-gray-300 pointer-events-none transition-all duration-150 peer-placeholder-shown:top-3 peer-placeholder-shown:text-base peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary peer-valid:-top-2 peer-valid:text-xs">Observações</label>

--- a/src/html/modals/orcamentos/novo.html
+++ b/src/html/modals/orcamentos/novo.html
@@ -40,6 +40,23 @@
             <label for="novoCondicao" class="absolute left-4 top-1/2 -translate-y-1/2 text-base text-gray-300 pointer-events-none transition-all duration-150 peer-focus:top-0 peer-focus:-translate-y-full peer-focus:text-xs peer-focus:text-primary peer-data-[filled=true]:top-0 peer-data-[filled=true]:-translate-y-full peer-data-[filled=true]:text-xs">Condição de pagamento</label>
             <i class="fas fa-chevron-down absolute right-4 top-1/2 -translate-y-1/2 text-gray-300 pointer-events-none"></i>
           </div>
+          <div class="relative">
+            <select id="novoTransportadora" class="peer w-full appearance-none bg-input border border-inputBorder rounded-lg px-4 pr-12 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition" data-filled="false">
+              <option value="" disabled selected hidden></option>
+            </select>
+            <label for="novoTransportadora" class="absolute left-4 top-1/2 -translate-y-1/2 text-base text-gray-300 pointer-events-none transition-all duration-150 peer-focus:top-0 peer-focus:-translate-y-full peer-focus:text-xs peer-focus:text-primary peer-data-[filled=true]:top-0 peer-data-[filled=true]:-translate-y-full peer-data-[filled=true]:text-xs">Transportadora</label>
+            <i class="fas fa-chevron-down absolute right-4 top-1/2 -translate-y-1/2 text-gray-300 pointer-events-none"></i>
+          </div>
+          <div class="relative">
+            <select id="novoFormaPagamento" class="peer w-full appearance-none bg-input border border-inputBorder rounded-lg px-4 pr-12 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition" data-filled="false">
+              <option value="" disabled selected hidden></option>
+              <option value="boleto">Boleto</option>
+              <option value="pix">Pix</option>
+              <option value="cartao">Cartão de Crédito</option>
+            </select>
+            <label for="novoFormaPagamento" class="absolute left-4 top-1/2 -translate-y-1/2 text-base text-gray-300 pointer-events-none transition-all duration-150 peer-focus:top-0 peer-focus:-translate-y-full peer-focus:text-xs peer-focus:text-primary peer-data-[filled=true]:top-0 peer-data-[filled=true]:-translate-y-full peer-data-[filled=true]:text-xs">Forma de Pagamento</label>
+            <i class="fas fa-chevron-down absolute right-4 top-1/2 -translate-y-1/2 text-gray-300 pointer-events-none"></i>
+          </div>
         <div class="relative lg:col-span-2">
             <textarea id="novoObservacoes" rows="2" placeholder=" " class="peer w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-transparent focus:border-primary focus:ring-2 focus:ring-primary/50 transition"></textarea>
             <label for="novoObservacoes" class="absolute left-4 top-3 text-base text-gray-300 pointer-events-none transition-all duration-150 peer-placeholder-shown:top-3 peer-placeholder-shown:text-base peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary peer-valid:-top-2 peer-valid:text-xs">Observações</label>

--- a/src/js/modals/orcamento-novo.js
+++ b/src/js/modals/orcamento-novo.js
@@ -13,6 +13,8 @@
   const produtoSelect = document.getElementById('itemProduto');
   const itensTbody = document.querySelector('#novoItensTabela tbody');
   const condicaoSelect = document.getElementById('novoCondicao');
+  const transportadoraSelect = document.getElementById('novoTransportadora');
+  const formaPagamentoSelect = document.getElementById('novoFormaPagamento');
   const pagamentoBox = document.getElementById('novoPagamento');
   const condicaoWrapper = condicaoSelect.parentElement;
   let parcelamentoLoaded = false;
@@ -99,6 +101,22 @@
     } catch(err){ console.error('Erro ao carregar contatos', err); }
   }
 
+  async function carregarTransportadoras(clienteId){
+    transportadoraSelect.innerHTML = '<option value="" disabled selected hidden></option>';
+    transportadoraSelect.setAttribute('data-filled', 'false');
+    if(!clienteId) return;
+    try {
+      const resp = await fetch(`http://localhost:3000/api/transportadoras/${clienteId}`);
+      const data = await resp.json();
+      data.forEach(tp => {
+        const opt = document.createElement('option');
+        opt.value = tp.id;
+        opt.textContent = tp.nome;
+        transportadoraSelect.appendChild(opt);
+      });
+    } catch(err){ console.error('Erro ao carregar transportadoras', err); }
+  }
+
   async function carregarProdutos(){
     try {
       const lista = await (window.electronAPI?.listarProdutos?.() ?? []);
@@ -110,7 +128,7 @@
   }
 
   // sincroniza labels flutuantes
-  ['novoCliente','novoContato','novoCondicao','itemProduto'].forEach(id => {
+  ['novoCliente','novoContato','novoCondicao','novoTransportadora','novoFormaPagamento','itemProduto'].forEach(id => {
     const el = document.getElementById(id);
     if(!el) return;
     const sync = () => el.setAttribute('data-filled', el.value !== '' ? 'true' : 'false');
@@ -121,6 +139,7 @@
 
   clienteSelect.addEventListener('change', () => {
     carregarContatos(clienteSelect.value);
+    carregarTransportadoras(clienteSelect.value);
   });
 
   carregarClientes();
@@ -319,6 +338,9 @@
     const contatoText = contatoSelect.options[contatoSelect.selectedIndex]?.textContent || '';
     const condicaoVal = condicaoSelect.value;
     const condicaoText = condicaoSelect.options[condicaoSelect.selectedIndex].textContent;
+    const transportadoraVal = transportadoraSelect.value;
+    const transportadoraText = transportadoraSelect.options[transportadoraSelect.selectedIndex]?.textContent || '';
+    const formaPagamentoVal = formaPagamentoSelect.value;
     const total = document.getElementById('novoTotal').textContent;
     const itens = Array.from(itensTbody.children).map(tr => ({
       id: tr.dataset.id,
@@ -366,14 +388,20 @@
       const clienteId = row.dataset.clienteId;
       const contato = row.dataset.contato;
       const contatoId = row.dataset.contatoId;
+      const transportadora = row.dataset.transportadora;
+      const transportadoraId = row.dataset.transportadoraId;
+      const formaPagamento = row.dataset.formaPagamento;
       const itemsData = JSON.parse(row.dataset.items || '[]');
-      window.selectedQuoteData = { id, cliente, clienteId, condicao, status: statusTxt, contato, contatoId, items: itemsData, row };
+      window.selectedQuoteData = { id, cliente, clienteId, condicao, status: statusTxt, contato, contatoId, transportadora, transportadoraId, formaPagamento, items: itemsData, row };
       Modal.open('modals/orcamentos/editar.html', '../js/modals/orcamento-editar.js', 'editarOrcamento');
     });
     tr.dataset.clienteId = clienteVal;
     tr.dataset.cliente = clienteText;
     tr.dataset.contatoId = contatoVal;
     tr.dataset.contato = contatoText;
+    tr.dataset.transportadoraId = transportadoraVal;
+    tr.dataset.transportadora = transportadoraText;
+    tr.dataset.formaPagamento = formaPagamentoVal;
     tr.dataset.items = JSON.stringify(itens);
     tr.dataset.condicao = condicaoVal;
     Modal.close(overlayId);


### PR DESCRIPTION
## Summary
- add transportadora and forma de pagamento selects on new and edit orçamento forms
- load client-specific transportadoras via new backend API

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a48550a9f08322986e4dc28907acc6