### PR TITLE
Impedir Exclusão de Produto com Orçamento Associado

### DIFF
--- a/backend/excluirProduto.test.js
+++ b/backend/excluirProduto.test.js
@@ -16,7 +16,7 @@ function setup() {
     id serial primary key,
     produto_id int
   );`);
-  db.public.none(`CREATE TABLE orcamento (
+  db.public.none(`CREATE TABLE orcamentos_itens (
     id serial primary key,
     produto_id int
   );`);
@@ -52,7 +52,7 @@ test('excluirProduto remove dependências', async () => {
 
 test('excluirProduto bloqueia se estiver em orçamento', async () => {
   const { excluirProduto, pool } = setup();
-  await pool.query('INSERT INTO orcamento (produto_id) VALUES (1);');
+  await pool.query('INSERT INTO orcamentos_itens (produto_id) VALUES (1);');
   await assert.rejects(() => excluirProduto(1), /orçamento/i);
 });
 

--- a/backend/produtos.js
+++ b/backend/produtos.js
@@ -329,7 +329,7 @@ async function excluirProduto(id) {
     }
 
     const { rowCount: orcamentoCount } = await client.query(
-      'SELECT 1 FROM orcamento WHERE produto_id=$1::int LIMIT 1',
+      'SELECT 1 FROM orcamentos_itens WHERE produto_id=$1::int LIMIT 1',
       [id]
     );
     if (orcamentoCount > 0) {

--- a/src/js/modals/produto-excluir.js
+++ b/src/js/modals/produto-excluir.js
@@ -1,6 +1,13 @@
 (function(){
   const overlay = document.getElementById('excluirProdutoOverlay');
   const close = () => Modal.close('excluirProduto');
+  function showErrorDialog(message){
+    const ov=document.createElement('div');
+    ov.className='fixed inset-0 z-[2000] bg-black/50 flex items-center justify-center p-4';
+    ov.innerHTML=`<div class="max-w-sm w-full glass-surface backdrop-blur-xl rounded-2xl border border-yellow-500/20 ring-1 ring-yellow-500/30 shadow-2xl/40 animate-modalFade"><div class="p-6 text-center"><h3 class="text-lg font-semibold mb-4 text-yellow-400">Atenção</h3><p class="text-sm text-gray-300 mb-6">${message}</p><div class="flex justify-center"><button id="errOk" class="btn-warning px-6 py-2 rounded-lg text-white font-medium active:scale-95">OK</button></div></div></div>`;
+    document.body.appendChild(ov);
+    ov.querySelector('#errOk').addEventListener('click',()=>ov.remove());
+  }
   overlay.addEventListener('click', e => { if (e.target === overlay) close(); });
   document.getElementById('cancelarExcluirProduto').addEventListener('click', close);
   document.addEventListener('keydown', function esc(e){ if(e.key==='Escape'){ close(); document.removeEventListener('keydown', esc); } });
@@ -14,7 +21,8 @@
       carregarProdutos();
     }catch(err){
       console.error(err);
-      showToast(err.message || 'Erro ao excluir produto', 'error');
+      close();
+      showErrorDialog(err.message || 'Erro ao excluir produto');
     }
   });
 })();


### PR DESCRIPTION
## Summary
- impede remoção de produto associado a orçamento
- adiciona aviso de erro ao tentar excluir produto vinculado a orçamento

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a75b450bf48322862723436b3e07af