### PR TITLE
Add spinner effect to product and material modals

### DIFF
--- a/src/html/modals/materia-prima/editar.html
+++ b/src/html/modals/materia-prima/editar.html
@@ -1,5 +1,5 @@
 <!-- Overlay / Modal: Editar Insumo -->
-<div id="editarInsumoOverlay" class="fixed inset-0 bg-black/50 flex items-center justify-center p-6">
+<div id="editarInsumoOverlay" class="hidden fixed inset-0 bg-black/50 flex items-center justify-center p-6">
   <div class="w-full max-w-2xl glass-surface backdrop-blur-xl rounded-3xl border border-white/10 ring-1 ring-white/5 shadow-2xl/40 animate-modalFade slide-in overflow-y-auto">
     <!-- Header -->
     <header class="relative px-8 py-5 border-b border-white/10">

--- a/src/html/modals/produtos/detalhes.html
+++ b/src/html/modals/produtos/detalhes.html
@@ -1,4 +1,4 @@
-<div id="detalhesProdutoOverlay" class="fixed inset-0 bg-black/50 flex items-center justify-center p-4">
+<div id="detalhesProdutoOverlay" class="hidden fixed inset-0 bg-black/50 flex items-center justify-center p-4">
   <div class="w-full max-w-6xl max-h-[90vh] glass-surface backdrop-blur-xl rounded-3xl border border-white/10 ring-1 ring-white/5 shadow-2xl/40 animate-modalFade slide-in overflow-hidden flex flex-col">
     <header class="px-8 py-5 border-b border-white/10 flex-shrink-0">
       <div class="flex items-center justify-between mb-3">

--- a/src/html/modals/produtos/editar.html
+++ b/src/html/modals/produtos/editar.html
@@ -1,4 +1,4 @@
-<div id="editarProdutoOverlay" class="fixed inset-0 bg-black/50 flex items-center justify-center p-4">
+<div id="editarProdutoOverlay" class="hidden fixed inset-0 bg-black/50 flex items-center justify-center p-4">
   <div role="dialog" aria-modal="true" tabindex="0" class="w-full max-w-7xl max-h-[90vh] glass-surface backdrop-blur-xl rounded-3xl border border-white/10 ring-1 ring-white/5 shadow-2xl/40 animate-modalFade slide-in overflow-hidden flex flex-col">
     <header class="flex items-center justify-between px-8 py-5 border-b border-white/10 flex-shrink-0">
       <button id="voltarEditarProduto" class="btn-neutral px-4 py-2 rounded-lg text-white font-medium flex items-center gap-2">← Voltar</button>

--- a/src/js/materia-prima.js
+++ b/src/js/materia-prima.js
@@ -326,13 +326,40 @@ function renderMateriais(listaMateriais) {
     attachRawMaterialInfoEvents();
 }
 
+function openModalWithSpinner(htmlPath, scriptPath, overlayId) {
+    Modal.closeAll();
+    const spinner = document.createElement('div');
+    spinner.id = 'modalLoading';
+    spinner.className = 'fixed inset-0 z-[2000] bg-black/50 flex items-center justify-center';
+    spinner.innerHTML = '<div class="w-16 h-16 border-4 border-[#b6a03e] border-t-transparent rounded-full animate-spin"></div>';
+    document.body.appendChild(spinner);
+    const start = Date.now();
+    function handleLoaded(e) {
+        if (e.detail !== overlayId) return;
+        const overlay = document.getElementById(`${overlayId}Overlay`);
+        const elapsed = Date.now() - start;
+        const show = () => {
+            spinner.remove();
+            overlay.classList.remove('hidden');
+        };
+        if (elapsed < 3000) {
+            setTimeout(show, Math.max(0, 2000 - elapsed));
+        } else {
+            show();
+        }
+        window.removeEventListener('modalSpinnerLoaded', handleLoaded);
+    }
+    window.addEventListener('modalSpinnerLoaded', handleLoaded);
+    Modal.open(htmlPath, scriptPath, overlayId, true);
+}
+
 function abrirNovoInsumo() {
     Modal.open('modals/materia-prima/novo.html', '../js/modals/materia-prima-novo.js', 'novoInsumo');
 }
 
 function abrirEditarInsumo(item) {
     window.materiaSelecionada = item;
-    Modal.open('modals/materia-prima/editar.html', '../js/modals/materia-prima-editar.js', 'editarInsumo');
+    openModalWithSpinner('modals/materia-prima/editar.html', '../js/modals/materia-prima-editar.js', 'editarInsumo');
 }
 
 function abrirExcluirInsumo(item) {

--- a/src/js/modals/materia-prima-editar.js
+++ b/src/js/modals/materia-prima-editar.js
@@ -83,7 +83,9 @@
   };
 
   infinitoCheckbox.addEventListener('change', toggleInfinito);
