### PR TITLE
Display Budget Code In Success Messages

### DIFF
--- a/src/js/modals/orcamento-editar.js
+++ b/src/js/modals/orcamento-editar.js
@@ -674,7 +674,7 @@
       });
       if (!resp.ok) throw new Error('Erro');
       if (window.reloadOrcamentos) await window.reloadOrcamentos();
-      showToast('Orçamento atualizado com sucesso!', 'success');
+      showToast(`ORÇAMENTO ${data.numero} ATUALIZADO COM SUCESSO!`, 'success');
       if (closeAfter) close();
     } catch (err) {
       console.error(err);
@@ -694,7 +694,7 @@
       if (window.reloadOrcamentos) await window.reloadOrcamentos();
       close();
       window.selectedQuoteId = clone.id;
-      showToast('Orçamento clonado salvo e aberto para edição', 'info');
+      showToast(`ORÇAMENTO ${clone.numero} CLONADO, SALVO E ABERTO PARA EDIÇÃO`, 'info');
       Modal.open('modals/orcamentos/editar.html', '../js/modals/orcamento-editar.js', 'editarOrcamento');
     } catch (err) {
       console.error(err);

--- a/src/js/modals/orcamento-novo.js
+++ b/src/js/modals/orcamento-novo.js
@@ -543,10 +543,14 @@
           body: JSON.stringify(body)
         });
         if (!resp.ok) throw new Error('Erro ao salvar');
-        await resp.json();
+        const result = await resp.json();
         if (window.reloadOrcamentos) await window.reloadOrcamentos();
         Modal.close(overlayId);
-        showToast(status === 'Rascunho' ? 'Orçamento salvo com sucesso!' : 'Orçamento salvo e enviado com sucesso!', 'success');
+        const message =
+          status === 'Rascunho'
+            ? `ORÇAMENTO ${result.numero} SALVO COM SUCESSO!`
+            : `ORÇAMENTO ${result.numero} SALVO E ENVIADO COM SUCESSO!`;
+        showToast(message, 'success');
       } catch (err) {
         console.error(err);
         showToast('Erro ao salvar orçamento', 'error');

--- a/src/js/modals/orcamento-visualizar.js
+++ b/src/js/modals/orcamento-visualizar.js
@@ -147,7 +147,7 @@
       if (window.reloadOrcamentos) await window.reloadOrcamentos();
       close();
       window.selectedQuoteId = clone.id;
-      showToast('Orçamento clonado salvo e aberto para edição', 'info');
+      showToast(`ORÇAMENTO ${clone.numero} CLONADO, SALVO E ABERTO PARA EDIÇÃO`, 'info');
       Modal.open('modals/orcamentos/editar.html', '../js/modals/orcamento-editar.js', 'editarOrcamento');
     } catch (err) {
       console.error(err);


### PR DESCRIPTION
## Summary
- show quote number in success toasts when creating budgets
- include budget code in update and clone notifications

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a5fcfafef4832289a6290fd7a77473