### PR TITLE
Corrigir abertura do PDF no navegador

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -20,6 +20,7 @@ app.use('/api/usuarios', usuariosRouter);
 app.use('/api/transportadoras', transportadorasRouter);
 app.use('/api/orcamentos', orcamentosRouter);
 app.use(passwordResetRouter);
+app.use('/pdf', express.static(path.join(__dirname, '../src/pdf')));
 
 // Endpoint simples para verificar a disponibilidade do servidor
 app.get('/status', (_req, res) => {

--- a/main.js
+++ b/main.js
@@ -1,7 +1,6 @@
 
 const { app, BrowserWindow, ipcMain, screen, shell } = require('electron');
 const path = require('path');
-const { pathToFileURL } = require('url');
 const DEBUG = process.env.DEBUG === 'true';
 const {
   registrarUsuario,
@@ -749,9 +748,9 @@ ipcMain.handle('get-saved-display', () => {
 });
 
 ipcMain.handle('open-pdf', (_event, id) => {
-  const pdfUrl = pathToFileURL(path.join(__dirname, 'src/pdf/index.html'));
-  pdfUrl.searchParams.set('id', id);
-  shell.openExternal(pdfUrl.toString());
+  const url = new URL('http://localhost:3000/pdf');
+  url.searchParams.set('id', id);
+  shell.openExternal(url.toString());
   return true;
 });
 


### PR DESCRIPTION
## Summary
- Serve arquivos de PDF via rota HTTP dedicada
- Abrir PDFs no navegador usando URL da API

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4e49cc814832296803663e8fb916d