-  carregarOpcoes();
+  carregarOpcoes().finally(() => {
+    window.dispatchEvent(new CustomEvent('modalSpinnerLoaded', { detail: 'editarInsumo' }));
+  });
   toggleInfinito();
 
   document.getElementById('abrirExcluirInsumo').addEventListener('click', () => {

--- a/src/js/modals/produto-detalhes.js
+++ b/src/js/modals/produto-detalhes.js
@@ -18,8 +18,12 @@
     if(titulo) titulo.textContent = `DETALHE DE ESTOQUE – ${item.nome || ''}`;
     const codigoEl = document.getElementById('codigoPeca');
     if(codigoEl) codigoEl.textContent = `Código da Peça: ${item.codigo || ''}`; // subtítulo mostra código da peça
-    carregarDetalhes(item.codigo, item.id);
+    carregarDetalhes(item.codigo, item.id).finally(() => {
+      window.dispatchEvent(new CustomEvent('modalSpinnerLoaded', { detail: 'detalhesProduto' }));
+    });
     window.reloadDetalhesProduto = () => carregarDetalhes(item.codigo, item.id);
+  } else {
+    window.dispatchEvent(new CustomEvent('modalSpinnerLoaded', { detail: 'detalhesProduto' }));
   }
 
   async function carregarDetalhes(codigo, id){

--- a/src/js/modals/produto-editar.js
+++ b/src/js/modals/produto-editar.js
@@ -638,6 +638,8 @@
         if (tableBody) {
           tableBody.innerHTML = `<tr><td colspan="6" class="py-4 text-center text-red-400">${msg}</td></tr>`;
         }
+      } finally {
+        window.dispatchEvent(new CustomEvent('modalSpinnerLoaded', { detail: 'editarProduto' }));
       }
     })();
   }

--- a/src/js/produtos.js
+++ b/src/js/produtos.js
@@ -382,6 +382,33 @@ function ajustarBotoes() {
     });
 }
 
+function openModalWithSpinner(htmlPath, scriptPath, overlayId) {
+    Modal.closeAll();
+    const spinner = document.createElement('div');
+    spinner.id = 'modalLoading';
+    spinner.className = 'fixed inset-0 z-[2000] bg-black/50 flex items-center justify-center';
+    spinner.innerHTML = '<div class="w-16 h-16 border-4 border-[#b6a03e] border-t-transparent rounded-full animate-spin"></div>';
+    document.body.appendChild(spinner);
+    const start = Date.now();
+    function handleLoaded(e) {
+        if (e.detail !== overlayId) return;
+        const overlay = document.getElementById(`${overlayId}Overlay`);
+        const elapsed = Date.now() - start;
+        const show = () => {
+            spinner.remove();
+            overlay.classList.remove('hidden');
+        };
+        if (elapsed < 3000) {
+            setTimeout(show, Math.max(0, 2000 - elapsed));
+        } else {
+            show();
+        }
+        window.removeEventListener('modalSpinnerLoaded', handleLoaded);
+    }
+    window.addEventListener('modalSpinnerLoaded', handleLoaded);
+    Modal.open(htmlPath, scriptPath, overlayId, true);
+}
+
 function abrirNovoProduto() {
     Modal.open('modals/produtos/novo.html', '../js/modals/produto-novo.js', 'novoProduto');
 }
@@ -392,7 +419,7 @@ function abrirEditarProduto(prod) {
         return;
     }
     window.produtoSelecionado = prod;
-    Modal.open('modals/produtos/editar.html', '../js/modals/produto-editar.js', 'editarProduto');
+    openModalWithSpinner('modals/produtos/editar.html', '../js/modals/produto-editar.js', 'editarProduto');
 }
 
 function abrirExcluirProduto(prod) {
@@ -402,7 +429,7 @@ function abrirExcluirProduto(prod) {
 
 function abrirDetalhesProduto(prod) {
     window.produtoDetalhes = prod;
-    Modal.open('modals/produtos/detalhes.html', '../js/modals/produto-detalhes.js', 'detalhesProduto');
+    openModalWithSpinner('modals/produtos/detalhes.html', '../js/modals/produto-detalhes.js', 'detalhesProduto');
 }
 
 if (document.readyState === 'loading') {


### PR DESCRIPTION
## Summary
- hide product edit and stock detail overlays until spinner finishes loading
- hide raw material edit overlay until spinner completes initialization

## Testing
- `npm test` *(fails: Cannot find module '/workspace/App-Gestao/backend')*


------
https://chatgpt.com/codex/tasks/task_e_68a729e1769c8322b71b566741c36ed8