### PR TITLE
Implementar salvamento e envio de novo orçamento

### DIFF
--- a/backend/orcamentosController.js
+++ b/backend/orcamentosController.js
@@ -1,0 +1,98 @@
+const express = require('express');
+const db = require('./db');
+
+const router = express.Router();
+
+router.post('/', async (req, res) => {
+  const {
+    cliente_id,
+    contato_id,
+    situacao,
+    parcelas,
+    forma_pagamento,
+    transportadora,
+    desconto_pagamento,
+    desconto_especial,
+    desconto_total,
+    valor_final,
+    observacoes,
+    validade,
+    prazo,
+    itens = [],
+    parcelas_detalhes = []
+  } = req.body;
+
+  const client = await db.connect();
+  try {
+    await client.query('BEGIN');
+    const { rows: last } = await client.query('SELECT numero FROM orcamentos ORDER BY id DESC LIMIT 1');
+    let numero = 'ORC1';
+    if (last.length) {
+      const seq = parseInt(String(last[0].numero).replace(/\D/g, ''), 10) + 1;
+      numero = `ORC${seq}`;
+    }
+    const now = new Date();
+    const insertOrc = await client.query(
+      `INSERT INTO orcamentos (numero, cliente_id, contato_id, data_emissao, situacao, parcelas, forma_pagamento, transportadora, desconto_pagamento, desconto_especial, desconto_total, valor_final, observacoes, validade, prazo)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15) RETURNING id`,
+      [
+        numero,
+        cliente_id,
+        contato_id,
+        now,
+        situacao,
+        parcelas,
+        forma_pagamento,
+        transportadora,
+        desconto_pagamento,
+        desconto_especial,
+        desconto_total,
+        valor_final,
+        observacoes,
+        validade,
+        prazo
+      ]
+    );
+    const orcamentoId = insertOrc.rows[0].id;
+
+    for (const item of itens) {
+      await client.query(
+        `INSERT INTO orcamentos_itens (orcamento_id, produto_id, codigo, nome, ncm, quantidade, valor_unitario, valor_unitario_desc, valor_desc, desconto_total, valor_total)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)`,
+        [
+          orcamentoId,
+          item.produto_id,
+          item.codigo,
+          item.nome,
+          item.ncm,
+          item.quantidade,
+          item.valor_unitario,
+          item.valor_unitario_desc,
+          item.valor_desc,
+          item.desconto_total,
+          item.valor_total
+        ]
+      );
+    }
+
+    for (let i = 0; i < parcelas_detalhes.length; i++) {
+      const p = parcelas_detalhes[i];
+      await client.query(
+        `INSERT INTO orcamento_parcelas (orcamento_id, numero_parcela, valor, data_vencimento, status)
+         VALUES ($1,$2,$3,$4,$5)`,
+        [orcamentoId, i + 1, p.valor, p.data_vencimento, 'Pendente']
+      );
+    }
+
+    await client.query('COMMIT');
+    res.json({ success: true, numero });
+  } catch (err) {
+    await client.query('ROLLBACK');
+    console.error('Erro ao salvar orçamento:', err);
+    res.status(500).json({ error: 'Erro ao salvar orçamento' });
+  } finally {
+    client.release();
+  }
+});
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -9,6 +9,7 @@ const clientesRouter        = require('./clientesController');
 const passwordResetRouter   = require('./passwordResetRoutes');
 const usuariosRouter        = require('./usuariosController');
 const transportadorasRouter = require('./transportadorasController');
+const orcamentosRouter      = require('./orcamentosController');
 
 const app = express();
 app.use(cors());
@@ -17,6 +18,7 @@ app.use(express.json());
 app.use('/api/clientes', clientesRouter);
 app.use('/api/usuarios', usuariosRouter);
 app.use('/api/transportadoras', transportadorasRouter);
+app.use('/api/orcamentos', orcamentosRouter);
 app.use(passwordResetRouter);
 
 // Endpoint simples para verificar a disponibilidade do servidor

--- a/src/js/utils/parcelamento.js
+++ b/src/js/utils/parcelamento.js
@@ -135,7 +135,11 @@
     }
     recompute(id);
   }
-  window.Parcelamento={init,updateTotal};
+  function getData(id){
+    const inst=instances.get(id); if(!inst) return null;
+    return JSON.parse(JSON.stringify(inst.state));
+  }
+  window.Parcelamento={init,updateTotal,getData};
   window.parseCurrencyToCents=parseCurrencyToCents;
   window.formatCentsBRL=formatCentsBRL;
   window.parseIntOnly=parseIntOnly;


### PR DESCRIPTION
## Summary
- Validar campos e confirmar antes de salvar ou enviar novos orçamentos
- Persistir orçamentos, itens e parcelas no banco via nova rota
- Expor dados de parcelamento para coleta no front-end

## Testing
- `node --test ./backend` *(fails: Cannot find module '/workspace/App-Gestao/backend')*

------
https://chatgpt.com/codex/tasks/task_e_68a49934628c83229d3b9f0ad65952db