### PR TITLE
Usar coluna prazo ao visualizar e editar orçamentos

### DIFF
--- a/src/js/modals/orcamento-editar.js
+++ b/src/js/modals/orcamento-editar.js
@@ -252,14 +252,17 @@
       });
     });
   }
+  const prazos = (data.prazo || '').split('/').map(p => parseInt(p, 10)).filter(n => !isNaN(n));
   const prefillParcelas = data.parcelas > 1 ? {
     count: data.parcelas,
     mode: data.tipo_parcela === 'igual' ? 'equal' : 'custom',
-    items: (data.parcelas_detalhes || []).map(p => ({
+    items: (data.parcelas_detalhes || []).map((p, i) => ({
       amount: Math.round((Number(p.valor) || 0) * 100),
-      dueInDays: (data.data_emissao && p.data_vencimento)
-        ? Math.round((new Date(p.data_vencimento) - new Date(data.data_emissao)) / 86400000)
-        : null
+      dueInDays: prazos[i] ?? (
+        data.data_emissao && p.data_vencimento
+          ? Math.round((new Date(p.data_vencimento) - new Date(data.data_emissao)) / 86400000)
+          : null
+      )
     }))
   } : null;
   editarCondicao.value = data.parcelas > 1 ? 'prazo' : 'vista';
@@ -268,11 +271,12 @@
   if (editarCondicao.value === 'vista') {
     const prazoInput = document.getElementById('editarPrazoVista');
     if (prazoInput) {
-      if (data.parcelas_detalhes && data.parcelas_detalhes[0] && data.data_emissao) {
-        prazoInput.value = Math.round((new Date(data.parcelas_detalhes[0].data_vencimento) - new Date(data.data_emissao)) / 86400000);
-      } else {
-        prazoInput.value = data.prazo || '';
-      }
+      prazoInput.value =
+        prazos[0] ?? (
+          data.parcelas_detalhes && data.parcelas_detalhes[0] && data.data_emissao
+            ? Math.round((new Date(data.parcelas_detalhes[0].data_vencimento) - new Date(data.data_emissao)) / 86400000)
+            : ''
+        );
       prazoInput.setAttribute('data-filled', prazoInput.value ? 'true' : 'false');
     }
   }

--- a/src/js/modals/orcamento-visualizar.js
+++ b/src/js/modals/orcamento-visualizar.js
@@ -126,8 +126,12 @@
       const pgBox = document.getElementById('visualizarPagamento');
       pgBox.classList.remove('hidden');
       const dataEmissao = new Date(data.data_emissao);
-      const rows = data.parcelas_detalhes.map(p => {
-        const prazo = Math.ceil((new Date(p.data_vencimento) - dataEmissao) / 86400000);
+      const prazos = (data.prazo || '').split('/').map(p => p.trim()).filter(Boolean);
+      const rows = data.parcelas_detalhes.map((p, i) => {
+        const prazo =
+          prazos[i] !== undefined
+            ? prazos[i]
+            : Math.ceil((new Date(p.data_vencimento) - dataEmissao) / 86400000);
         return `<tr class="border-b border-white/10"><td class="px-6 py-4 text-left text-sm text-white">${p.numero_parcela}ª</td><td class="px-6 py-4 text-left text-sm text-white">${fmt(p.valor)}</td><td class="px-6 py-4 text-left text-sm text-white">${prazo} dias</td></tr>`;
       }).join('');
       pgBox.innerHTML = `


### PR DESCRIPTION
## Summary
- utilizar coluna `prazo` para calcular prazos de parcelas na visualização
- pré-preencher edição de orçamento com prazos vindos da coluna `prazo`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a726b94dc08322950e4c1523f37b8d