### PR TITLE
Corrigir alerta de campos faltantes em novo orçamento

### DIFF
--- a/src/js/modals/orcamento-novo.js
+++ b/src/js/modals/orcamento-novo.js
@@ -61,6 +61,14 @@
     document.body.appendChild(overlay);
     overlay.querySelector('#blockedOk').addEventListener('click',()=>overlay.remove());
   }
+
+  function showMissingDialog(fields){
+    const overlay=document.createElement('div');
+    overlay.className='fixed inset-0 bg-black/50 flex items-center justify-center p-4';
+    overlay.innerHTML=`<div class="max-w-sm w-full glass-surface backdrop-blur-xl rounded-2xl border border-yellow-500/20 ring-1 ring-yellow-500/30 shadow-2xl/40 animate-modalFade"><div class="p-6 text-center"><h3 class="text-lg font-semibold mb-4 text-yellow-400">Dados Incompletos</h3><p class="text-sm text-gray-300 mb-6">Preencha os campos: ${fields.join(', ')}</p><div class="flex justify-center"><button id="missingOk" class="btn-warning px-6 py-2 rounded-lg text-white font-medium active:scale-95">OK</button></div></div></div>`;
+    document.body.appendChild(overlay);
+    overlay.querySelector('#missingOk').addEventListener('click',()=>overlay.remove());
+  }
   function confirmResetIfNeeded(action){
     if(!condicaoDefinida){action();return;}
     showResetDialog(ok=>{
@@ -399,7 +407,7 @@
     }
 
     if (missing.length) {
-      showToast('Preencha os campos: ' + missing.join(', '), 'error');
+      showMissingDialog(missing);
       return;
     }
 


### PR DESCRIPTION
## Summary
- substituir toast por diálogo com visual de condição de pagamento ao salvar orçamento sem informações

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a49ee91180832298649fc90344e6ca