### PR TITLE
Limit table height to avoid page scroll

### DIFF
--- a/src/css/materia-prima.css
+++ b/src/css/materia-prima.css
@@ -386,3 +386,9 @@ body {
     margin-left: -4.5vw; /* Evita sobreposição do toggle com a barra lateral */
     flex-shrink: 1; /* Permite que o toggle encolha se necessário */
 }
+/* Limit table height to avoid page scroll */
+.table-scroll {
+    max-height: calc(var(--module-height) - 260px) !important;
+    overflow-y: auto;
+    overflow-x: hidden;
+}


### PR DESCRIPTION
## Summary
- add `.table-scroll` CSS class in Matéria-Prima styles to limit table height and enable scrolling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a74c2083288322b2203a672359f8f5