### PR TITLE
Restrict PDF Download For Draft Budgets

### DIFF
--- a/backend/orcamentosController.js
+++ b/backend/orcamentosController.js
@@ -236,6 +236,19 @@ router.put('/:id', async (req, res) => {
   }
 });
 
+// Atualiza apenas o status de um orçamento
+router.patch('/:id/status', async (req, res) => {
+  const { id } = req.params;
+  const { situacao } = req.body;
+  try {
+    await db.query('UPDATE orcamentos SET situacao=$1 WHERE id=$2', [situacao, id]);
+    res.json({ success: true });
+  } catch (err) {
+    console.error('Erro ao atualizar status do orçamento:', err);
+    res.status(500).json({ error: 'Erro ao atualizar status do orçamento' });
+  }
+});
+
 // Clona um orçamento existente
 router.post('/:id/clone', async (req, res) => {
   const { id } = req.params;

--- a/src/css/orcamentos.css
+++ b/src/css/orcamentos.css
@@ -169,6 +169,24 @@ body {
     color: var(--color-violet);
 }
 
+/* Ícone de download desabilitado */
+.pdf-disabled {
+    position: relative;
+    cursor: not-allowed;
+    opacity: 0.6;
+}
+
+.pdf-disabled::after {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: -10%;
+    width: 120%;
+    height: 2px;
+    background: var(--color-red);
+    transform: rotate(45deg);
+}
+
 .info-icon {
     width: 20px;
     height: 20px;

--- a/src/js/orcamentos.js
+++ b/src/js/orcamentos.js
@@ -30,6 +30,38 @@ function hideLoadingSpinner() {
     document.getElementById('orcamentoLoading')?.remove();
 }
 
+function showPdfUnavailableDialog(id) {
+    const overlay = document.createElement('div');
+    overlay.className = 'fixed inset-0 bg-black/50 flex items-center justify-center p-4';
+    overlay.innerHTML = `<div class="max-w-sm w-full glass-surface backdrop-blur-xl rounded-2xl border border-red-500/20 ring-1 ring-red-500/30 shadow-2xl/40 animate-modalFade">
+        <div class="p-6 text-center">
+            <h3 class="text-lg font-semibold mb-4 text-red-400">Função Indisponível</h3>
+            <p class="text-sm text-gray-300 mb-6">Não é possivel gerar PDF para Orçamentos em RASCUNHO!</p>
+            <div class="flex justify-center gap-4">
+                <button id="pdfConvert" class="btn-warning px-4 py-2 rounded-lg text-white font-medium flex items-center gap-2">
+                    Converter <span class="info-icon" title="muda status para pendente"></span>
+                </button>
+                <button id="pdfOk" class="btn-neutral px-4 py-2 rounded-lg text-white font-medium">OK</button>
+            </div>
+        </div>
+    </div>`;
+    document.body.appendChild(overlay);
+    overlay.querySelector('#pdfOk').addEventListener('click', () => overlay.remove());
+    overlay.querySelector('#pdfConvert').addEventListener('click', async () => {
+        try {
+            await fetch(`http://localhost:3000/api/orcamentos/${id}/status`, {
+                method: 'PATCH',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ situacao: 'Pendente' })
+            });
+            overlay.remove();
+            carregarOrcamentos();
+        } catch (err) {
+            console.error('Erro ao atualizar status', err);
+        }
+    });
+}
+
 async function carregarOrcamentos() {
     try {
         const resp = await fetch('http://localhost:3000/api/orcamentos');
@@ -56,6 +88,9 @@ async function carregarOrcamentos() {
             const condicao = o.parcelas > 1 ? `${o.parcelas}x` : 'À vista';
             const badgeClass = statusClasses[o.situacao] || 'badge-neutral';
             const valor = Number(o.valor_final || 0).toLocaleString('pt-BR', {style:'currency', currency:'BRL'});
+            const isDraft = o.situacao === 'Rascunho';
+            const downloadClass = isDraft ? 'pdf-disabled relative' : '';
+            const downloadTitle = isDraft ? 'PDF indisponível' : 'Baixar PDF';
             tr.innerHTML = `
                 <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-white">${o.numero}</td>
                 <td class="px-6 py-4 whitespace-nowrap text-sm text-white">${o.cliente || ''}</td>
@@ -67,7 +102,7 @@ async function carregarOrcamentos() {
                     <div class="flex items-center justify-center space-x-2">
                         <i class="fas fa-eye w-5 h-5 cursor-pointer p-1 rounded transition-colors duration-150 hover:bg-white/10" style="color: var(--color-primary)" title="Visualizar"></i>
                         <i class="fas fa-edit w-5 h-5 cursor-pointer p-1 rounded transition-colors duration-150 hover:bg-white/10" style="color: var(--color-primary)" title="Editar"></i>
-                        <i class="fas fa-download w-5 h-5 cursor-pointer p-1 rounded transition-colors duration-150 hover:bg-white/10" style="color: var(--color-primary)" title="Baixar PDF"></i>
+                        <i class="fas fa-download w-5 h-5 cursor-pointer p-1 rounded transition-colors duration-150 hover:bg-white/10 ${downloadClass}" style="color: var(--color-primary)" title="${downloadTitle}"></i>
                     </div>
                 </td>`;
             tbody.appendChild(tr);
@@ -96,6 +131,19 @@ async function carregarOrcamentos() {
                     hideLoadingSpinner();
                     Modal.open('modals/orcamentos/editar.html', '../js/modals/orcamento-editar.js', 'editarOrcamento');
                 }, delay);
+            });
+        });
+        tbody.querySelectorAll('.fa-download').forEach(icon => {
+            icon.addEventListener('click', e => {
+                e.stopPropagation();
+                const tr = e.currentTarget.closest('tr');
+                const id = tr.dataset.id;
+                const status = tr.cells[5]?.innerText.trim();
+                if (status === 'Rascunho') {
+                    showPdfUnavailableDialog(id);
+                } else {
+                    window.open(`http://localhost:3000/api/orcamentos/${id}/pdf`, '_blank');
+                }
             });
         });
         await popularClientes();


### PR DESCRIPTION
## Summary
- Add PATCH endpoint for updating a budget's status.
- Show red-slash PDF icon and dialog explaining PDF generation is unavailable for draft budgets with option to convert to pending.
- Style disabled PDF icons with red diagonal overlay.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4bdcbbc5083229c10f420b60952ff