### PR TITLE
Remove loading spinner from budget edit flow

### DIFF
--- a/src/js/modals/orcamento-editar.js
+++ b/src/js/modals/orcamento-editar.js
@@ -240,7 +240,6 @@
   });
 
   recalcTotals();
-  document.dispatchEvent(new Event('orcamentoEditarCarregado'));
 
   const statusMap = {
     'Rascunho': 'badge-info',

--- a/src/js/orcamentos.js
+++ b/src/js/orcamentos.js
@@ -13,23 +13,6 @@ async function popularClientes() {
         console.error('Erro ao carregar clientes', err);
     }
 }
-
-function showLoadingSpinner() {
-    const overlay = document.createElement('div');
-    overlay.id = 'orcamentoLoading';
-    overlay.className = 'fixed inset-0 bg-black/50 flex items-center justify-center z-50';
-    overlay.innerHTML = `
-        <div class="spinner"></div>
-        <style>
-            #orcamentoLoading .spinner{border:4px solid rgba(255,255,255,0.3);border-top-color:var(--color-primary);border-radius:50%;width:3rem;height:3rem;animation:spin 1s linear infinite;}
-            @keyframes spin{to{transform:rotate(360deg);}}
-        </style>`;
-    document.body.appendChild(overlay);
-}
-function hideLoadingSpinner() {
-    document.getElementById('orcamentoLoading')?.remove();
-}
-
 function showPdfUnavailableDialog(id) {
     const overlay = document.createElement('div');
     overlay.className = 'fixed inset-0 bg-black/50 flex items-center justify-center p-4';
@@ -117,28 +100,7 @@ async function carregarOrcamentos() {
                 e.stopPropagation();
                 const id = e.currentTarget.closest('tr').dataset.id;
                 window.selectedQuoteId = id;
-                showLoadingSpinner();
-                const start = Date.now();
-                try {
-                    const resp = await fetch(`http://localhost:3000/api/orcamentos/${id}`);
-                    window.quoteData = await resp.json();
-                } catch (err) {
-                    console.error('Erro ao carregar orçamento', err);
-                }
-
-                const handleLoaded = () => {
-                    const elapsed = Date.now() - start;
-                    const delay = elapsed < 3000 ? Math.max(2000 - elapsed, 0) : 0;
-                    setTimeout(() => {
-                        hideLoadingSpinner();
-                        document.getElementById('editarOrcamentoOverlay')?.classList.remove('hidden');
-                    }, delay);
-                    document.removeEventListener('orcamentoEditarCarregado', handleLoaded);
-                };
-                document.addEventListener('orcamentoEditarCarregado', handleLoaded);
-
                 await Modal.open('modals/orcamentos/editar.html', '../js/modals/orcamento-editar.js', 'editarOrcamento');
-                document.getElementById('editarOrcamentoOverlay')?.classList.add('hidden');
             });
         });
         tbody.querySelectorAll('.fa-download').forEach(icon => {


### PR DESCRIPTION
## Summary
- open edit budget modal directly without loading spinner overlay
- drop unused spinner logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4c4620e908322946bce782e673878