### PR TITLE
Centraliza título no modal de edição de produto

### DIFF
--- a/src/html/modals/produtos/editar.html
+++ b/src/html/modals/produtos/editar.html
@@ -1,8 +1,8 @@
 <div id="editarProdutoOverlay" class="fixed inset-0 bg-black/50 flex items-center justify-center p-4">
   <div role="dialog" aria-modal="true" tabindex="0" class="w-full max-w-7xl max-h-[90vh] glass-surface backdrop-blur-xl rounded-3xl border border-white/10 ring-1 ring-white/5 shadow-2xl/40 animate-modalFade slide-in overflow-hidden flex flex-col">
-    <header class="flex items-center justify-between px-8 py-5 border-b border-white/10 flex-shrink-0">
+    <header class="flex flex-wrap items-center justify-between gap-4 px-8 py-5 border-b border-white/10 flex-shrink-0">
       <button id="voltarEditarProduto" class="btn-neutral px-4 py-2 rounded-lg text-white font-medium flex items-center gap-2">← Voltar</button>
-      <h2 class="text-lg font-semibold text-white">EDITAR PRODUTO</h2>
+      <h2 class="text-lg font-semibold text-white flex-1 text-center">EDITAR PRODUTO</h2>
       <div class="flex items-center gap-3">
         <button id="salvarEditarProduto" class="btn-success px-4 py-2 rounded-lg text-white font-medium flex items-center gap-2">Salvar</button>
           <button id="clonarProduto" class="btn-secondary px-4 py-2 rounded-lg text-white font-medium">Clonar</button>


### PR DESCRIPTION
## Summary
- Centraliza o título do modal Editar Produto de forma consistente com o preço de venda

## Testing
- `npm test` (falhou: Cannot find module '/workspace/App-Gestao/backend')

------
https://chatgpt.com/codex/tasks/task_e_68a7298756d88322b8dd0863f07f2e9e