### PR TITLE
Adicionar Campo Dono Em Orçamentos

### DIFF
--- a/backend/orcamentosController.js
+++ b/backend/orcamentosController.js
@@ -59,6 +59,7 @@ router.post('/', async (req, res) => {
     observacoes,
     validade,
     prazo,
+    dono,
     itens = [],
     parcelas_detalhes = []
   } = req.body;
@@ -74,8 +75,8 @@ router.post('/', async (req, res) => {
     }
     const now = new Date();
     const insertOrc = await client.query(
-      `INSERT INTO orcamentos (numero, cliente_id, contato_id, data_emissao, situacao, parcelas, forma_pagamento, transportadora, desconto_pagamento, desconto_especial, desconto_total, valor_final, observacoes, validade, prazo)
-       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15) RETURNING id`,
+      `INSERT INTO orcamentos (numero, cliente_id, contato_id, data_emissao, situacao, parcelas, forma_pagamento, transportadora, desconto_pagamento, desconto_especial, desconto_total, valor_final, observacoes, validade, prazo, dono)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16) RETURNING id`,
       [
         numero,
         cliente_id,
@@ -91,7 +92,8 @@ router.post('/', async (req, res) => {
         valor_final,
         observacoes,
         validade,
-        prazo
+        prazo,
+        dono
       ]
     );
     const orcamentoId = insertOrc.rows[0].id;
@@ -153,6 +155,7 @@ router.put('/:id', async (req, res) => {
     observacoes,
     validade,
     prazo,
+    dono,
     itens = [],
     parcelas_detalhes = []
   } = req.body;
@@ -163,7 +166,7 @@ router.put('/:id', async (req, res) => {
     await client.query(
       `UPDATE orcamentos SET cliente_id=$1, contato_id=$2, situacao=$3, parcelas=$4, forma_pagamento=$5,
        transportadora=$6, desconto_pagamento=$7, desconto_especial=$8, desconto_total=$9, valor_final=$10,
-       observacoes=$11, validade=$12, prazo=$13 WHERE id=$14`,
+       observacoes=$11, validade=$12, prazo=$13, dono=$14 WHERE id=$15`,
       [
         cliente_id,
         contato_id,
@@ -178,6 +181,7 @@ router.put('/:id', async (req, res) => {
         observacoes,
         validade,
         prazo,
+        dono,
         id
       ]
     );
@@ -246,8 +250,8 @@ router.post('/:id/clone', async (req, res) => {
 
     const insert = await client.query(
       `INSERT INTO orcamentos (numero, cliente_id, contato_id, data_emissao, situacao, parcelas, forma_pagamento, transportadora,
-       desconto_pagamento, desconto_especial, desconto_total, valor_final, observacoes, validade, prazo)
-       VALUES ($1,$2,$3,NOW(),'Rascunho',$4,$5,$6,$7,$8,$9,$10,$11,$12,$13) RETURNING id`,
+       desconto_pagamento, desconto_especial, desconto_total, valor_final, observacoes, validade, prazo, dono)
+       VALUES ($1,$2,$3,NOW(),'Rascunho',$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14) RETURNING id`,
       [
         numero,
         orc.cliente_id,
@@ -261,7 +265,8 @@ router.post('/:id/clone', async (req, res) => {
         orc.valor_final,
         orc.observacoes,
         orc.validade,
-        orc.prazo
+        orc.prazo,
+        orc.dono
       ]
     );
     const newId = insert.rows[0].id;

--- a/src/html/modals/orcamentos/editar.html
+++ b/src/html/modals/orcamentos/editar.html
@@ -66,6 +66,13 @@
             <label for="editarFormaPagamento" class="absolute left-4 top-1/2 -translate-y-1/2 text-base text-gray-300 pointer-events-none transition-all duration-150 peer-focus:top-0 peer-focus:-translate-y-full peer-focus:text-xs peer-focus:text-primary peer-data-[filled=true]:top-0 peer-data-[filled=true]:-translate-y-full peer-data-[filled=true]:text-xs">Forma de Pagamento</label>
             <i class="fas fa-chevron-down absolute right-4 top-1/2 -translate-y-1/2 text-gray-300 pointer-events-none"></i>
           </div>
+          <div class="relative">
+            <select id="editarDono" class="peer w-full appearance-none bg-input border border-inputBorder rounded-lg px-4 pr-12 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition" data-filled="false">
+              <option value="" disabled selected hidden></option>
+            </select>
+            <label for="editarDono" class="absolute left-4 top-1/2 -translate-y-1/2 text-base text-gray-300 pointer-events-none transition-all duration-150 peer-focus:top-0 peer-focus:-translate-y-full peer-focus:text-xs peer-focus:text-primary peer-data-[filled=true]:top-0 peer-data-[filled=true]:-translate-y-full peer-data-[filled=true]:text-xs">Dono</label>
+            <i class="fas fa-chevron-down absolute right-4 top-1/2 -translate-y-1/2 text-gray-300 pointer-events-none"></i>
+          </div>
           <div class="relative lg:col-span-2">
             <textarea id="editarObservacoes" rows="2" placeholder=" " class="peer w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-transparent focus:border-primary focus:ring-2 focus:ring-primary/50 transition"></textarea>
             <label for="editarObservacoes" class="absolute left-4 top-3 text-base text-gray-300 pointer-events-none transition-all duration-150 peer-placeholder-shown:top-3 peer-placeholder-shown:text-base peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary peer-valid:-top-2 peer-valid:text-xs">Observações</label>

--- a/src/html/modals/orcamentos/novo.html
+++ b/src/html/modals/orcamentos/novo.html
@@ -57,6 +57,13 @@
             <label for="novoFormaPagamento" class="absolute left-4 top-1/2 -translate-y-1/2 text-base text-gray-300 pointer-events-none transition-all duration-150 peer-focus:top-0 peer-focus:-translate-y-full peer-focus:text-xs peer-focus:text-primary peer-data-[filled=true]:top-0 peer-data-[filled=true]:-translate-y-full peer-data-[filled=true]:text-xs">Forma de Pagamento</label>
             <i class="fas fa-chevron-down absolute right-4 top-1/2 -translate-y-1/2 text-gray-300 pointer-events-none"></i>
           </div>
+          <div class="relative">
+            <select id="novoDono" class="peer w-full appearance-none bg-input border border-inputBorder rounded-lg px-4 pr-12 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition" data-filled="false">
+              <option value="" disabled selected hidden></option>
+            </select>
+            <label for="novoDono" class="absolute left-4 top-1/2 -translate-y-1/2 text-base text-gray-300 pointer-events-none transition-all duration-150 peer-focus:top-0 peer-focus:-translate-y-full peer-focus:text-xs peer-focus:text-primary peer-data-[filled=true]:top-0 peer-data-[filled=true]:-translate-y-full peer-data-[filled=true]:text-xs">Dono</label>
+            <i class="fas fa-chevron-down absolute right-4 top-1/2 -translate-y-1/2 text-gray-300 pointer-events-none"></i>
+          </div>
         <div class="relative lg:col-span-2">
             <textarea id="novoObservacoes" rows="2" placeholder=" " class="peer w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-transparent focus:border-primary focus:ring-2 focus:ring-primary/50 transition"></textarea>
             <label for="novoObservacoes" class="absolute left-4 top-3 text-base text-gray-300 pointer-events-none transition-all duration-150 peer-placeholder-shown:top-3 peer-placeholder-shown:text-base peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary peer-valid:-top-2 peer-valid:text-xs">Observações</label>

--- a/src/js/modals/orcamento-novo.js
+++ b/src/js/modals/orcamento-novo.js
@@ -26,6 +26,7 @@
   const condicaoSelect = document.getElementById('novoCondicao');
   const transportadoraSelect = document.getElementById('novoTransportadora');
   const formaPagamentoSelect = document.getElementById('novoFormaPagamento');
+  const donoSelect = document.getElementById('novoDono');
   const pagamentoBox = document.getElementById('novoPagamento');
   const condicaoWrapper = condicaoSelect.parentElement;
   let parcelamentoLoaded = false;
@@ -111,6 +112,16 @@
     } catch(err){ console.error('Erro ao carregar clientes', err); }
   }
 
+  async function carregarUsuarios(){
+    try {
+      const resp = await fetch('http://localhost:3000/api/usuarios/lista');
+      const data = await resp.json();
+      donoSelect.innerHTML = '<option value="" disabled selected hidden></option>' +
+        data.map(u => `<option value="${u.nome}">${u.nome}</option>`).join('');
+      donoSelect.setAttribute('data-filled','false');
+    } catch(err){ console.error('Erro ao carregar usuários', err); }
+  }
+
   async function carregarContatos(clienteId){
     contatoSelect.innerHTML = '<option value="" disabled selected hidden></option>';
     contatoSelect.setAttribute('data-filled', 'false');
@@ -161,7 +172,7 @@
   }
 
   // sincroniza labels flutuantes
-  ['novoCliente','novoContato','novoCondicao','novoTransportadora','novoFormaPagamento','itemProduto'].forEach(id => {
+  ['novoCliente','novoContato','novoCondicao','novoTransportadora','novoFormaPagamento','itemProduto','novoDono'].forEach(id => {
     const el = document.getElementById(id);
     if(!el) return;
     const sync = () => el.setAttribute('data-filled', el.value !== '' ? 'true' : 'false');
@@ -173,9 +184,17 @@
   clienteSelect.addEventListener('change', () => {
     carregarContatos(clienteSelect.value);
     carregarTransportadoras(clienteSelect.value);
+    if(!donoSelect.value){
+      const donoCli = clients[clienteSelect.value]?.dono_cliente;
+      if(donoCli){
+        donoSelect.value = donoCli;
+        donoSelect.setAttribute('data-filled','true');
+      }
+    }
   });
 
   carregarClientes();
+  carregarUsuarios();
   carregarProdutos();
 
   function formatCurrency(v) {
@@ -381,6 +400,8 @@
     if (!transportadoraVal) missing.push('Transportadora');
     const formaPagamentoVal = formaPagamentoSelect.value;
     if (!formaPagamentoVal) missing.push('Forma de Pagamento');
+    const donoVal = donoSelect.value;
+    if (!donoVal) missing.push('Dono');
     if (itensTbody.children.length === 0) missing.push('Itens');
 
     const dataEmissao = new Date();
@@ -455,6 +476,7 @@
           observacoes: document.getElementById('novoObservacoes').value || '',
           validade: validadeVal,
           prazo,
+          dono: donoVal,
           itens,
           parcelas_detalhes: parcelasDetalhes
         };


### PR DESCRIPTION
## Summary
- incluir seletor de dono nos modais de novo e edição de orçamento
- carregar donos a partir dos usuários e preencher automaticamente conforme o cliente
- salvar informação de dono nos registros de orçamentos

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4b57e12188322915adadabdd90e60