### PR TITLE
Adicionar spinner nos modais de orçamento

### DIFF
--- a/src/html/modals/orcamentos/editar.html
+++ b/src/html/modals/orcamentos/editar.html
@@ -1,4 +1,4 @@
-<div id="editarOrcamentoOverlay" class="fixed inset-x-0 bottom-0 top-14 z-[1002] bg-black/50 flex items-start justify-center p-4 overflow-y-auto">
+<div id="editarOrcamentoOverlay" class="hidden fixed inset-x-0 bottom-0 top-14 z-[1002] bg-black/50 flex items-start justify-center p-4 overflow-y-auto">
   <div role="dialog" aria-modal="true" tabindex="0" class="w-full max-w-5xl h-full max-h-full glass-surface backdrop-blur-xl rounded-3xl border border-white/10 ring-1 ring-white/5 shadow-2xl/40 animate-modalFade slide-in overflow-hidden flex flex-col">
     <header class="relative flex items-center justify-between px-8 py-5 border-b border-white/10 flex-shrink-0">
       <div class="flex items-center gap-3">

--- a/src/html/modals/orcamentos/visualizar.html
+++ b/src/html/modals/orcamentos/visualizar.html
@@ -1,4 +1,4 @@
-<div id="visualizarOrcamentoOverlay" class="fixed inset-x-0 bottom-0 top-14 z-[1002] bg-black/50 flex items-start justify-center p-4 overflow-y-auto">
+<div id="visualizarOrcamentoOverlay" class="hidden fixed inset-x-0 bottom-0 top-14 z-[1002] bg-black/50 flex items-start justify-center p-4 overflow-y-auto">
   <div role="dialog" aria-modal="true" tabindex="0" class="w-full max-w-5xl h-full max-h-full glass-surface backdrop-blur-xl rounded-3xl border border-white/10 ring-1 ring-white/5 shadow-2xl/40 animate-modalFade slide-in overflow-hidden flex flex-col">
     <header class="relative flex items-center justify-between px-8 py-5 border-b border-white/10 flex-shrink-0">
       <div class="flex items-center gap-3">

--- a/src/js/modals/orcamento-editar.js
+++ b/src/js/modals/orcamento-editar.js
@@ -710,4 +710,6 @@
       showToast('Erro ao clonar orçamento', 'error');
     }
   });
+
+  window.dispatchEvent(new CustomEvent('orcamentoModalLoaded', { detail: overlayId }));
 })();

--- a/src/js/modals/orcamento-visualizar.js
+++ b/src/js/modals/orcamento-visualizar.js
@@ -165,5 +165,6 @@
       showToast('Erro ao clonar orçamento', 'error');
     }
   });
+  window.dispatchEvent(new CustomEvent('orcamentoModalLoaded', { detail: overlayId }));
 })();
 

--- a/src/js/orcamentos.js
+++ b/src/js/orcamentos.js
@@ -61,6 +61,33 @@ function showFunctionUnavailableDialog(message) {
     overlay.querySelector('#funcUnavailableOk').addEventListener('click', () => overlay.remove());
 }
 
+function openQuoteModal(htmlPath, scriptPath, overlayId) {
+    Modal.closeAll();
+    const spinner = document.createElement('div');
+    spinner.id = 'modalLoading';
+    spinner.className = 'fixed inset-0 z-[2000] bg-black/50 flex items-center justify-center';
+    spinner.innerHTML = '<div class="w-16 h-16 border-4 border-white border-t-transparent rounded-full animate-spin"></div>';
+    document.body.appendChild(spinner);
+    const start = Date.now();
+    function handleLoaded(e) {
+        if (e.detail !== overlayId) return;
+        const overlay = document.getElementById(`${overlayId}Overlay`);
+        const elapsed = Date.now() - start;
+        const show = () => {
+            spinner.remove();
+            overlay.classList.remove('hidden');
+        };
+        if (elapsed < 3000) {
+            setTimeout(show, Math.max(0, 2000 - elapsed));
+        } else {
+            show();
+        }
+        window.removeEventListener('orcamentoModalLoaded', handleLoaded);
+    }
+    window.addEventListener('orcamentoModalLoaded', handleLoaded);
+    Modal.open(htmlPath, scriptPath, overlayId, true);
+}
+
 async function carregarOrcamentos() {
     try {
         const resp = await fetch('http://localhost:3000/api/orcamentos');
@@ -122,7 +149,7 @@ async function carregarOrcamentos() {
                 }
                 const id = e.currentTarget.closest('tr').dataset.id;
                 window.selectedQuoteId = id;
-                await Modal.open('modals/orcamentos/editar.html', '../js/modals/orcamento-editar.js', 'editarOrcamento');
+                openQuoteModal('modals/orcamentos/editar.html', '../js/modals/orcamento-editar.js', 'editarOrcamento');
             });
         });
         tbody.querySelectorAll('.fa-eye').forEach(icon => {
@@ -130,7 +157,7 @@ async function carregarOrcamentos() {
                 e.stopPropagation();
                 const id = e.currentTarget.closest('tr').dataset.id;
                 window.selectedQuoteId = id;
-                await Modal.open('modals/orcamentos/visualizar.html', '../js/modals/orcamento-visualizar.js', 'visualizarOrcamento');
+                openQuoteModal('modals/orcamentos/visualizar.html', '../js/modals/orcamento-visualizar.js', 'visualizarOrcamento');
             });
         });
         tbody.querySelectorAll('.fa-download').forEach(icon => {


### PR DESCRIPTION
## Summary
- Mostrar spinner enquanto dados dos orçamentos carregam
- Exibir modais de orçamento somente após carregamento completo

## Testing
- `npm test` (fails: Cannot find module '/workspace/App-Gestao/backend')

------
https://chatgpt.com/codex/tasks/task_e_68a724807cf88322a1efa04cbef2b9b7