### PR TITLE
Ajustar Impressão De Pdf Com Dados Reais

### DIFF
--- a/main.js
+++ b/main.js
@@ -747,6 +747,20 @@ ipcMain.handle('get-saved-display', () => {
   return currentDisplayId || null;
 });
 
+ipcMain.handle('open-pdf', (_event, id) => {
+  const pdfWindow = new BrowserWindow({ width: 900, height: 700, show: false });
+  pdfWindow.loadFile(path.join(__dirname, 'src/pdf/index.html'), {
+    query: { id }
+  });
+  pdfWindow.once('ready-to-show', () => {
+    pdfWindow.show();
+  });
+  pdfWindow.webContents.once('did-finish-load', () => {
+    pdfWindow.webContents.print({ silent: false, printBackground: true });
+  });
+  return true;
+});
+
 if (DEBUG) {
   ipcMain.on('debug-log', (_, m) => console.log('[popup]', m));
 }

--- a/preload.js
+++ b/preload.js
@@ -65,6 +65,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   reloadWindow: () => ipcRenderer.invoke('reload-window'),
   getDisplays: () => ipcRenderer.invoke('get-displays'),
   setDisplay: (id) => ipcRenderer.invoke('set-display', id),
+  openPdf: (id) => ipcRenderer.invoke('open-pdf', id),
     getSavedDisplay: () => ipcRenderer.invoke('get-saved-display'),
     onActivateTab: (callback) =>
       ipcRenderer.on('activate-tab', (_event, tab) => callback(tab)),

--- a/src/js/orcamentos.js
+++ b/src/js/orcamentos.js
@@ -112,9 +112,8 @@ async function carregarOrcamentos() {
                 if (status === 'Rascunho') {
                     showPdfUnavailableDialog(id);
                 } else {
-                    const pdfWindow = window.open('../pdf/index.html', '_blank');
-                    if (pdfWindow) {
-                        pdfWindow.addEventListener('load', () => pdfWindow.print());
+                    if (window.electronAPI?.openPdf) {
+                        window.electronAPI.openPdf(id);
                     }
                 }
             });

--- a/src/pdf/script.js
+++ b/src/pdf/script.js
@@ -1,37 +1,11 @@
 const docContainer = document.getElementById('doc-container');
-const template     = document.getElementById('page-template');
+const template = document.getElementById('page-template');
 
