### PR TITLE
Switch PDF To Landscape Orientation And Remove Auto Print

### DIFF
--- a/src/pdf/print.css
+++ b/src/pdf/print.css
@@ -1,7 +1,7 @@
 /* print.css */
 
 @page {
-  size: A4 portrait;
+  size: A4 landscape;
   margin: 5mm;
 }
 

--- a/src/pdf/script.js
+++ b/src/pdf/script.js
@@ -1,11 +1,11 @@
 const docContainer = document.getElementById('doc-container');
 const template = document.getElementById('page-template');
 
-const thresholdSingle = 13;
-const maxFirst = 20;
-const maxFullNext = 30;
-const maxLastNext = 23;
-const minLastItems = 4;
+const thresholdSingle = 9;
+const maxFirst = 14;
+const maxFullNext = 21;
+const maxLastNext = 16;
+const minLastItems = 3;
 
 function createPage(html) {
   const clone = template.content.cloneNode(true);
@@ -152,7 +152,7 @@ async function buildDocument() {
       createPage(html);
     });
 
-    window.print();
+    // Printing is now user-initiated; remove automatic print dialog
   } catch (err) {
     console.error('Erro ao gerar documento', err);
   }


### PR DESCRIPTION
## Summary
- Disable automatic print dialog so the PDF page opens without printing
- Adapt PDF styling for landscape orientation and adjust pagination thresholds

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a5c631cfc883228f53c29342eaf0b3