### PR TITLE
Corrige botões de editar orçamento inoperantes

### DIFF
--- a/src/js/orcamentos.js
+++ b/src/js/orcamentos.js
@@ -95,14 +95,6 @@ async function carregarOrcamentos() {
             ownerSelect.innerHTML = '<option value="">Todos os Donos</option>' +
                 [...owners].map(d => `<option value="${d}">${d}</option>`).join('');
         }
-        tbody.querySelectorAll('.fa-edit').forEach(icon => {
-            icon.addEventListener('click', async e => {
-                e.stopPropagation();
-                const id = e.currentTarget.closest('tr').dataset.id;
-                window.selectedQuoteId = id;
-                await Modal.open('modals/orcamentos/editar.html', '../js/modals/orcamento-editar.js', 'editarOrcamento');
-            });
-        });
         tbody.querySelectorAll('.fa-download').forEach(icon => {
             icon.addEventListener('click', e => {
                 e.stopPropagation();
@@ -185,6 +177,20 @@ function initOrcamentos() {
     if (novoBtn) {
         novoBtn.addEventListener('click', () => {
             Modal.open('modals/orcamentos/novo.html', '../js/modals/orcamento-novo.js', 'novoOrcamento');
+        });
+    }
+
+    const tbody = document.getElementById('orcamentosTabela');
+    if (tbody) {
+        tbody.addEventListener('click', async e => {
+            const editIcon = e.target.closest('.fa-edit');
+            if (editIcon) {
+                e.stopPropagation();
+                const id = editIcon.closest('tr').dataset.id;
+                window.selectedQuoteId = id;
+                await Modal.open('modals/orcamentos/editar.html', '../js/modals/orcamento-editar.js', 'editarOrcamento');
+                return;
+            }
         });
     }
 


### PR DESCRIPTION
## Summary
- usa delegação de eventos na tabela de orçamentos para acionar o modal de edição
- remove cadastro de listeners individuais que não funcionavam após recarregar a lista

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4d19e9c6c8322b35cbe63ae69c283