### PR TITLE
Adjust Orcamentos Pdf Button And Action Buttons Position

### DIFF
--- a/src/css/orcamentos.css
+++ b/src/css/orcamentos.css
@@ -185,11 +185,11 @@ body {
     content: '';
     position: absolute;
     top: 50%;
-    left: -10%;
-    width: 120%;
+    left: 0;
+    width: 100%;
     height: 2px;
     background: var(--color-red);
-    transform: rotate(45deg);
+    transform: translateY(-50%);
 }
 
 .icon-disabled {
@@ -281,6 +281,10 @@ body {
 /* Ajusta altura da tabela e ações de filtro */
 .table-scroll {
     max-height: calc(var(--module-height) - 260px) !important;
+}
+
+.table-scroll thead {
+    z-index: 1;
 }
 
 #bt-actions {


### PR DESCRIPTION
## Summary
- Make inactive PDF buttons use the same horizontal strike style as other disabled actions
- Ensure action buttons don't overlap the table header when scrolling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5f819eff48322b991001fa0664597