### PR TITLE
Fix null overlay handling in budget modals

### DIFF
--- a/src/js/modals/orcamento-editar.js
+++ b/src/js/modals/orcamento-editar.js
@@ -1,10 +1,9 @@
  (async () => {
   const overlayId = 'editarOrcamento';
   const overlay = document.getElementById('editarOrcamentoOverlay');
+  if (!overlay) return;
   const close = () => Modal.close(overlayId);
-  if (overlay) {
-    overlay.addEventListener('click', e => { if (e.target === overlay) close(); });
-  }
+  overlay.addEventListener('click', e => { if (e.target === overlay) close(); });
   document.addEventListener('keydown', function esc(e){ if(e.key === 'Escape'){ close(); document.removeEventListener('keydown', esc); } });
 
   // carga de dados

--- a/src/js/modals/orcamento-novo.js
+++ b/src/js/modals/orcamento-novo.js
@@ -1,6 +1,7 @@
 (() => {
   const overlayId = 'novoOrcamento';
   const overlay = document.getElementById('novoOrcamentoOverlay');
+  if (!overlay) return;
   const close = () => Modal.close(overlayId);
   overlay.addEventListener('click', e => { if (e.target === overlay) close(); });
   document.addEventListener('keydown', function esc(e){ if(e.key === 'Escape'){ close(); document.removeEventListener('keydown', esc); } });


### PR DESCRIPTION
## Summary
- Guard modal scripts against missing overlay elements for creating and editing budgets

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4e1bb27148322876df74f22002e98