### PR TITLE
Padronizar caixa de diálogo de condição de pagamento

### DIFF
--- a/src/js/modals/orcamento-editar.js
+++ b/src/js/modals/orcamento-editar.js
@@ -46,6 +46,14 @@
     overlay.querySelector('#resetNo').addEventListener('click',()=>{overlay.remove();cb(false);});
   }
 
+  function showBlockedDialog(){
+    const overlay=document.createElement('div');
+    overlay.className='fixed inset-0 bg-black/50 flex items-center justify-center p-4';
+    overlay.innerHTML=`<div class="max-w-sm w-full glass-surface backdrop-blur-xl rounded-2xl border border-yellow-500/20 ring-1 ring-yellow-500/30 shadow-2xl/40 animate-modalFade"><div class="p-6 text-center"><h3 class="text-lg font-semibold mb-4 text-yellow-400">Atenção</h3><p class="text-sm text-gray-300 mb-6">Você não pode escolher uma condição de pagamento bloqueada. Se desejar manter esta condição de pagamento, desbloqueie-a antes de continuar.</p><div class="flex justify-center"><button id="blockedOk" class="btn-warning px-6 py-2 rounded-lg text-white font-medium active:scale-95">OK</button></div></div></div>`;
+    document.body.appendChild(overlay);
+    overlay.querySelector('#blockedOk').addEventListener('click',()=>overlay.remove());
+  }
+
   function showActionDialog(message, cb){
     const overlay=document.createElement('div');
     overlay.className='fixed inset-0 bg-black/50 flex items-center justify-center p-4';
@@ -76,7 +84,7 @@
     }
   }
   editarCondicao.addEventListener('change',()=>{condicaoDefinida=true;editarCondicao.setAttribute('data-filled','true');updateCondicao();recalcTotals();});
-  condicaoWrapper.addEventListener('click',e=>{if(editarCondicao.disabled){e.preventDefault();alert('Você não pode escolher uma condição de pagamento bloqueada. Se desejar manter esta condição de pagamento, desbloqueie-a antes de continuar.');}});
+  condicaoWrapper.addEventListener('click',e=>{if(editarCondicao.disabled){e.preventDefault();showBlockedDialog();}});
   editarCondicao.disabled=true;
   editarCondicao.style.pointerEvents='none';
 

--- a/src/js/modals/orcamento-novo.js
+++ b/src/js/modals/orcamento-novo.js
@@ -43,6 +43,13 @@
     overlay.querySelector('#resetYes').addEventListener('click',()=>{overlay.remove();cb(true);});
     overlay.querySelector('#resetNo').addEventListener('click',()=>{overlay.remove();cb(false);});
   }
+  function showBlockedDialog(){
+    const overlay=document.createElement('div');
+    overlay.className='fixed inset-0 bg-black/50 flex items-center justify-center p-4';
+    overlay.innerHTML=`<div class="max-w-sm w-full glass-surface backdrop-blur-xl rounded-2xl border border-yellow-500/20 ring-1 ring-yellow-500/30 shadow-2xl/40 animate-modalFade"><div class="p-6 text-center"><h3 class="text-lg font-semibold mb-4 text-yellow-400">Atenção</h3><p class="text-sm text-gray-300 mb-6">Você não pode escolher uma condição de pagamento bloqueada. Se desejar manter esta condição de pagamento, desbloqueie-a antes de continuar.</p><div class="flex justify-center"><button id="blockedOk" class="btn-warning px-6 py-2 rounded-lg text-white font-medium active:scale-95">OK</button></div></div></div>`;
+    document.body.appendChild(overlay);
+    overlay.querySelector('#blockedOk').addEventListener('click',()=>overlay.remove());
+  }
   function confirmResetIfNeeded(action){
     if(!condicaoDefinida){action();return;}
     showResetDialog(ok=>{
@@ -69,7 +76,7 @@
     }
   }
   condicaoSelect.addEventListener('change', ()=>{condicaoDefinida=true;condicaoSelect.setAttribute('data-filled','true');updateCondicao();recalcTotals();});
-  condicaoWrapper.addEventListener('click',e=>{if(condicaoSelect.disabled){e.preventDefault();alert('Você não pode escolher uma condição de pagamento bloqueada. Se desejar manter esta condição de pagamento, desbloqueie-a antes de continuar.');}});
+  condicaoWrapper.addEventListener('click',e=>{if(condicaoSelect.disabled){e.preventDefault();showBlockedDialog();}});
   condicaoSelect.disabled = true;
   condicaoSelect.style.pointerEvents='none';
   updateCondicao();


### PR DESCRIPTION
## Summary
- aplicar modal de atenção estilizado ao clicar em condição de pagamento bloqueada na criação de orçamento
- aplicar modal de atenção estilizado ao clicar em condição de pagamento bloqueada na edição de orçamento

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a48c0e92588322aad6b4c85bc1bdd4