### PR TITLE
Preencher Prazo Do PDF Com Informação Da Tabela Orcamento

### DIFF
--- a/src/pdf/script.js
+++ b/src/pdf/script.js
@@ -107,6 +107,7 @@ async function buildDocument() {
           <p><strong>Situação do Orçamento:</strong> ${orc.situacao}</p>
           <p><strong>Quantidade de Parcelas:</strong> ${orc.parcelas}</p>
           <p><strong>Forma de Pagamento:</strong> ${orc.forma_pagamento || ''}</p>
+          <p><strong>Prazo:</strong> ${orc.prazo || ''}</p>
         </div>
         <div class="text-right">
           <p><strong>Nome Fantasia:</strong> ${cliente.nome_fantasia || ''}</p>


### PR DESCRIPTION
## Summary
- add prazo field to PDF header rendering from database

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a725e7b5208322b62adfa4b9448233