### PR TITLE
Resolve duplicate tipo_parcela declaration

### DIFF
--- a/backend/orcamentosController.js
+++ b/backend/orcamentosController.js
@@ -61,7 +61,6 @@ router.post('/', async (req, res) => {
     validade,
     prazo,
     dono,
-    tipo_parcela,
     itens = [],
     parcelas_detalhes = []
   } = req.body;
@@ -96,8 +95,7 @@ router.post('/', async (req, res) => {
         observacoes,
         validade,
         prazo,
-        dono,
-        tipo_parcela
+        dono
       ]
     );
     const orcamentoId = insertOrc.rows[0].id;
@@ -165,7 +163,6 @@ router.put('/:id', async (req, res) => {
     validade,
     prazo,
     dono,
-    tipo_parcela,
     itens = [],
     parcelas_detalhes = []
   } = req.body;
@@ -193,7 +190,6 @@ router.put('/:id', async (req, res) => {
         validade,
         prazo,
         dono,
-        tipo_parcela,
         id
       ]
     );
@@ -296,8 +292,7 @@ router.post('/:id/clone', async (req, res) => {
         orc.observacoes,
         orc.validade,
         orc.prazo,
-        orc.dono,
-        orc.tipo_parcela
+        orc.dono
       ]
     );
     const newId = insert.rows[0].id;


### PR DESCRIPTION
## Summary
- fix duplicated `tipo_parcela` fields in orçamento routes
- ensure `INSERT` and `UPDATE` statements use correct parameter counts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4dd3769188322a77ab049202504a9