### PR TITLE
Aplicar lógica de carregamento oculto no modal de edição de produto

### DIFF
--- a/src/html/modals/produtos/editar.html
+++ b/src/html/modals/produtos/editar.html
@@ -1,4 +1,4 @@
-<div id="editarProdutoOverlay" class="fixed inset-0 bg-black/50 flex items-center justify-center p-4 pt-[4vw]">
+<div id="editarProdutoOverlay" class="hidden fixed inset-0 bg-black/50 flex items-center justify-center p-4 pt-[4vw]">
   <div role="dialog" aria-modal="true" tabindex="0" class="w-full max-w-7xl max-h-[90vh] glass-surface backdrop-blur-xl rounded-3xl border border-white/10 ring-1 ring-white/5 shadow-2xl/40 animate-modalFade slide-in overflow-hidden flex flex-col">
     <header class="flex flex-wrap items-center justify-between gap-4 px-8 py-5 border-b border-white/10 flex-shrink-0">
       <div class="flex-1">


### PR DESCRIPTION
## Summary
- Oculta o modal de edição de produto até que todos os dados sejam carregados e o spinner seja removido

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a73a42d880832280b31f3a53b8fe65