### PR TITLE
Improve raw material module load animation

### DIFF
--- a/src/js/materia-prima.js
+++ b/src/js/materia-prima.js
@@ -38,7 +38,7 @@ function initMateriaPrima() {
         popover.addEventListener('mouseleave', ocultar);
     }
 
-    carregarMateriais();
+    requestAnimationFrame(() => requestAnimationFrame(carregarMateriais));
 }
 
 async function carregarMateriais() {


### PR DESCRIPTION
## Summary
- Use double `requestAnimationFrame` to defer raw material loading for smoother page animation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a728b7cf2c8322ade959ffab72d971