### PR TITLE
Adicionar tag de valor total no rodapé

### DIFF
--- a/src/html/modals/orcamentos/editar.html
+++ b/src/html/modals/orcamentos/editar.html
@@ -135,11 +135,14 @@
         </div>
       </div>
     </div>
-    <footer class="flex justify-end gap-3 px-8 py-6 border-t border-white/10 flex-shrink-0">
-      <button id="clonarOrcamento" class="btn-secondary px-4 py-2 rounded-lg text-white font-medium">Clonar</button>
-      <button id="salvarFecharOrcamento" class="btn-dark-green px-4 py-2 rounded-lg text-white font-medium">Salvar e Fechar</button>
-      <button id="converterOrcamento" class="btn-purple px-4 py-2 rounded-lg text-white font-medium">Converter em Pedido</button>
-      <button id="cancelarOrcamento" class="btn-danger-light px-4 py-2 rounded-lg font-medium">Cancelar</button>
+    <footer class="flex items-center justify-between gap-3 px-8 py-6 border-t border-white/10 flex-shrink-0">
+      <span class="badge-success px-6 py-3 rounded-full text-lg font-semibold">Valor Total: <span id="totalOrcamentoFooter">R$ 0,00</span></span>
+      <div class="flex gap-3">
+        <button id="clonarOrcamento" class="btn-secondary px-4 py-2 rounded-lg text-white font-medium">Clonar</button>
+        <button id="salvarFecharOrcamento" class="btn-dark-green px-4 py-2 rounded-lg text-white font-medium">Salvar e Fechar</button>
+        <button id="converterOrcamento" class="btn-purple px-4 py-2 rounded-lg text-white font-medium">Converter em Pedido</button>
+        <button id="cancelarOrcamento" class="btn-danger-light px-4 py-2 rounded-lg font-medium">Cancelar</button>
+      </div>
     </footer>
   </div>
 </div>

--- a/src/html/modals/orcamentos/novo.html
+++ b/src/html/modals/orcamentos/novo.html
@@ -125,9 +125,12 @@
         </div>
       </div>
     </div>
-    <footer class="flex justify-end gap-3 px-8 py-6 border-t border-white/10 flex-shrink-0">
-      <button id="enviarNovoOrcamento" class="btn-secondary px-4 py-2 rounded-lg text-white font-medium">Salvar e Enviar</button>
-      <button id="cancelarNovoOrcamento" class="btn-danger-light px-4 py-2 rounded-lg font-medium">Cancelar</button>
+    <footer class="flex items-center justify-between gap-3 px-8 py-6 border-t border-white/10 flex-shrink-0">
+      <span class="badge-success px-6 py-3 rounded-full text-lg font-semibold">Valor Total: <span id="novoTotalFooter">R$ 0,00</span></span>
+      <div class="flex gap-3">
+        <button id="enviarNovoOrcamento" class="btn-secondary px-4 py-2 rounded-lg text-white font-medium">Salvar e Enviar</button>
+        <button id="cancelarNovoOrcamento" class="btn-danger-light px-4 py-2 rounded-lg font-medium">Cancelar</button>
+      </div>
     </footer>
   </div>
 </div>

--- a/src/html/modals/orcamentos/visualizar.html
+++ b/src/html/modals/orcamentos/visualizar.html
@@ -99,9 +99,12 @@
 
       </div>
     </div>
-    <footer class="flex justify-end gap-3 px-8 py-6 border-t border-white/10 flex-shrink-0">
-      <button id="clonarOrcamento" class="btn-secondary px-4 py-2 rounded-lg text-white font-medium">Clonar</button>
-      <button id="voltarVisualizarOrcamentoFooter" class="btn-neutral px-4 py-2 rounded-lg text-white font-medium">Voltar</button>
+    <footer class="flex items-center justify-between gap-3 px-8 py-6 border-t border-white/10 flex-shrink-0">
+      <span class="badge-success px-6 py-3 rounded-full text-lg font-semibold">Valor Total: <span id="totalOrcamentoFooter">R$ 0,00</span></span>
+      <div class="flex gap-3">
+        <button id="clonarOrcamento" class="btn-secondary px-4 py-2 rounded-lg text-white font-medium">Clonar</button>
+        <button id="voltarVisualizarOrcamentoFooter" class="btn-neutral px-4 py-2 rounded-lg text-white font-medium">Voltar</button>
+      </div>
     </footer>
   </div>
 </div>

--- a/src/js/modals/orcamento-editar.js
+++ b/src/js/modals/orcamento-editar.js
@@ -556,6 +556,8 @@
     document.getElementById('descontoOrcamento').textContent = formatCurrency(desconto);
     const total = subtotal - desconto;
     document.getElementById('totalOrcamento').textContent = formatCurrency(total);
+    const footerTotal = document.getElementById('totalOrcamentoFooter');
+    if (footerTotal) footerTotal.textContent = formatCurrency(total);
     document.querySelectorAll('#orcamentoItens tbody tr').forEach(updateLineTotal);
     editarCondicao.disabled = total === 0;
     editarCondicao.style.pointerEvents = editarCondicao.disabled ? 'none' : 'auto';

--- a/src/js/modals/orcamento-novo.js
+++ b/src/js/modals/orcamento-novo.js
@@ -256,6 +256,8 @@
     document.getElementById('novoDesconto').textContent = formatCurrency(desconto);
     const total = subtotal - desconto;
     document.getElementById('novoTotal').textContent = formatCurrency(total);
+    const footerTotal = document.getElementById('novoTotalFooter');
+    if (footerTotal) footerTotal.textContent = formatCurrency(total);
     itensTbody.querySelectorAll('tr').forEach(updateLineTotal);
     condicaoSelect.disabled = total === 0;
     condicaoSelect.style.pointerEvents = condicaoSelect.disabled ? 'none' : 'auto';

--- a/src/js/modals/orcamento-visualizar.js
+++ b/src/js/modals/orcamento-visualizar.js
@@ -110,6 +110,8 @@
     document.getElementById('descontoEspOrcamento').textContent = fmt(descEsp);
     document.getElementById('descontoOrcamento').textContent = fmt(desconto);
     document.getElementById('totalOrcamento').textContent = fmt(total);
+    const footerTotal = document.getElementById('totalOrcamentoFooter');
+    if (footerTotal) footerTotal.textContent = fmt(total);
 
     if (data.parcelas_detalhes && data.parcelas_detalhes.length) {
       const pgBox = document.getElementById('visualizarPagamento');


### PR DESCRIPTION
## Summary
- mostrar o valor total do orçamento em destaque verde no rodapé
- manter o total atualizado nas telas de visualização, edição e criação de orçamento

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5ff4d5e6883228ef5dd3e7c23e81d