### PR TITLE
Indicar Status Rascunho Bloqueado Em Editar Orçamento

### DIFF
--- a/src/css/orcamentos.css
+++ b/src/css/orcamentos.css
@@ -210,6 +210,25 @@ body {
     transform: translateY(-50%);
 }
 
+/* Opções de status desabilitadas */
+.status-disabled {
+    position: relative;
+    cursor: not-allowed;
+    background: #111827;
+    opacity: 0.6;
+}
+
+.status-disabled::after {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 0;
+    width: 100%;
+    height: 2px;
+    background: var(--color-red);
+    transform: translateY(-50%);
+}
+
 .info-icon {
     width: 20px;
     height: 20px;

--- a/src/js/modals/orcamento-editar.js
+++ b/src/js/modals/orcamento-editar.js
@@ -293,7 +293,7 @@
   let currentStatus = data.situacao || 'Rascunho';
   const statusTag = document.getElementById('statusTag');
   const statusOptions = document.getElementById('statusOptions');
-  const UNAVAILABLE_MSG = 'Função indisponível: o orçamento não é mais RASCUNHO.';
+  const UNAVAILABLE_MSG = 'Função indisponível: só pode ser editado se o pedido estiver como RASCUNHO.';
 
   function updateStatusTag() {
     if (!statusTag) return;
@@ -308,12 +308,13 @@
       statusOptions.classList.toggle('hidden');
     });
     statusOptions.querySelectorAll('button').forEach(btn => {
-      if(btn.dataset.status==='Rascunho' && statusLocked){
-        btn.classList.add('icon-disabled');
+      if (btn.dataset.status === 'Rascunho' && statusLocked) {
+        btn.classList.add('status-disabled');
+        btn.classList.remove('hover:bg-gray-700');
       }
       btn.addEventListener('click', () => {
         const next = btn.dataset.status;
-        if(next==='Rascunho' && statusLocked){
+        if (next === 'Rascunho' && statusLocked) {
           showFunctionUnavailableDialog(UNAVAILABLE_MSG);
           statusOptions.classList.add('hidden');
           return;


### PR DESCRIPTION
## Summary
- show unavailable message when attempting to switch to Draft in non-draft orders
- style Draft status option as inactive with dark background and red line

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5f7145c0c8322919e22d19f40b97a