### PR TITLE
Fix Scrollbar Overlap In New Budget Modal

### DIFF
--- a/src/html/modals/orcamentos/novo.html
+++ b/src/html/modals/orcamentos/novo.html
@@ -17,7 +17,7 @@
         <button id="limparNovoOrcamento" class="btn-danger px-4 py-2 rounded-lg text-white font-medium">Limpar Tudo</button>
       </div>
     </header>
-    <div class="modal-body flex-1 overflow-y-auto"><!-- Scroll do Novo Orçamento restrito ao corpo (entre header e footer), igual Editar Orçamento -->
+    <div class="modal-body flex-1 overflow-y-auto pb-6"><!-- Scroll do Novo Orçamento restrito ao corpo (entre header e footer), igual Editar Orçamento -->
       <div class="px-8 py-6 space-y-6">
         <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
           <div class="relative">
@@ -125,7 +125,7 @@
         </div>
       </div>
     </div>
-    <footer class="flex justify-end gap-3 px-8 py-6 border-t border-white/10 flex-shrink-0">
+    <footer class="flex justify-end gap-3 px-8 py-4 border-t border-white/10 flex-shrink-0">
       <button id="enviarNovoOrcamento" class="btn-secondary px-4 py-2 rounded-lg text-white font-medium">Salvar e Enviar</button>
       <button id="cancelarNovoOrcamento" class="btn-danger-light px-4 py-2 rounded-lg font-medium">Cancelar</button>
     </footer>


### PR DESCRIPTION
## Summary
- ensure the New Budget modal body has bottom padding so scrolling stops above the footer
- compact footer spacing so two action buttons sit harmoniously

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a5f787f5808322aa7ab0a1a60ffb87