### PR TITLE
Ajustar O Modal Novo Orçamento Para Que O Scroll Vertical Funcione Exatamente Como No Editar Orçamento

### DIFF
--- a/src/html/modals/orcamentos/novo.html
+++ b/src/html/modals/orcamentos/novo.html
@@ -1,4 +1,4 @@
-<div id="novoOrcamentoOverlay" class="fixed inset-x-0 bottom-0 top-14 z-[1002] bg-black/50 flex items-start justify-center p-4 overflow-y-hidden">
+<div id="novoOrcamentoOverlay" class="fixed inset-x-0 bottom-0 top-14 z-[1002] bg-black/50 flex items-start justify-center p-4 overflow-y-auto">
   <div role="dialog" aria-modal="true" tabindex="0" class="w-full max-w-5xl h-full max-h-full glass-surface backdrop-blur-xl rounded-3xl border border-white/10 ring-1 ring-white/5 shadow-2xl/40 animate-modalFade slide-in overflow-hidden flex flex-col relative">
     <header class="relative flex items-center justify-between px-8 py-5 border-b border-white/10 flex-shrink-0">
       <div class="flex items-center gap-3">
@@ -17,7 +17,7 @@
         <button id="limparNovoOrcamento" class="btn-danger px-4 py-2 rounded-lg text-white font-medium">Limpar Tudo</button>
       </div>
     </header>
-    <div class="flex-1 overflow-y-auto pb-24">
+    <div class="flex-1 overflow-y-auto">
       <div class="px-8 py-6 space-y-6">
         <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
           <div class="relative">
@@ -125,7 +125,7 @@
         </div>
       </div>
     </div>
-    <footer class="absolute bottom-0 left-0 right-0 flex justify-end gap-3 px-8 py-6 border-t border-white/10">
+    <footer class="flex justify-end gap-3 px-8 py-6 border-t border-white/10 flex-shrink-0">
       <button id="enviarNovoOrcamento" class="btn-secondary px-4 py-2 rounded-lg text-white font-medium">Salvar e Enviar</button>
       <button id="cancelarNovoOrcamento" class="btn-danger-light px-4 py-2 rounded-lg font-medium">Cancelar</button>
     </footer>

--- a/src/js/modals/orcamento-novo.js
+++ b/src/js/modals/orcamento-novo.js
@@ -1,6 +1,7 @@
 (() => {
   const overlayId = 'novoOrcamento';
   const overlay = document.getElementById('novoOrcamentoOverlay');
+  // Scroll restrito ao corpo do modal Novo Orçamento (entre header e footer)
   if (!overlay) return;
   const close = () => Modal.close(overlayId);
   overlay.addEventListener('click', e => { if (e.target === overlay) close(); });


### PR DESCRIPTION
## Summary
- Limita a rolagem vertical ao corpo do modal Novo Orçamento entre header e footer
- Documenta ajuste de rolagem diretamente no script do modal

## Testing
- `npm test` *(erro: Cannot find module '/workspace/App-Gestao/backend')*

------
https://chatgpt.com/codex/tasks/task_e_68a5c9cff5ec832280c747c8df940916