### PR TITLE
Fix footer scroll in novo orçamento modal

### DIFF
--- a/src/html/modals/orcamentos/novo.html
+++ b/src/html/modals/orcamentos/novo.html
@@ -1,4 +1,4 @@
-<div id="novoOrcamentoOverlay" class="fixed inset-x-0 bottom-0 top-14 z-[1002] bg-black/50 flex items-start justify-center p-4 overflow-y-auto">
+<div id="novoOrcamentoOverlay" class="fixed inset-x-0 bottom-0 top-14 z-[1002] bg-black/50 flex items-start justify-center p-4 overflow-y-hidden">
   <div role="dialog" aria-modal="true" tabindex="0" class="w-full max-w-5xl h-full max-h-full glass-surface backdrop-blur-xl rounded-3xl border border-white/10 ring-1 ring-white/5 shadow-2xl/40 animate-modalFade slide-in overflow-hidden flex flex-col relative">
     <header class="relative flex items-center justify-between px-8 py-5 border-b border-white/10 flex-shrink-0">
       <div class="flex items-center gap-3">


### PR DESCRIPTION
## Summary
- keep Novo Orçamento modal footer fixed by restricting scrolling to content area

## Testing
- `npm test` *(fails: Cannot find module '/workspace/App-Gestao/backend')*
- `node --test backend/*.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a5c3a86dc48322a90c1b65916d370b