### PR TITLE
Mostrar descontos especiais e de pagamento nos orçamentos

### DIFF
--- a/src/css/orcamentos.css
+++ b/src/css/orcamentos.css
@@ -154,6 +154,11 @@ body {
     color: var(--color-blue);
 }
 
+.badge-orange {
+    background: rgba(255, 165, 0, 0.2);
+    color: #ff8c00;
+}
+
 .badge-warning {
     background: rgba(212, 193, 105, 0.2);
     color: var(--color-primary);

--- a/src/html/modals/orcamentos/editar.html
+++ b/src/html/modals/orcamentos/editar.html
@@ -88,6 +88,8 @@
             <h3 class="text-lg font-semibold text-white">Itens</h3>
             <div class="flex flex-wrap gap-2 text-sm ml-4">
               <span class="badge-neutral px-3 py-1 rounded-full font-medium">Subtotal: <span id="subtotalOrcamento">R$ 0,00</span></span>
+              <span class="badge-warning px-3 py-1 rounded-full font-medium">Desc. Pagamento: <span id="descontoPagOrcamento">R$ 0,00</span></span>
+              <span class="badge-orange px-3 py-1 rounded-full font-medium">Desc. Especial: <span id="descontoEspOrcamento">R$ 0,00</span></span>
               <span class="badge-danger px-3 py-1 rounded-full font-medium">Desconto: <span id="descontoOrcamento">R$ 0,00</span></span>
               <span class="badge-success px-3 py-1 rounded-full font-medium">Total: <span id="totalOrcamento">R$ 0,00</span></span>
             </div>

--- a/src/html/modals/orcamentos/novo.html
+++ b/src/html/modals/orcamentos/novo.html
@@ -79,6 +79,8 @@
             <h3 class="text-lg font-semibold text-white">Itens</h3>
             <div class="flex flex-wrap gap-2 text-sm ml-4">
               <span class="badge-neutral px-3 py-1 rounded-full font-medium">Subtotal: <span id="novoSubtotal">R$ 0,00</span></span>
+              <span class="badge-warning px-3 py-1 rounded-full font-medium">Desc. Pagamento: <span id="novoDescPag">R$ 0,00</span></span>
+              <span class="badge-orange px-3 py-1 rounded-full font-medium">Desc. Especial: <span id="novoDescEsp">R$ 0,00</span></span>
               <span class="badge-danger px-3 py-1 rounded-full font-medium">Desconto: <span id="novoDesconto">R$ 0,00</span></span>
               <span class="badge-success px-3 py-1 rounded-full font-medium">Total: <span id="novoTotal">R$ 0,00</span></span>
             </div>

--- a/src/js/modals/orcamento-editar.js
+++ b/src/js/modals/orcamento-editar.js
@@ -468,19 +468,26 @@
 
   function recalcTotals() {
     let subtotal = 0;
-    let desconto = 0;
+    let descPagTot = 0;
+    let descEspTot = 0;
     document.querySelectorAll('#orcamentoItens tbody tr').forEach(tr => {
       const qty = parseFloat(tr.children[1].textContent) || 0;
       const val = parseFloat(tr.children[2].textContent) || 0;
-      const desc = parseFloat(tr.children[4].textContent) || 0;
+      const descTotal = parseFloat(tr.children[4].textContent) || 0;
+      const defaultDesc = (qty > 1 ? 5 : 0) + (editarCondicao.value === 'vista' ? 5 : 0);
+      const descPagPrc = Math.min(defaultDesc, descTotal);
+      const descEspPrc = Math.max(descTotal - descPagPrc, 0);
       const line = qty * val;
-      const lineDesc = line * (desc / 100);
       subtotal += line;
-      desconto += lineDesc;
+      descPagTot += (val * (descPagPrc / 100)) * qty;
+      descEspTot += (val * (descEspPrc / 100)) * qty;
     });
-    const total = subtotal - desconto;
+    const desconto = descPagTot + descEspTot;
     document.getElementById('subtotalOrcamento').textContent = formatCurrency(subtotal);
+    document.getElementById('descontoPagOrcamento').textContent = formatCurrency(descPagTot);
+    document.getElementById('descontoEspOrcamento').textContent = formatCurrency(descEspTot);
     document.getElementById('descontoOrcamento').textContent = formatCurrency(desconto);
+    const total = subtotal - desconto;
     document.getElementById('totalOrcamento').textContent = formatCurrency(total);
     document.querySelectorAll('#orcamentoItens tbody tr').forEach(updateLineTotal);
     editarCondicao.disabled = total === 0;

--- a/src/js/modals/orcamento-novo.js
+++ b/src/js/modals/orcamento-novo.js
@@ -228,17 +228,24 @@
 
   function recalcTotals() {
     let subtotal = 0;
-    let desconto = 0;
+    let descPagTot = 0;
+    let descEspTot = 0;
     itensTbody.querySelectorAll('tr').forEach(tr => {
       const qty = parseFloat(tr.children[1].textContent) || 0;
       const val = parseFloat(tr.children[2].textContent) || 0;
-      const desc = parseFloat(tr.children[4].textContent) || 0;
+      const descTotal = parseFloat(tr.children[4].textContent) || 0;
+      const defaultDesc = (qty > 1 ? 5 : 0) + (condicaoSelect.value === 'vista' ? 5 : 0);
+      const descPagPrc = Math.min(defaultDesc, descTotal);
+      const descEspPrc = Math.max(descTotal - descPagPrc, 0);
       const line = qty * val;
-      const lineDesc = line * (desc / 100);
       subtotal += line;
-      desconto += lineDesc;
+      descPagTot += (val * (descPagPrc / 100)) * qty;
+      descEspTot += (val * (descEspPrc / 100)) * qty;
     });
+    const desconto = descPagTot + descEspTot;
     document.getElementById('novoSubtotal').textContent = formatCurrency(subtotal);
+    document.getElementById('novoDescPag').textContent = formatCurrency(descPagTot);
+    document.getElementById('novoDescEsp').textContent = formatCurrency(descEspTot);
     document.getElementById('novoDesconto').textContent = formatCurrency(desconto);
     const total = subtotal - desconto;
     document.getElementById('novoTotal').textContent = formatCurrency(total);


### PR DESCRIPTION
## Summary
- Add yellow and orange discount badges to new and edit budget forms
- Compute and show payment and special discount totals in budget logic
- Style orange discount badge

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4ce654fec8322a8077b77f000b5e9