### PR TITLE
Prevent Header Overlap In Budget Modals

### DIFF
--- a/src/html/modals/orcamentos/editar.html
+++ b/src/html/modals/orcamentos/editar.html
@@ -1,5 +1,5 @@
-<div id="editarOrcamentoOverlay" class="fixed inset-0 bg-black/50 flex items-start justify-center p-4 overflow-y-auto">
-  <div role="dialog" aria-modal="true" tabindex="0" class="w-full max-w-5xl h-full max-h-[calc(100vh-2rem)] glass-surface backdrop-blur-xl rounded-3xl border border-white/10 ring-1 ring-white/5 shadow-2xl/40 animate-modalFade slide-in overflow-hidden flex flex-col">
+<div id="editarOrcamentoOverlay" class="fixed inset-x-0 bottom-0 top-14 z-[1002] bg-black/50 flex items-start justify-center p-4 overflow-y-auto">
+  <div role="dialog" aria-modal="true" tabindex="0" class="w-full max-w-5xl h-full max-h-full glass-surface backdrop-blur-xl rounded-3xl border border-white/10 ring-1 ring-white/5 shadow-2xl/40 animate-modalFade slide-in overflow-hidden flex flex-col">
     <header class="relative flex items-center justify-between px-8 py-5 border-b border-white/10 flex-shrink-0">
       <div class="flex items-center gap-3">
         <button id="voltarEditarOrcamento" class="btn-neutral px-4 py-2 rounded-lg text-white font-medium flex items-center gap-2">← Voltar</button>

--- a/src/html/modals/orcamentos/novo.html
+++ b/src/html/modals/orcamentos/novo.html
@@ -1,5 +1,5 @@
-<div id="novoOrcamentoOverlay" class="fixed inset-0 bg-black/50 flex items-start justify-center p-4 overflow-y-auto">
-  <div role="dialog" aria-modal="true" tabindex="0" class="w-full max-w-5xl h-full max-h-[calc(100vh-2rem)] glass-surface backdrop-blur-xl rounded-3xl border border-white/10 ring-1 ring-white/5 shadow-2xl/40 animate-modalFade slide-in overflow-hidden flex flex-col">
+<div id="novoOrcamentoOverlay" class="fixed inset-x-0 bottom-0 top-14 z-[1002] bg-black/50 flex items-start justify-center p-4 overflow-y-auto">
+  <div role="dialog" aria-modal="true" tabindex="0" class="w-full max-w-5xl h-full max-h-full glass-surface backdrop-blur-xl rounded-3xl border border-white/10 ring-1 ring-white/5 shadow-2xl/40 animate-modalFade slide-in overflow-hidden flex flex-col">
     <header class="relative flex items-center justify-between px-8 py-5 border-b border-white/10 flex-shrink-0">
       <div class="flex items-center gap-3">
         <button id="voltarNovoOrcamento" class="btn-neutral px-4 py-2 rounded-lg text-white font-medium flex items-center gap-2">← Voltar</button>


### PR DESCRIPTION
## Summary
- keep header clear by constraining overlay to viewport below top bar
- ensure modal content grows instead of footer

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4dfb31a0083228720272597be37c6