### PR TITLE
Show Approval Date Next To Status Tag

### DIFF
--- a/src/html/modals/orcamentos/visualizar.html
+++ b/src/html/modals/orcamentos/visualizar.html
@@ -11,6 +11,7 @@
       </div>
       <h2 id="tituloVisualizarOrcamento" class="absolute left-1/2 -translate-x-1/2 text-lg font-semibold text-white">VISUALIZAR ORÇAMENTO</h2>
       <div class="flex items-center gap-3">
+        <span id="dataAprovacaoTag" class="text-sm text-gray-300 hidden"></span>
         <span id="statusTag" class="badge-warning px-3 py-1 rounded-full text-xs font-medium">Pendente</span>
       </div>
     </header>

--- a/src/js/modals/orcamento-visualizar.js
+++ b/src/js/modals/orcamento-visualizar.js
@@ -72,6 +72,15 @@
     const tag = document.getElementById('statusTag');
     tag.textContent = data.situacao;
     tag.className = `${statusClasses[data.situacao] || 'badge-neutral'} px-3 py-1 rounded-full text-xs font-medium`;
+    const dataTag = document.getElementById('dataAprovacaoTag');
+    if (['Aprovado', 'Rejeitado', 'Expirado'].includes(data.situacao) && data.data_aprovacao) {
+      const dt = new Date(data.data_aprovacao);
+      dataTag.textContent = dt.toLocaleDateString('pt-BR');
+      dataTag.classList.remove('hidden');
+    } else {
+      dataTag.textContent = '';
+      dataTag.classList.add('hidden');
+    }
 
     let subtotal = 0, descPag = 0, descEsp = 0;
     data.itens.forEach(it => {


### PR DESCRIPTION
## Summary
- display approval date beside status tag when viewing budgets

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a71fac75988322b34e57961e5c7431