### PR TITLE
Fix Pdf Document Opening Blank

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,5 +1,5 @@
 
-const { app, BrowserWindow, ipcMain, screen, shell } = require('electron');
+const { app, BrowserWindow, ipcMain, screen } = require('electron');
 const path = require('path');
 const { pathToFileURL } = require('url');
 const DEBUG = process.env.DEBUG === 'true';
@@ -749,9 +749,15 @@ ipcMain.handle('get-saved-display', () => {
 });
 
 ipcMain.handle('open-pdf', (_event, id) => {
-  const pdfUrl = pathToFileURL(path.join(__dirname, 'src/pdf/index.html'));
-  pdfUrl.searchParams.set('id', id);
-  shell.openExternal(pdfUrl.toString());
+  const pdfPath = path.join(__dirname, 'src/pdf/index.html');
+  const pdfWin = new BrowserWindow({
+    width: 900,
+    height: 700,
+    webPreferences: {
+      contextIsolation: true
+    }
+  });
+  pdfWin.loadFile(pdfPath, { query: { id } });
   return true;
 });
 


### PR DESCRIPTION
## Summary
- open PDF documents in an internal Electron window instead of launching the default browser
- remove unused `shell` import from main process

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4e2afdeac8322b37195a4a884046b