### PR TITLE
Corrigir Exibição De Itens No Modal De Edição De Orçamento

### DIFF
--- a/src/js/modals/orcamento-editar.js
+++ b/src/js/modals/orcamento-editar.js
@@ -29,6 +29,7 @@
   const editarValidade = document.getElementById('editarValidade');
   const donoSelect = document.getElementById('editarDono');
   const produtoSelect = document.getElementById('novoItemProduto');
+  const itensTbody = document.querySelector('#orcamentoItens tbody');
   const pagamentoBox = document.getElementById('editarPagamento');
   const condicaoWrapper = editarCondicao.parentElement;
   let parcelamentoLoaded = false;
@@ -287,8 +288,6 @@
     });
   }
 
-  const itensTbody = document.querySelector('#orcamentoItens tbody');
-
   function formatCurrency(v) {
     return v.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
   }
@@ -458,8 +457,6 @@
       attachRowEvents(tr);
       recalcTotals();
     }
-
-    (data.items || []).forEach(addItem);
 
     document.getElementById('adicionarItem').addEventListener('click', () => {
       const prodId = produtoSelect.value;


### PR DESCRIPTION
## Summary
- Garanta que o corpo da tabela exista antes de iterar pelos itens do orçamento
- Elimine a iteração redundante sobre `data.items`

## Testing
- `npm test`
- `ELECTRON_RUN_AS_NODE=1 npm start` *(fails: libatk-1.0.so.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a4d2633b30832292d23605588df6b2