### PR TITLE
Add spinner effect to product and material modals

### DIFF
--- a/src/js/materia-prima.js
+++ b/src/js/materia-prima.js
@@ -326,13 +326,40 @@ function renderMateriais(listaMateriais) {
     attachRawMaterialInfoEvents();
 }
 
+function openModalWithSpinner(htmlPath, scriptPath, overlayId) {
+    Modal.closeAll();
+    const spinner = document.createElement('div');
+    spinner.id = 'modalLoading';
+    spinner.className = 'fixed inset-0 z-[2000] bg-black/50 flex items-center justify-center';
+    spinner.innerHTML = '<div class="w-16 h-16 border-4 border-[#b6a03e] border-t-transparent rounded-full animate-spin"></div>';
+    document.body.appendChild(spinner);
+    const start = Date.now();
+    function handleLoaded(e) {
+        if (e.detail !== overlayId) return;
+        const overlay = document.getElementById(`${overlayId}Overlay`);
+        const elapsed = Date.now() - start;
+        const show = () => {
+            spinner.remove();
+            overlay.classList.remove('hidden');
+        };
+        if (elapsed < 3000) {
+            setTimeout(show, Math.max(0, 2000 - elapsed));
+        } else {
+            show();
+        }
+        window.removeEventListener('modalSpinnerLoaded', handleLoaded);
+    }
+    window.addEventListener('modalSpinnerLoaded', handleLoaded);
+    Modal.open(htmlPath, scriptPath, overlayId, true);
+}
+
 function abrirNovoInsumo() {
     Modal.open('modals/materia-prima/novo.html', '../js/modals/materia-prima-novo.js', 'novoInsumo');
 }
 
 function abrirEditarInsumo(item) {
     window.materiaSelecionada = item;
-    Modal.open('modals/materia-prima/editar.html', '../js/modals/materia-prima-editar.js', 'editarInsumo');
+    openModalWithSpinner('modals/materia-prima/editar.html', '../js/modals/materia-prima-editar.js', 'editarInsumo');
 }
 
 function abrirExcluirInsumo(item) {

--- a/src/js/modals/materia-prima-editar.js
+++ b/src/js/modals/materia-prima-editar.js
@@ -83,7 +83,9 @@
   };
 
   infinitoCheckbox.addEventListener('change', toggleInfinito);
-  carregarOpcoes();
+  carregarOpcoes().finally(() => {
+    window.dispatchEvent(new CustomEvent('modalSpinnerLoaded', { detail: 'editarInsumo' }));
+  });
   toggleInfinito();
 
   document.getElementById('abrirExcluirInsumo').addEventListener('click', () => {

--- a/src/js/modals/produto-detalhes.js
+++ b/src/js/modals/produto-detalhes.js
@@ -18,8 +18,12 @@
     if(titulo) titulo.textContent = `DETALHE DE ESTOQUE – ${item.nome || ''}`;
     const codigoEl = document.getElementById('codigoPeca');
     if(codigoEl) codigoEl.textContent = `Código da Peça: ${item.codigo || ''}`; // subtítulo mostra código da peça
-    carregarDetalhes(item.codigo, item.id);
+    carregarDetalhes(item.codigo, item.id).finally(() => {
+      window.dispatchEvent(new CustomEvent('modalSpinnerLoaded', { detail: 'detalhesProduto' }));
+    });
     window.reloadDetalhesProduto = () => carregarDetalhes(item.codigo, item.id);
+  } else {
+    window.dispatchEvent(new CustomEvent('modalSpinnerLoaded', { detail: 'detalhesProduto' }));
   }
 
   async function carregarDetalhes(codigo, id){

--- a/src/js/modals/produto-editar.js
+++ b/src/js/modals/produto-editar.js
@@ -638,6 +638,8 @@
         if (tableBody) {
           tableBody.innerHTML = `<tr><td colspan="6" class="py-4 text-center text-red-400">${msg}</td></tr>`;
         }
+      } finally {
+        window.dispatchEvent(new CustomEvent('modalSpinnerLoaded', { detail: 'editarProduto' }));
       }
     })();
   }

--- a/src/js/produtos.js
+++ b/src/js/produtos.js
@@ -382,6 +382,33 @@ function ajustarBotoes() {
     });
 }
 
+function openModalWithSpinner(htmlPath, scriptPath, overlayId) {
+    Modal.closeAll();
+    const spinner = document.createElement('div');
+    spinner.id = 'modalLoading';
+    spinner.className = 'fixed inset-0 z-[2000] bg-black/50 flex items-center justify-center';
+    spinner.innerHTML = '<div class="w-16 h-16 border-4 border-[#b6a03e] border-t-transparent rounded-full animate-spin"></div>';
+    document.body.appendChild(spinner);
+    const start = Date.now();
+    function handleLoaded(e) {
+        if (e.detail !== overlayId) return;
+        const overlay = document.getElementById(`${overlayId}Overlay`);
+        const elapsed = Date.now() - start;
+        const show = () => {
+            spinner.remove();
+            overlay.classList.remove('hidden');
+        };
+        if (elapsed < 3000) {
+            setTimeout(show, Math.max(0, 2000 - elapsed));
+        } else {
+            show();
+        }
+        window.removeEventListener('modalSpinnerLoaded', handleLoaded);
+    }
+    window.addEventListener('modalSpinnerLoaded', handleLoaded);
+    Modal.open(htmlPath, scriptPath, overlayId, true);
+}
+
 function abrirNovoProduto() {
     Modal.open('modals/produtos/novo.html', '../js/modals/produto-novo.js', 'novoProduto');
 }
@@ -392,7 +419,7 @@ function abrirEditarProduto(prod) {
         return;
     }
     window.produtoSelecionado = prod;
-    Modal.open('modals/produtos/editar.html', '../js/modals/produto-editar.js', 'editarProduto');
+    openModalWithSpinner('modals/produtos/editar.html', '../js/modals/produto-editar.js', 'editarProduto');
 }
 
 function abrirExcluirProduto(prod) {
@@ -402,7 +429,7 @@ function abrirExcluirProduto(prod) {
 
 function abrirDetalhesProduto(prod) {
     window.produtoDetalhes = prod;
-    Modal.open('modals/produtos/detalhes.html', '../js/modals/produto-detalhes.js', 'detalhesProduto');
+    openModalWithSpinner('modals/produtos/detalhes.html', '../js/modals/produto-detalhes.js', 'detalhesProduto');
 }
 
 if (document.readyState === 'loading') {


### PR DESCRIPTION
## Summary
- show loading spinner when opening product detail or edit modals
- show loading spinner when opening raw material edit modal
- remove spinner after modal initialization using custom event

## Testing
- `npm test` *(fails: Cannot find module '/workspace/App-Gestao/backend')*


------
https://chatgpt.com/codex/tasks/task_e_68a729e1769c8322b71b566741c36ed8