### PR TITLE
Corrigir aparência de ações para orçamentos aprovados, rejeitados e expirados

### DIFF
--- a/src/js/modals/orcamento-editar.js
+++ b/src/js/modals/orcamento-editar.js
@@ -308,7 +308,7 @@
     });
     statusOptions.querySelectorAll('button').forEach(btn => {
       if(btn.dataset.status==='Rascunho' && statusLocked){
-        btn.classList.add('action-disabled');
+        btn.classList.add('icon-disabled');
       }
       btn.addEventListener('click', () => {
         const next = btn.dataset.status;

--- a/src/js/orcamentos.js
+++ b/src/js/orcamentos.js
@@ -91,7 +91,7 @@ async function carregarOrcamentos() {
             const downloadClass = isDraft ? 'pdf-disabled relative' : '';
             const downloadTitle = isDraft ? 'PDF indisponível' : 'Baixar PDF';
             const editBlocked = ['Aprovado','Expirado','Rejeitado'].includes(o.situacao);
-            const editClass = editBlocked ? 'action-disabled' : '';
+            const editClass = editBlocked ? 'icon-disabled' : '';
             tr.innerHTML = `
                 <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-white">${o.numero}</td>
                 <td class="px-6 py-4 whitespace-nowrap text-sm text-white">${o.cliente || ''}</td>
@@ -116,7 +116,7 @@ async function carregarOrcamentos() {
         tbody.querySelectorAll('.fa-edit').forEach(icon => {
             icon.addEventListener('click', async e => {
                 e.stopPropagation();
-                if (icon.classList.contains('action-disabled')) {
+                if (icon.classList.contains('icon-disabled')) {
                     showFunctionUnavailableDialog('Orçamentos aprovados, expirados ou rejeitados não podem ser editados.');
                     return;
                 }


### PR DESCRIPTION
## Summary
- Ajusta classe de ícones desabilitados na tabela de orçamentos
- Alinha estilo de botão desabilitado na edição de orçamentos

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5f55813e88322a5429909b0a5d0ee