### PR TITLE
Corrige abertura de orçamentos clonados

### DIFF
--- a/src/js/modals/orcamento-editar.js
+++ b/src/js/modals/orcamento-editar.js
@@ -708,7 +708,13 @@
       close();
       window.selectedQuoteId = clone.id;
       showToast(`ORÇAMENTO ${clone.numero} CLONADO, SALVO E ABERTO PARA EDIÇÃO`, 'info');
-      Modal.open('modals/orcamentos/editar.html', '../js/modals/orcamento-editar.js', 'editarOrcamento');
+      if (typeof openQuoteModal === 'function') {
+        openQuoteModal('modals/orcamentos/editar.html', '../js/modals/orcamento-editar.js', 'editarOrcamento');
+      } else {
+        Modal.open('modals/orcamentos/editar.html', '../js/modals/orcamento-editar.js', 'editarOrcamento');
+        const overlay = document.getElementById('editarOrcamentoOverlay');
+        overlay?.classList.remove('hidden');
+      }
     } catch (err) {
       console.error(err);
       showToast('Erro ao clonar orçamento', 'error');

--- a/src/js/modals/orcamento-visualizar.js
+++ b/src/js/modals/orcamento-visualizar.js
@@ -163,7 +163,13 @@
       close();
       window.selectedQuoteId = clone.id;
       showToast(`ORÇAMENTO ${clone.numero} CLONADO, SALVO E ABERTO PARA EDIÇÃO`, 'info');
-      Modal.open('modals/orcamentos/editar.html', '../js/modals/orcamento-editar.js', 'editarOrcamento');
+      if (typeof openQuoteModal === 'function') {
+        openQuoteModal('modals/orcamentos/editar.html', '../js/modals/orcamento-editar.js', 'editarOrcamento');
+      } else {
+        Modal.open('modals/orcamentos/editar.html', '../js/modals/orcamento-editar.js', 'editarOrcamento');
+        const overlay = document.getElementById('editarOrcamentoOverlay');
+        overlay?.classList.remove('hidden');
+      }
     } catch (err) {
       console.error(err);
       showToast('Erro ao clonar orçamento', 'error');


### PR DESCRIPTION
## Summary
- ensure cloned budgets reopen using the same spinner workflow

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7301e237883229f4272ae5e3264ce