### PR TITLE
Align New Budget Footer Buttons And Expand Budget Modals

### DIFF
--- a/src/html/modals/orcamentos/editar.html
+++ b/src/html/modals/orcamentos/editar.html
@@ -1,5 +1,5 @@
-<div id="editarOrcamentoOverlay" class="fixed inset-0 bg-black/50 flex items-center justify-center p-4">
-  <div role="dialog" aria-modal="true" tabindex="0" class="w-full max-w-5xl max-h-[80vh] glass-surface backdrop-blur-xl rounded-3xl border border-white/10 ring-1 ring-white/5 shadow-2xl/40 animate-modalFade slide-in overflow-hidden flex flex-col">
+<div id="editarOrcamentoOverlay" class="fixed inset-0 bg-black/50 flex items-start justify-center p-4 overflow-y-auto">
+  <div role="dialog" aria-modal="true" tabindex="0" class="w-full max-w-5xl h-full max-h-[calc(100vh-2rem)] glass-surface backdrop-blur-xl rounded-3xl border border-white/10 ring-1 ring-white/5 shadow-2xl/40 animate-modalFade slide-in overflow-hidden flex flex-col">
     <header class="relative flex items-center justify-between px-8 py-5 border-b border-white/10 flex-shrink-0">
       <div class="flex items-center gap-3">
         <button id="voltarEditarOrcamento" class="btn-neutral px-4 py-2 rounded-lg text-white font-medium flex items-center gap-2">← Voltar</button>

--- a/src/html/modals/orcamentos/novo.html
+++ b/src/html/modals/orcamentos/novo.html
@@ -1,5 +1,5 @@
-<div id="novoOrcamentoOverlay" class="fixed inset-0 bg-black/50 flex items-center justify-center p-4">
-  <div role="dialog" aria-modal="true" tabindex="0" class="w-full max-w-5xl max-h-[80vh] glass-surface backdrop-blur-xl rounded-3xl border border-white/10 ring-1 ring-white/5 shadow-2xl/40 animate-modalFade slide-in overflow-hidden flex flex-col">
+<div id="novoOrcamentoOverlay" class="fixed inset-0 bg-black/50 flex items-start justify-center p-4 overflow-y-auto">
+  <div role="dialog" aria-modal="true" tabindex="0" class="w-full max-w-5xl h-full max-h-[calc(100vh-2rem)] glass-surface backdrop-blur-xl rounded-3xl border border-white/10 ring-1 ring-white/5 shadow-2xl/40 animate-modalFade slide-in overflow-hidden flex flex-col">
     <header class="relative flex items-center justify-between px-8 py-5 border-b border-white/10 flex-shrink-0">
       <div class="flex items-center gap-3">
         <button id="voltarNovoOrcamento" class="btn-neutral px-4 py-2 rounded-lg text-white font-medium flex items-center gap-2">← Voltar</button>


### PR DESCRIPTION
## Summary
- anchor budget modals to top and stretch to full viewport height
- ensure new budget footer buttons behave like edit modal's footer

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4dbb89ed08322a4a40e70b109910d