-// Configurações da lógica de paginação
-const thresholdSingle = 13;    // até 13 itens cabe tudo numa página só
-const maxFirst        = 20;    // itens máximos na 1ª página, antes de distribuir o resto
-const maxFullNext     = 30;    // itens máximos em cada página intermediária
-const maxLastNext     = 23;    // itens máximos na última página (30 totais menos 7 do bloco)
-const minLastItems    = 4;     // mínimo de itens na última página
-
-// Arrays de exemplo
-const finishes = ['Off-white','Grafite','Prata','Verde','Madeira','Braco','Veludo'];
-const lines    = ['Acervo','Essencial','Infinito','Favo','Rio'];
-const products = ['Bandeja','Caixa','Base','Vaso'];
-const sizes    = ['P','M','G'];
-
-// Gera 60 itens de exemplo
-const items = Array.from({length:84}, (_, i) => {
-  const idx  = i + 1;
-  const name = `${products[i%products.length]} ${lines[i%lines.length]} ${sizes[i%sizes.length]} ${finishes[i%finishes.length]}`;
-  const qty  = (i % 5) + 1;
-  const unit = (idx * 10).toFixed(2);
-  const disc = idx.toFixed(2);
-  const tot  = ((qty * parseFloat(unit)) - parseFloat(disc)).toFixed(2);
-  return [
-    `COD${idx}`,
-    name,
-    `NCM${1000 + idx}`,
-    `${qty}`,
-    `R$ ${unit}`,
-    `R$ ${disc}`,
-    `R$ ${tot}`
-  ];
-});
+const thresholdSingle = 13;
+const maxFirst = 20;
+const maxFullNext = 30;
+const maxLastNext = 23;
+const minLastItems = 4;
 
 function createPage(html) {
   const clone = template.content.cloneNode(true);
@@ -39,127 +13,149 @@ function createPage(html) {
   docContainer.appendChild(clone);
 }
 
-function buildDocument() {
-  const total = items.length;
-  let pages  = [];
-  let rem    = items.slice();
+function formatCurrency(v) {
+  return Number(v || 0).toLocaleString('pt-BR', {
+    style: 'currency',
+    currency: 'BRL'
+  });
+}
 
-  // Caso caiba tudo numa página só
-  if (total <= thresholdSingle) {
-    pages.push(rem.splice(0, rem.length));
+function formatEndereco(end) {
+  if (!end) return '';
+  const { rua = '', numero = '', bairro = '', cidade = '', estado = '' } = end;
+  return `${rua}, ${numero} – ${bairro} – ${cidade}/${estado}`;
+}
 
-  } else {
-    // 1) Fatia a 1ª página
-    // garante que sobrem ao menos minLastItems para a última página
-    let firstCount = Math.min(maxFirst, rem.length - minLastItems);
-    // mas jamais menos que thresholdSingle, para caber o bloco
-    if (firstCount < thresholdSingle) {
-      firstCount = Math.min(rem.length, thresholdSingle);
-    }
-    pages.push(rem.splice(0, firstCount));
+async function buildDocument() {
+  const params = new URLSearchParams(window.location.search);
+  const id = params.get('id');
+  if (!id) return;
+  try {
+    const orc = await fetch(`http://localhost:3000/api/orcamentos/${id}`).then(r => r.json());
+    const cliente = await fetch(`http://localhost:3000/api/clientes/${orc.cliente_id}`).then(r => r.json());
 
-    // 2) Páginas intermediárias de até maxFullNext
-    while (rem.length > maxLastNext) {
-      let chunkSize = maxFullNext;
-      // se sobraria menos que minLastItems para a última, ajusta
-      if (rem.length - maxFullNext < minLastItems) {
-        chunkSize = rem.length - minLastItems;
-      }
-      pages.push(rem.splice(0, chunkSize));
-    }
+    const items = orc.itens.map(it => [
+      it.codigo,
+      it.nome,
+      it.ncm,
+      it.quantidade,
+      formatCurrency(it.valor_unitario),
+      formatCurrency(it.desconto_total),
+      formatCurrency(it.valor_total)
+    ]);
 
-    // 3) Última página
-    if (rem.length > 0) {
+    const total = items.length;
+    let pages = [];
+    let rem = items.slice();
+
+    if (total <= thresholdSingle) {
       pages.push(rem.splice(0, rem.length));
+    } else {
+      let firstCount = Math.min(maxFirst, rem.length - minLastItems);
+      if (firstCount < thresholdSingle) {
+        firstCount = Math.min(rem.length, thresholdSingle);
+      }
+      pages.push(rem.splice(0, firstCount));
+
+      while (rem.length > maxLastNext) {
+        let chunkSize = maxFullNext;
+        if (rem.length - maxFullNext < minLastItems) {
+          chunkSize = rem.length - minLastItems;
+        }
+        pages.push(rem.splice(0, chunkSize));
+      }
+
+      if (rem.length > 0) {
+        pages.push(rem.splice(0, rem.length));
+      }
     }
-  }
 
-  // Gera cada página
-  pages.forEach((chunk, idx) => {
-    const isFirst = idx === 0;
-    const isLast  = idx === pages.length - 1;
+    pages.forEach((chunk, idx) => {
+      const isFirst = idx === 0;
+      const isLast = idx === pages.length - 1;
 
-    // Cabeçalho só na 1ª página
-    let header = '';
-    if (isFirst) {
-      header = `
+      let header = '';
+      if (isFirst) {
+        header = `
       <div class="grid grid-cols-2 gap-2 mb-2">
         <div>
-          <p><strong>Número do Orçamento:</strong> 12</p>
-          <p><strong>Data de Emissão:</strong> 26/10/2023</p>
-          <p><strong>Situação do Orçamento:</strong> Finalizado</p>
-          <p><strong>Quantidade de Parcelas:</strong> 1</p>
-          <p><strong>Forma de Pagamento:</strong> À Vista</p>
+          <p><strong>Número do Orçamento:</strong> ${orc.numero}</p>
+          <p><strong>Data de Emissão:</strong> ${new Date(orc.data_emissao).toLocaleDateString('pt-BR')}</p>
+          <p><strong>Situação do Orçamento:</strong> ${orc.situacao}</p>
+          <p><strong>Quantidade de Parcelas:</strong> ${orc.parcelas}</p>
+          <p><strong>Forma de Pagamento:</strong> ${orc.forma_pagamento || ''}</p>
         </div>
         <div class="text-right">
-          <p><strong>Nome Fantasia:</strong> RARARA</p>
-          <p><strong>Razão Social:</strong> HAHAHA</p>
-          <p><strong>CNPJ:</strong> 99.999.999/9999-99</p>
-          <p><strong>Inscrição Estadual:</strong> 999999999</p>
+          <p><strong>Nome Fantasia:</strong> ${cliente.nome_fantasia || ''}</p>
+          <p><strong>Razão Social:</strong> ${cliente.razao_social || ''}</p>
+          <p><strong>CNPJ:</strong> ${cliente.cnpj || ''}</p>
+          <p><strong>Inscrição Estadual:</strong> ${cliente.inscricao_estadual || ''}</p>
         </div>
       </div>
       <div class="grid grid-cols-3 gap-2 mb-2">
         <div>
-          <p><strong>Contato:</strong> AHARA</p>
-          <p><strong>Telefone Fixo:</strong> (31) 3357-4894</p>
-          <p><strong>Telefone Celular:</strong> (31) 98522-8153</p>
-          <p><strong>E-mail:</strong> contato@empresa.com.br</p>
+          <p><strong>Contato:</strong> ${cliente.comprador_nome || ''}</p>
+          <p><strong>Telefone Fixo:</strong> ${cliente.telefone_fixo || ''}</p>
+          <p><strong>Telefone Celular:</strong> ${cliente.telefone_celular || ''}</p>
+          <p><strong>E-mail:</strong> ${cliente.email || ''}</p>
         </div>
         <div>
-          <p><strong>Endereço de Entrega:</strong> Rua X, 123 – Bairro Y – Cidade Z – UF</p>
+          <p><strong>Endereço de Entrega:</strong> ${formatEndereco(cliente.endereco_entrega)}</p>
         </div>
         <div>
-          <p><strong>Endereço de Faturamento:</strong> Igual ao de entrega</p>
-          <p><strong>Endereço de Registro:</strong> Igual ao de entrega</p>
-          <p><strong>Transportadora:</strong> RAHARA</p>
+          <p><strong>Endereço de Faturamento:</strong> ${formatEndereco(cliente.endereco_cobranca)}</p>
+          <p><strong>Endereço de Registro:</strong> ${formatEndereco(cliente.endereco_registro)}</p>
+          <p><strong>Transportadora:</strong> ${orc.transportadora || cliente.transportadora || ''}</p>
         </div>
       </div>`;
-    }
+      }
 
-    // Título dinâmico
-    const title = isFirst
-      ? `ITENS DO ORÇAMENTO (N° 12)`
-      : `ITENS DO ORÇAMENTO (N° 12) - Continuação`;
+      const title = isFirst
+        ? `ITENS DO ORÇAMENTO (N° ${orc.numero})`
+        : `ITENS DO ORÇAMENTO (N° ${orc.numero}) - Continuação`;
 
-    // Monta a tabela
-    const cols   = ['Código','Nome do Produto','NCM','Quantidade','Valor Unitário','Total Desconto','Valor Total'];
-    const widths = ['10%','30%','12%','10%','12%','13%','13%'];
-    const thead  = `<thead><tr>${cols.map((c,i)=>`<th style="width:${widths[i]}">${c}</th>`).join('')}</tr></thead>`;
-    const tbody  = `<tbody>${chunk.map(row=>`<tr>${row.map(cell=>`<td>${cell}</td>`).join('')}</tr>`).join('')}</tbody>`;
+      const cols = ['Código','Nome do Produto','NCM','Quantidade','Valor Unitário','Total Desconto','Valor Total'];
+      const widths = ['10%','30%','12%','10%','12%','13%','13%'];
+      const thead = `<thead><tr>${cols.map((c,i)=>`<th style="width:${widths[i]}">${c}</th>`).join('')}</tr></thead>`;
+      const tbody = `<tbody>${chunk.map(row=>`<tr>${row.map(cell=>`<td>${cell}</td>`).join('')}</tr>`).join('')}</tbody>`;
 
-    let html = `
+      let html = `
       ${header}
       <h3 class="font-bold text-accent-red mb-1">${title}</h3>
       <table>${thead}${tbody}</table>`;
 
-    // Se for a última página, adiciona resumo/observações/assinatura
-    if (isLast) {
-      html += `
+      if (isLast) {
+        html += `
       <div class="text-sm mt-2">
         <h3 class="font-bold text-accent-red mb-1">RESUMO DE VALORES</h3>
         <table class="w-full mb-2">
-          <tr><td>Desconto de Pagamento:</td><td class="text-right">R$ 189,00</td></tr>
-          <tr><td>Desconto Especial:</td><td class="text-right">R$ 11,00</td></tr>
-          <tr><td>Desconto Total:</td><td class="text-right">R$ 200,00</td></tr>
-          <tr class="border-t"><td><strong>Valor a Pagar:</strong></td><td class="text-right"><strong>R$ 1,00</strong></td></tr>
+          <tr><td>Desconto de Pagamento:</td><td class="text-right">${formatCurrency(orc.desconto_pagamento)}</td></tr>
+          <tr><td>Desconto Especial:</td><td class="text-right">${formatCurrency(orc.desconto_especial)}</td></tr>
+          <tr><td>Desconto Total:</td><td class="text-right">${formatCurrency(orc.desconto_total)}</td></tr>
+          <tr class="border-t"><td><strong>Valor a Pagar:</strong></td><td class="text-right"><strong>${formatCurrency(orc.valor_final)}</strong></td></tr>
         </table>
         <p class="font-semibold text-accent-red mb-1">OBSERVAÇÕES:</p>
-        <p>- Conferir este orçamento. Caso divergência, contatar o vendedor.</p>
+        <p>${orc.observacoes || '- Nenhuma observação.'}</p>
         <div class="mt-2">
           <p><strong>AUTORIZAÇÃO DO PEDIDO:</strong></p>
           <p>Nome do Responsável: ____________________________</p>
           <p>Assinatura: ____________________________</p>
         </div>
       </div>`;
-    } else {
-      // Páginas intermediárias: apenas espaço para assinatura
-      html += `
+      } else {
+        html += `
       <p class="mt-2"><strong>Nome do Responsável:</strong> ____________________________</p>
       <p><strong>Assinatura:</strong> ____________________________</p>`;
-    }
+      }
 
-    createPage(html);
-  });
+      createPage(html);
+    });
+
+    window.print();
+  } catch (err) {
+    console.error('Erro ao gerar documento', err);
+  }
 }
 
 window.onload = buildDocument;
+


### PR DESCRIPTION
## Summary
- Open PDF in a dedicated Electron window and trigger print dialog
- Expose `openPdf` API to renderer and hook into budget listing
- Generate PDF content using real order and client data

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4dc501e4c832282df88ea2715063c