### PR TITLE
Registrar Tipo De Parcela Ao Salvar Orcamento

### DIFF
--- a/backend/orcamentosController.js
+++ b/backend/orcamentosController.js
@@ -60,6 +60,7 @@ router.post('/', async (req, res) => {
     validade,
     prazo,
     dono,
+    tipo_parcela,
     itens = [],
     parcelas_detalhes = []
   } = req.body;
@@ -75,8 +76,8 @@ router.post('/', async (req, res) => {
     }
     const now = new Date();
     const insertOrc = await client.query(
-      `INSERT INTO orcamentos (numero, cliente_id, contato_id, data_emissao, situacao, parcelas, forma_pagamento, transportadora, desconto_pagamento, desconto_especial, desconto_total, valor_final, observacoes, validade, prazo, dono)
-       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16) RETURNING id`,
+      `INSERT INTO orcamentos (numero, cliente_id, contato_id, data_emissao, situacao, parcelas, forma_pagamento, transportadora, desconto_pagamento, desconto_especial, desconto_total, valor_final, observacoes, validade, prazo, dono, tipo_parcela)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17) RETURNING id`,
       [
         numero,
         cliente_id,
@@ -93,7 +94,8 @@ router.post('/', async (req, res) => {
         observacoes,
         validade,
         prazo,
-        dono
+        dono,
+        tipo_parcela
       ]
     );
     const orcamentoId = insertOrc.rows[0].id;
@@ -160,6 +162,7 @@ router.put('/:id', async (req, res) => {
     validade,
     prazo,
     dono,
+    tipo_parcela,
     itens = [],
     parcelas_detalhes = []
   } = req.body;
@@ -170,7 +173,7 @@ router.put('/:id', async (req, res) => {
     await client.query(
       `UPDATE orcamentos SET cliente_id=$1, contato_id=$2, situacao=$3, parcelas=$4, forma_pagamento=$5,
        transportadora=$6, desconto_pagamento=$7, desconto_especial=$8, desconto_total=$9, valor_final=$10,
-       observacoes=$11, validade=$12, prazo=$13, dono=$14 WHERE id=$15`,
+       observacoes=$11, validade=$12, prazo=$13, dono=$14, tipo_parcela=$15 WHERE id=$16`,
       [
         cliente_id,
         contato_id,
@@ -186,6 +189,7 @@ router.put('/:id', async (req, res) => {
         validade,
         prazo,
         dono,
+        tipo_parcela,
         id
       ]
     );
@@ -271,8 +275,8 @@ router.post('/:id/clone', async (req, res) => {
 
     const insert = await client.query(
       `INSERT INTO orcamentos (numero, cliente_id, contato_id, data_emissao, situacao, parcelas, forma_pagamento, transportadora,
-       desconto_pagamento, desconto_especial, desconto_total, valor_final, observacoes, validade, prazo, dono)
-       VALUES ($1,$2,$3,NOW(),'Rascunho',$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14) RETURNING id`,
+       desconto_pagamento, desconto_especial, desconto_total, valor_final, observacoes, validade, prazo, dono, tipo_parcela)
+       VALUES ($1,$2,$3,NOW(),'Rascunho',$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15) RETURNING id`,
       [
         numero,
         orc.cliente_id,
@@ -287,7 +291,8 @@ router.post('/:id/clone', async (req, res) => {
         orc.observacoes,
         orc.validade,
         orc.prazo,
-        orc.dono
+        orc.dono,
+        orc.tipo_parcela
       ]
     );
     const newId = insert.rows[0].id;

--- a/src/js/modals/orcamento-editar.js
+++ b/src/js/modals/orcamento-editar.js
@@ -523,6 +523,7 @@
     let parcelas = 1;
     let prazo = '';
     let parcelasDetalhes = [];
+    let tipoParcela = 'a vista';
     if(condicaoVal === 'vista'){
       const prazoVista = document.getElementById('editarPrazoVista')?.value;
       if(!prazoVista) missing.push('Prazo (dias)');
@@ -544,6 +545,7 @@
           valor: it.amount / 100,
           data_vencimento: new Date(dataEmissao.getTime() + (it.dueInDays || 0) * 86400000).toISOString().split('T')[0]
         }));
+        tipoParcela = pdata.mode === 'equal' ? 'igual' : 'diferente';
       }
     }
 
@@ -604,6 +606,7 @@
       validade: editarValidade.value || null,
       prazo,
       dono: donoVal,
+      tipo_parcela: tipoParcela,
       itens,
       parcelas_detalhes: parcelasDetalhes
     };

--- a/src/js/modals/orcamento-novo.js
+++ b/src/js/modals/orcamento-novo.js
@@ -441,6 +441,7 @@
     let parcelas = 1;
     let prazo = '';
     let parcelasDetalhes = [];
+    let tipoParcela = 'a vista';
     if (condicaoVal === 'vista') {
       const prazoVista = document.getElementById('novoPrazoVista')?.value;
       if (!prazoVista) missing.push('Prazo (dias)');
@@ -462,6 +463,7 @@
           valor: it.amount / 100,
           data_vencimento: new Date(dataEmissao.getTime() + (it.dueInDays || 0) * 86400000).toISOString().split('T')[0]
         }));
+        tipoParcela = pdata.mode === 'equal' ? 'igual' : 'diferente';
       }
     }
 
@@ -525,6 +527,7 @@
           validade: validadeVal,
           prazo,
           dono: donoVal,
+          tipo_parcela: tipoParcela,
           itens,
           parcelas_detalhes: parcelasDetalhes
         };


### PR DESCRIPTION
## Summary
- Registrar modo de parcelamento ou "a vista" no orçamento ao criar
- Persistir tipo de parcela ao editar orçamento
- Incluir campo `tipo_parcela` nas operações de banco de dados

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4d89b309883228b4deb45047df1f5