### PR TITLE
Editar Orçamentos: Ajustar Status Bloqueado E Validade

### DIFF
--- a/src/css/orcamentos.css
+++ b/src/css/orcamentos.css
@@ -203,11 +203,11 @@ body {
     content: '';
     position: absolute;
     top: 50%;
-    left: -10%;
-    width: 120%;
+    left: 0;
+    width: 100%;
     height: 2px;
     background: var(--color-red);
-    transform: rotate(45deg);
+    transform: translateY(-50%);
 }
 
 .info-icon {

--- a/src/js/modals/orcamento-editar.js
+++ b/src/js/modals/orcamento-editar.js
@@ -293,6 +293,7 @@
   let currentStatus = data.situacao || 'Rascunho';
   const statusTag = document.getElementById('statusTag');
   const statusOptions = document.getElementById('statusOptions');
+  const UNAVAILABLE_MSG = 'Função indisponível: o orçamento não é mais RASCUNHO.';
 
   function updateStatusTag() {
     if (!statusTag) return;
@@ -313,7 +314,7 @@
       btn.addEventListener('click', () => {
         const next = btn.dataset.status;
         if(next==='Rascunho' && statusLocked){
-          showFunctionUnavailableDialog('Não é possível retornar o orçamento para rascunho.');
+          showFunctionUnavailableDialog(UNAVAILABLE_MSG);
           statusOptions.classList.add('hidden');
           return;
         }
@@ -332,8 +333,13 @@
   if(statusLocked){
     [editarCliente, editarValidade, donoSelect].forEach(el=>{if(el) el.disabled=true;});
     [editarCliente.parentElement, editarValidade.parentElement, donoSelect.parentElement].forEach(wrapper=>{
-      wrapper.addEventListener('click',e=>{e.preventDefault();showFunctionUnavailableDialog('O orçamento não é mais um rascunho e não pode ser alterado.');});
+      wrapper.addEventListener('click',e=>{e.preventDefault();showFunctionUnavailableDialog(UNAVAILABLE_MSG);});
     });
+    const validadeLabel = document.querySelector('label[for="editarValidade"]');
+    if(validadeLabel && editarValidade.value){
+      validadeLabel.classList.remove('top-1/2','-translate-y-1/2','text-base');
+      validadeLabel.classList.add('top-0','-translate-y-full','text-xs');
+    }
   }
 
   function formatCurrency(v) {


### PR DESCRIPTION
## Summary
- Mantém a linha de bloqueio horizontal nos itens de status
- Centraliza o título da validade quando o campo está preenchido e bloqueado
- Exibe diálogo de função indisponível ao interagir com campos bloqueados

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a5f437c84c83228643fca2fbb7a2ab