### PR TITLE
Fix budget view labels and item loading

### DIFF
--- a/src/html/modals/orcamentos/visualizar.html
+++ b/src/html/modals/orcamentos/visualizar.html
@@ -29,7 +29,7 @@
           </div>
           <div class="relative">
             <input id="visualizarValidade" type="date" placeholder=" " class="peer w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition" disabled />
-            <label for="visualizarValidade" class="absolute left-4 top-1/2 -translate-y-1/2 text-base text-gray-300 pointer-events-none transition-all duration-150 peer-focus:top-0 peer-focus:-translate-y-full peer-focus:text-xs peer-focus:text-primary peer-valid:top-0 peer-valid:-translate-y-full peer-valid:text-xs">Validade</label>
+            <label for="visualizarValidade" class="absolute left-4 top-1/2 -translate-y-1/2 text-base text-gray-300 pointer-events-none transition-all duration-150 peer-focus:top-0 peer-focus:-translate-y-full peer-focus:text-xs peer-focus:text-primary peer-valid:top-0 peer-valid:-translate-y-full peer-valid:text-xs peer-data-[filled=true]:top-0 peer-data-[filled=true]:-translate-y-full peer-data-[filled=true]:text-xs">Validade</label>
             <i class="fas fa-calendar-alt absolute right-4 top-1/2 -translate-y-1/2 text-gray-300 pointer-events-none"></i>
           </div>
           <div class="relative">
@@ -57,7 +57,7 @@
           </div>
           <div class="relative lg:col-span-2">
             <textarea id="visualizarObservacoes" rows="2" placeholder=" " class="peer w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-transparent focus:border-primary focus:ring-2 focus:ring-primary/50 transition" disabled></textarea>
-            <label for="visualizarObservacoes" class="absolute left-4 top-3 text-base text-gray-300 pointer-events-none transition-all duration-150 peer-placeholder-shown:top-3 peer-placeholder-shown:text-base peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary peer-valid:-top-2 peer-valid:text-xs">Observações</label>
+            <label for="visualizarObservacoes" class="absolute left-4 top-3 text-base text-gray-300 pointer-events-none transition-all duration-150 peer-placeholder-shown:top-3 peer-placeholder-shown:text-base peer-focus:-top-2 peer-focus:text-xs peer-focus:text-primary peer-valid:-top-2 peer-valid:text-xs peer-data-[filled=true]:-top-2 peer-data-[filled=true]:text-xs">Observações</label>
           </div>
         </div>
 

--- a/src/js/modals/orcamento-visualizar.js
+++ b/src/js/modals/orcamento-visualizar.js
@@ -72,23 +72,32 @@
 
     let subtotal = 0, descPag = 0, descEsp = 0;
     data.itens.forEach(it => {
+      const qtd = Number(it.quantidade) || 0;
+      const valorUnit = Number(it.valor_unitario) || 0;
+      const valorUnitDesc = Number(it.valor_unitario_desc) || 0;
+      const descPagPrc = Number(it.desconto_pagamento_prc) || 0;
+      const descEspPrc = Number(it.desconto_especial_prc) || 0;
+      const valorTotal = Number(it.valor_total) || 0;
+      const descPagUnit = Number(it.desconto_pagamento) || 0;
+      const descEspUnit = Number(it.desconto_especial) || 0;
+
       const tr = document.createElement('tr');
       tr.className = 'border-b border-white/10';
       tr.innerHTML = `
         <td class="px-6 py-4 text-sm text-white">${it.nome}</td>
-        <td class="px-6 py-4 text-center text-sm text-white">${it.quantidade}</td>
-        <td class="px-6 py-4 text-right text-sm text-white">${it.valor_unitario.toFixed(2)}</td>
-        <td class="px-6 py-4 text-right text-sm text-white">${it.valor_unitario_desc.toFixed(2)}</td>
-        <td class="px-6 py-4 text-center text-sm text-white">${(it.desconto_pagamento_prc + it.desconto_especial_prc).toFixed(2)}</td>
-        <td class="px-6 py-4 text-right text-sm text-white">${it.valor_total.toFixed(2)}</td>
+        <td class="px-6 py-4 text-center text-sm text-white">${qtd}</td>
+        <td class="px-6 py-4 text-right text-sm text-white">${valorUnit.toFixed(2)}</td>
+        <td class="px-6 py-4 text-right text-sm text-white">${valorUnitDesc.toFixed(2)}</td>
+        <td class="px-6 py-4 text-center text-sm text-white">${(descPagPrc + descEspPrc).toFixed(2)}</td>
+        <td class="px-6 py-4 text-right text-sm text-white">${valorTotal.toFixed(2)}</td>
         <td class="px-6 py-4 text-center">
           <i class="fas fa-edit w-5 h-5 p-1 rounded icon-disabled" style="color: var(--color-primary)"></i>
           <i class="fas fa-trash w-5 h-5 p-1 rounded text-red-400 icon-disabled"></i>
         </td>`;
       itensTbody.appendChild(tr);
-      subtotal += it.valor_unitario * it.quantidade;
-      descPag += it.desconto_pagamento * it.quantidade;
-      descEsp += it.desconto_especial * it.quantidade;
+      subtotal += valorUnit * qtd;
+      descPag += descPagUnit * qtd;
+      descEsp += descEspUnit * qtd;
     });
     const desconto = descPag + descEsp;
     const total = subtotal - desconto;
@@ -103,7 +112,7 @@
       const pgBox = document.getElementById('visualizarPagamento');
       pgBox.classList.remove('hidden');
       pgBox.innerHTML = '<h4 class="text-white font-medium mb-4">Parcelas</h4>' +
-        data.parcelas_detalhes.map(p => `<div class="flex justify-between text-sm text-white mb-2"><span>${p.numero_parcela}ª parcela</span><span>${p.valor.toFixed(2)} - ${new Date(p.data_vencimento).toLocaleDateString('pt-BR')}</span></div>`).join('');
+        data.parcelas_detalhes.map(p => `<div class="flex justify-between text-sm text-white mb-2"><span>${p.numero_parcela}ª parcela</span><span>${Number(p.valor).toFixed(2)} - ${new Date(p.data_vencimento).toLocaleDateString('pt-BR')}</span></div>`).join('');
     }
 
   } catch (err) {


### PR DESCRIPTION
## Summary
- ensure labels float in read-only budget modal to avoid overlapping content
- correctly parse numeric fields so budget items display and totals calculate

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5f5fda3dc832285402316096a9363