### PR TITLE
Limpar observações ao resetar novo orçamento

### DIFF
--- a/src/js/modals/orcamento-novo.js
+++ b/src/js/modals/orcamento-novo.js
@@ -517,6 +517,7 @@
     limparBtn.addEventListener('click', () => {
       confirmResetIfNeeded(() => {
         overlay.querySelectorAll('input').forEach(i => i.value = '');
+        overlay.querySelectorAll('textarea').forEach(t => t.value = '');
         overlay.querySelectorAll('select').forEach(s => { s.selectedIndex = 0; s.setAttribute('data-filled', 'false'); });
         itensTbody.innerHTML = '';
         recalcTotals();


### PR DESCRIPTION
## Summary
- Limpa também campos de observações ao clicar em **Limpar Tudo** no novo orçamento

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4c80375dc8322a981fe18ac7a955e