### PR TITLE
Corrigir comportamento de rolagem do modal Novo Orçamento

### DIFF
--- a/src/html/modals/orcamentos/novo.html
+++ b/src/html/modals/orcamentos/novo.html
@@ -1,4 +1,4 @@
-<div id="novoOrcamentoOverlay" class="fixed inset-x-0 bottom-0 top-14 z-[1002] bg-black/50 flex items-start justify-center p-4 overflow-y-auto">
+<div id="novoOrcamentoOverlay" class="fixed inset-x-0 bottom-0 top-14 z-[1002] bg-black/50 flex items-start justify-center p-4 overflow-hidden">
   <div role="dialog" aria-modal="true" tabindex="0" class="w-full max-w-5xl h-full max-h-full glass-surface backdrop-blur-xl rounded-3xl border border-white/10 ring-1 ring-white/5 shadow-2xl/40 animate-modalFade slide-in overflow-hidden flex flex-col relative">
     <header class="relative flex items-center justify-between px-8 py-5 border-b border-white/10 flex-shrink-0">
       <div class="flex items-center gap-3">
@@ -17,7 +17,7 @@
         <button id="limparNovoOrcamento" class="btn-danger px-4 py-2 rounded-lg text-white font-medium">Limpar Tudo</button>
       </div>
     </header>
-    <div class="flex-1 overflow-y-auto">
+    <div class="modal-body flex-1 overflow-y-auto"><!-- Scroll do Novo Orçamento restrito ao corpo (entre header e footer), igual Editar Orçamento -->
       <div class="px-8 py-6 space-y-6">
         <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
           <div class="relative">

--- a/src/js/modals/orcamento-novo.js
+++ b/src/js/modals/orcamento-novo.js
@@ -1,7 +1,7 @@
 (() => {
   const overlayId = 'novoOrcamento';
   const overlay = document.getElementById('novoOrcamentoOverlay');
-  // Scroll restrito ao corpo do modal Novo Orçamento (entre header e footer)
+  // Scroll do Novo Orçamento restrito ao corpo (entre header e footer), igual Editar Orçamento.
   if (!overlay) return;
   const close = () => Modal.close(overlayId);
   overlay.addEventListener('click', e => { if (e.target === overlay) close(); });


### PR DESCRIPTION
## Summary
- Limita a rolagem ao corpo do modal Novo Orçamento, preservando header e footer fixos

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a5f3472a9c8322a31fe3281acbf518