### PR TITLE
Atualiza Filtros De Orçamentos Com Tag Rascunho Azul

### DIFF
--- a/src/css/orcamentos.css
+++ b/src/css/orcamentos.css
@@ -149,6 +149,11 @@ body {
     color: var(--color-green);
 }
 
+.badge-info {
+    background: rgba(138, 167, 243, 0.2);
+    color: var(--color-blue);
+}
+
 .badge-warning {
     background: rgba(212, 193, 105, 0.2);
     color: var(--color-primary);

--- a/src/html/modals/orcamentos/editar.html
+++ b/src/html/modals/orcamentos/editar.html
@@ -7,6 +7,7 @@
         <div class="relative">
           <button id="statusTag" class="badge-warning px-3 py-1 rounded-full text-xs font-medium cursor-pointer">Pendente</button>
           <div id="statusOptions" class="hidden absolute left-0 mt-2 w-32 bg-gray-800 z-50 rounded-xl border border-white/10 shadow-lg">
+            <button data-status="Rascunho" class="block w-full text-left px-4 py-2 text-white hover:bg-gray-700">Rascunho</button>
             <button data-status="Pendente" class="block w-full text-left px-4 py-2 text-white hover:bg-gray-700">Pendente</button>
             <button data-status="Aprovado" class="block w-full text-left px-4 py-2 text-white hover:bg-gray-700">Aprovado</button>
             <button data-status="Rejeitado" class="block w-full text-left px-4 py-2 text-white hover:bg-gray-700">Rejeitado</button>

--- a/src/html/orcamentos.html
+++ b/src/html/orcamentos.html
@@ -19,6 +19,7 @@
                 <label class="block text-sm font-medium mb-2 text-white">Status</label>
                 <select id="filterStatus" class="input-glass text-white rounded-md px-4 py-3 w-full">
                     <option value="">Todos os Status</option>
+                    <option value="Rascunho">Rascunho</option>
                     <option value="Pendente">Pendente</option>
                     <option value="Aprovado">Aprovado</option>
                     <option value="Rejeitado">Rejeitado</option>
@@ -35,14 +36,15 @@
                     <option value="Mês">Mês</option>
                     <option value="Trimestre">Trimestre</option>
                     <option value="Ano">Ano</option>
+                    <option value="Personalizado">Personalizado</option>
                 </select>
             </div>
 
             <!-- Salesperson Filter -->
             <div class="flex-1 min-w-0">
-                <label class="block text-sm font-medium mb-2 text-white">Vendedor</label>
-                <select id="filterSeller" class="input-glass text-white rounded-md px-4 py-3 w-full">
-                    <option value="">Todos os Vendedores</option>
+                <label class="block text-sm font-medium mb-2 text-white">Dono</label>
+                <select id="filterOwner" class="input-glass text-white rounded-md px-4 py-3 w-full">
+                    <option value="">Todos os Donos</option>
                     <option value="João Silva">João Silva</option>
                     <option value="Maria Santos">Maria Santos</option>
                     <option value="Pedro Costa">Pedro Costa</option>
@@ -66,8 +68,8 @@
                     Limpar
                 </button>
             </div>
-        </div>
-    </div>
+</div>
+</div>
 
     <!-- Quotes Table -->
     <div class="glass-surface rounded-xl shadow-lg animate-fade-in-up table-scroll">
@@ -85,5 +87,24 @@
             </thead>
             <tbody id="orcamentosTabela" class="divide-y divide-white/10"></tbody>
             </table>
+    </div>
+</div>
+
+<!-- Modal de período personalizado -->
+<div id="periodModal" class="hidden fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+    <div class="bg-white rounded-lg p-6 text-gray-800">
+        <div class="flex gap-4 mb-4">
+            <div>
+                <label for="startDate" class="block text-sm mb-1">De</label>
+                <input type="date" id="startDate" class="border rounded px-2 py-1" />
+            </div>
+            <div>
+                <label for="endDate" class="block text-sm mb-1">Até</label>
+                <input type="date" id="endDate" class="border rounded px-2 py-1" />
+            </div>
+        </div>
+        <div class="text-right">
+            <button id="periodConfirm" class="btn-primary text-white px-4 py-2 rounded">Confirmar</button>
+        </div>
     </div>
 </div>

--- a/src/js/modals/orcamento-editar.js
+++ b/src/js/modals/orcamento-editar.js
@@ -192,7 +192,7 @@
   });
 
   const statusMap = {
-    'Rascunho': 'badge-neutral',
+    'Rascunho': 'badge-info',
     'Pendente': 'badge-warning',
     'Aprovado': 'badge-success',
     'Rejeitado': 'badge-danger',

--- a/src/js/orcamentos.js
+++ b/src/js/orcamentos.js
@@ -1,11 +1,16 @@
 // Lógica de interação para o módulo de Orçamentos
-function popularClientes() {
+window.customStartDate = null;
+window.customEndDate = null;
+async function popularClientes() {
     const select = document.getElementById('filterClient');
-    const rows = document.querySelectorAll('#orcamentosTabela tr');
-    const clientes = [...new Set(Array.from(rows).map(r => r.cells[1]?.textContent.trim()).filter(Boolean))];
-    if (select) {
+    if (!select) return;
+    try {
+        const resp = await fetch('http://localhost:3000/api/clientes/lista');
+        const data = await resp.json();
         select.innerHTML = '<option value="">Todos os Clientes</option>' +
-            clientes.map(c => `<option value="${c}">${c}</option>`).join('');
+            data.map(c => `<option value="${c.nome_fantasia}">${c.nome_fantasia}</option>`).join('');
+    } catch (err) {
+        console.error('Erro ao carregar clientes', err);
     }
 }
 
@@ -16,7 +21,7 @@ async function carregarOrcamentos() {
         const tbody = document.getElementById('orcamentosTabela');
         tbody.innerHTML = '';
         const statusClasses = {
-            'Rascunho': 'badge-neutral',
+            'Rascunho': 'badge-info',
             'Pendente': 'badge-warning',
             'Aprovado': 'badge-success',
             'Rejeitado': 'badge-danger',
@@ -29,6 +34,7 @@ async function carregarOrcamentos() {
             tr.setAttribute('onmouseover', "this.style.background='rgba(163, 148, 167, 0.05)'");
             tr.setAttribute('onmouseout', "this.style.background='transparent'");
             tr.dataset.id = o.id;
+            tr.dataset.dono = o.dono || o.vendedor || '';
             const condicao = o.parcelas > 1 ? `${o.parcelas}x` : 'À vista';
             const badgeClass = statusClasses[o.situacao] || 'badge-neutral';
             const valor = Number(o.valor_final || 0).toLocaleString('pt-BR', {style:'currency', currency:'BRL'});
@@ -56,7 +62,7 @@ async function carregarOrcamentos() {
                 Modal.open('modals/orcamentos/editar.html', '../js/modals/orcamento-editar.js', 'editarOrcamento');
             });
         });
-        popularClientes();
+        await popularClientes();
     } catch (err) {
         console.error('Erro ao carregar orçamentos', err);
     }
@@ -66,27 +72,33 @@ window.reloadOrcamentos = carregarOrcamentos;
 function aplicarFiltro() {
     const status = document.getElementById('filterStatus')?.value || '';
     const periodo = document.getElementById('filterPeriod')?.value || '';
-    const vendedor = document.getElementById('filterSeller')?.value || '';
+    const dono = document.getElementById('filterOwner')?.value || '';
     const cliente = document.getElementById('filterClient')?.value.toLowerCase() || '';
     const now = new Date();
     document.querySelectorAll('#orcamentosTabela tr').forEach(row => {
         const rowStatus = row.cells[5]?.innerText.trim() || '';
         const rowCliente = row.cells[1]?.innerText.trim().toLowerCase() || '';
-        const rowVendedor = (row.dataset.vendedor || '').toLowerCase();
+        const rowDono = (row.dataset.dono || '').toLowerCase();
         const dateText = row.cells[2]?.innerText.trim();
         let show = true;
 
         if (status) show &&= rowStatus === status;
-        if (vendedor) show &&= rowVendedor === vendedor.toLowerCase();
+        if (dono) show &&= rowDono === dono.toLowerCase();
         if (cliente) show &&= rowCliente === cliente;
         if (periodo) {
             const [d, m, y] = dateText.split('/').map(Number);
             const rowDate = new Date(y, m - 1, d);
-            const diff = (now - rowDate) / (1000 * 60 * 60 * 24);
-            if (periodo === 'Semana') show &&= diff <= 7;
-            else if (periodo === 'Mês') show &&= diff <= 30;
-            else if (periodo === 'Trimestre') show &&= diff <= 90;
-            else if (periodo === 'Ano') show &&= diff <= 365;
+            if (periodo === 'Personalizado' && window.customStartDate && window.customEndDate) {
+                const inicio = new Date(window.customStartDate);
+                const fim = new Date(window.customEndDate);
+                show &&= rowDate >= inicio && rowDate <= fim;
+            } else {
+                const diff = (now - rowDate) / (1000 * 60 * 60 * 24);
+                if (periodo === 'Semana') show &&= diff <= 7;
+                else if (periodo === 'Mês') show &&= diff <= 30;
+                else if (periodo === 'Trimestre') show &&= diff <= 90;
+                else if (periodo === 'Ano') show &&= diff <= 365;
+            }
         }
 
         row.style.display = show ? '' : 'none';
@@ -96,8 +108,10 @@ function aplicarFiltro() {
 function limparFiltros() {
     document.getElementById('filterStatus').value = '';
     document.getElementById('filterPeriod').value = '';
-    document.getElementById('filterSeller').value = '';
+    document.getElementById('filterOwner').value = '';
     document.getElementById('filterClient').value = '';
+    window.customStartDate = null;
+    window.customEndDate = null;
     aplicarFiltro();
 }
 
@@ -121,6 +135,23 @@ function initOrcamentos() {
     const limpar = document.getElementById('btnLimpar');
     if (filtrar) filtrar.addEventListener('click', aplicarFiltro);
     if (limpar) limpar.addEventListener('click', limparFiltros);
+
+    const periodSelect = document.getElementById('filterPeriod');
+    const periodModal = document.getElementById('periodModal');
+    const periodConfirm = document.getElementById('periodConfirm');
+    periodSelect?.addEventListener('change', () => {
+        if (periodSelect.value === 'Personalizado') {
+            periodModal.classList.remove('hidden');
+        }
+    });
+    periodConfirm?.addEventListener('click', () => {
+        window.customStartDate = document.getElementById('startDate').value;
+        window.customEndDate = document.getElementById('endDate').value;
+        periodModal.classList.add('hidden');
+        periodSelect.value = 'Personalizado';
+        aplicarFiltro();
+    });
+
     carregarOrcamentos();
 }
 


### PR DESCRIPTION
## Summary
- colore status "Rascunho" com badge azul
- permite filtrar orçamentos por dono e período personalizado
- carrega lista de clientes a partir do backend

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4a6d158648322ae20c9f754dcb7c9