### PR TITLE
Fix Edit Budget Modal Loading Behavior

### DIFF
--- a/src/js/modals/orcamento-editar.js
+++ b/src/js/modals/orcamento-editar.js
@@ -229,6 +229,9 @@
     sel.addEventListener('blur', sync);
   });
 
+  recalcTotals();
+  document.dispatchEvent(new Event('orcamentoEditarCarregado'));
+
   const statusMap = {
     'Rascunho': 'badge-info',
     'Pendente': 'badge-warning',

--- a/src/js/orcamentos.js
+++ b/src/js/orcamentos.js
@@ -90,12 +90,20 @@ async function carregarOrcamentos() {
                 } catch (err) {
                     console.error('Erro ao carregar orçamento', err);
                 }
-                const elapsed = Date.now() - start;
-                const delay = elapsed < 3000 ? Math.max(2000 - elapsed, 0) : 0;
-                setTimeout(() => {
-                    hideLoadingSpinner();
-                    Modal.open('modals/orcamentos/editar.html', '../js/modals/orcamento-editar.js', 'editarOrcamento');
-                }, delay);
+
+                const handleLoaded = () => {
+                    const elapsed = Date.now() - start;
+                    const delay = elapsed < 3000 ? Math.max(2000 - elapsed, 0) : 0;
+                    setTimeout(() => {
+                        hideLoadingSpinner();
+                        document.getElementById('editarOrcamentoOverlay')?.classList.remove('hidden');
+                    }, delay);
+                    document.removeEventListener('orcamentoEditarCarregado', handleLoaded);
+                };
+                document.addEventListener('orcamentoEditarCarregado', handleLoaded);
+
+                await Modal.open('modals/orcamentos/editar.html', '../js/modals/orcamento-editar.js', 'editarOrcamento');
+                document.getElementById('editarOrcamentoOverlay')?.classList.add('hidden');
             });
         });
         await popularClientes();


### PR DESCRIPTION
## Summary
- Ensure edit budget modal remains hidden and spinner waits for data loading
- Notify when edit modal data finishes loading and compute totals up front

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4c08c869083228dc3a323ee317df2