### PR TITLE
Show Spinner And Success Toast When Cloning Budget

### DIFF
--- a/src/js/modals/orcamento-editar.js
+++ b/src/js/modals/orcamento-editar.js
@@ -700,6 +700,11 @@
   document.getElementById('cancelarOrcamento').addEventListener('click', close);
   document.getElementById('voltarEditarOrcamento').addEventListener('click', close);
   document.getElementById('clonarOrcamento').addEventListener('click', async () => {
+    const spinner = document.createElement('div');
+    spinner.id = 'modalLoading';
+    spinner.className = 'fixed inset-0 z-[2000] bg-black/50 flex items-center justify-center';
+    spinner.innerHTML = '<div class="w-16 h-16 border-4 border-[#b6a03e] border-t-transparent rounded-full animate-spin"></div>';
+    document.body.appendChild(spinner);
     try {
       const resp = await fetch(`http://localhost:3000/api/orcamentos/${id}/clone`, { method: 'POST' });
       if (!resp.ok) throw new Error('Erro');
@@ -707,15 +712,18 @@
       if (window.reloadOrcamentos) await window.reloadOrcamentos();
       close();
       window.selectedQuoteId = clone.id;
-      showToast(`ORÇAMENTO ${clone.numero} CLONADO, SALVO E ABERTO PARA EDIÇÃO`, 'info');
-      if (typeof openQuoteModal === 'function') {
-        openQuoteModal('modals/orcamentos/editar.html', '../js/modals/orcamento-editar.js', 'editarOrcamento');
-      } else {
-        Modal.open('modals/orcamentos/editar.html', '../js/modals/orcamento-editar.js', 'editarOrcamento');
+      function handleLoaded(e) {
+        if (e.detail !== 'editarOrcamento') return;
+        spinner.remove();
         const overlay = document.getElementById('editarOrcamentoOverlay');
         overlay?.classList.remove('hidden');
+        showToast(`ORÇAMENTO ${clone.numero} CLONADO, SALVO E ABERTO PARA EDIÇÃO`, 'info');
+        window.removeEventListener('orcamentoModalLoaded', handleLoaded);
       }
+      window.addEventListener('orcamentoModalLoaded', handleLoaded);
+      Modal.open('modals/orcamentos/editar.html', '../js/modals/orcamento-editar.js', 'editarOrcamento');
     } catch (err) {
+      spinner.remove();
       console.error(err);
       showToast('Erro ao clonar orçamento', 'error');
     }

--- a/src/js/modals/orcamento-visualizar.js
+++ b/src/js/modals/orcamento-visualizar.js
@@ -155,6 +155,11 @@
   }
 
   overlay.querySelector('#clonarVisualizarOrcamento').addEventListener('click', async () => {
+    const spinner = document.createElement('div');
+    spinner.id = 'modalLoading';
+    spinner.className = 'fixed inset-0 z-[2000] bg-black/50 flex items-center justify-center';
+    spinner.innerHTML = '<div class="w-16 h-16 border-4 border-[#b6a03e] border-t-transparent rounded-full animate-spin"></div>';
+    document.body.appendChild(spinner);
     try {
       const resp = await fetch(`http://localhost:3000/api/orcamentos/${id}/clone`, { method: 'POST' });
       if (!resp.ok) throw new Error('Erro');
@@ -162,15 +167,18 @@
       if (window.reloadOrcamentos) await window.reloadOrcamentos();
       close();
       window.selectedQuoteId = clone.id;
-      showToast(`ORÇAMENTO ${clone.numero} CLONADO, SALVO E ABERTO PARA EDIÇÃO`, 'info');
-      if (typeof openQuoteModal === 'function') {
-        openQuoteModal('modals/orcamentos/editar.html', '../js/modals/orcamento-editar.js', 'editarOrcamento');
-      } else {
-        Modal.open('modals/orcamentos/editar.html', '../js/modals/orcamento-editar.js', 'editarOrcamento');
+      function handleLoaded(e) {
+        if (e.detail !== 'editarOrcamento') return;
+        spinner.remove();
         const overlay = document.getElementById('editarOrcamentoOverlay');
         overlay?.classList.remove('hidden');
+        showToast(`ORÇAMENTO ${clone.numero} CLONADO, SALVO E ABERTO PARA EDIÇÃO`, 'info');
+        window.removeEventListener('orcamentoModalLoaded', handleLoaded);
       }
+      window.addEventListener('orcamentoModalLoaded', handleLoaded);
+      Modal.open('modals/orcamentos/editar.html', '../js/modals/orcamento-editar.js', 'editarOrcamento');
     } catch (err) {
+      spinner.remove();
       console.error(err);
       showToast('Erro ao clonar orçamento', 'error');
     }


### PR DESCRIPTION
## Summary
- show loading spinner during budget clone
- display cloned budget modal then success toast after load

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a735c6b2408322854a429315295557