### PR TITLE
Fix budget edit overlay handling

### DIFF
--- a/src/js/modals/orcamento-editar.js
+++ b/src/js/modals/orcamento-editar.js
@@ -2,7 +2,9 @@
   const overlayId = 'editarOrcamento';
   const overlay = document.getElementById('editarOrcamentoOverlay');
   const close = () => Modal.close(overlayId);
-  overlay.addEventListener('click', e => { if (e.target === overlay) close(); });
+  if (overlay) {
+    overlay.addEventListener('click', e => { if (e.target === overlay) close(); });
+  }
   document.addEventListener('keydown', function esc(e){ if(e.key === 'Escape'){ close(); document.removeEventListener('keydown', esc); } });
 
   // carga de dados


### PR DESCRIPTION
## Summary
- ensure budget edit modal attaches listeners only when overlay exists

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4dfdbc69883228bb4a89168183fcf