### PR TITLE
Reset payment terms on item changes

### DIFF
--- a/src/js/modals/orcamento-editar.js
+++ b/src/js/modals/orcamento-editar.js
@@ -46,8 +46,8 @@
     });
   }
   function resetCondicao(){
-    editarCondicao.value='vista';
-    editarCondicao.setAttribute('data-filled','true');
+    editarCondicao.value='';
+    editarCondicao.setAttribute('data-filled','false');
     pagamentoBox.classList.add('hidden');
     pagamentoBox.innerHTML='';
     condicaoDefinida=false;
@@ -86,7 +86,7 @@
   }
   function confirmResetIfNeeded(action){
     if(!condicaoDefinida){action();return;}
-    showResetDialog(ok=>{if(!ok) return;resetCondicao();action();});
+    showResetDialog(ok=>{if(!ok) return;resetCondicao();applyDefaultDiscounts();action();});
   }
   function updateCondicao(prefill){
     if(editarCondicao.value==='vista'){
@@ -518,7 +518,7 @@
     document.querySelectorAll('#orcamentoItens tbody tr').forEach(updateLineTotal);
     editarCondicao.disabled = total === 0;
     editarCondicao.style.pointerEvents = editarCondicao.disabled ? 'none' : 'auto';
-    if(total === 0) resetCondicao();
+    if(total === 0){ resetCondicao(); prevCondicao=''; }
     if(editarCondicao.value==='prazo' && window.Parcelamento){
       Parcelamento.updateTotal('editarParcelamento', parseCurrencyToCents(document.getElementById('totalOrcamento').textContent));
     }

--- a/src/js/modals/orcamento-novo.js
+++ b/src/js/modals/orcamento-novo.js
@@ -77,6 +77,7 @@
     showResetDialog(ok=>{
       if(!ok) return;
       resetCondicao();
+      applyDefaultDiscounts();
       action();
     });
   }
@@ -257,7 +258,7 @@
     itensTbody.querySelectorAll('tr').forEach(updateLineTotal);
     condicaoSelect.disabled = total === 0;
     condicaoSelect.style.pointerEvents = condicaoSelect.disabled ? 'none' : 'auto';
-    if(total === 0) resetCondicao();
+    if(total === 0){ resetCondicao(); prevCondicao=''; }
     if(condicaoSelect.value==='prazo' && window.Parcelamento){
       Parcelamento.updateTotal('novoParcelamento', parseCurrencyToCents(document.getElementById('novoTotal').textContent));
     }


### PR DESCRIPTION
## Summary
- ensure payment condition resets and discounts update when item table changes in new budgets
- clear payment condition and apply default discounts on edits when user confirms reset

## Testing
- `npm test` *(fails: test failed)*

------
https://chatgpt.com/codex/tasks/task_e_68a5c48101b48322bbc2b705682d6a8b