### PR TITLE
Show Sale Price Tag In Product Modals

### DIFF
--- a/src/html/modals/produtos/editar.html
+++ b/src/html/modals/produtos/editar.html
@@ -1,8 +1,9 @@
 <div id="editarProdutoOverlay" class="hidden fixed inset-0 bg-black/50 flex items-center justify-center p-4 pt-[4vw]">
   <div role="dialog" aria-modal="true" tabindex="0" class="w-full max-w-7xl max-h-[90vh] glass-surface backdrop-blur-xl rounded-3xl border border-white/10 ring-1 ring-white/5 shadow-2xl/40 animate-modalFade slide-in overflow-hidden flex flex-col">
     <header class="flex flex-wrap items-center justify-between gap-4 px-8 py-5 border-b border-white/10 flex-shrink-0">
-      <div class="flex-1">
+      <div class="flex-1 flex items-center gap-4">
         <button id="voltarEditarProduto" class="btn-neutral px-4 py-2 rounded-lg text-white font-medium flex items-center gap-2">← Voltar</button>
+        <span id="precoVendaTag" class="bg-green-500 text-white px-4 py-2 rounded-lg text-lg font-bold">R$ 0,00</span>
       </div>
       <h2 class="text-lg font-semibold text-white flex-1 text-center" id="tituloeditar">EDITAR PRODUTO</h2>
       <div class="flex-1 flex items-center justify-end gap-3">

--- a/src/html/modals/produtos/novo.html
+++ b/src/html/modals/produtos/novo.html
@@ -1,10 +1,11 @@
 <div id="novoProdutoOverlay" class="fixed inset-0 bg-black/50 flex items-center justify-center p-4 pt-[4vw]">
   <div role="dialog" aria-modal="true" tabindex="0" class="w-full max-w-7xl max-h-[90vh] bg-surface/60 backdrop-blur-xl rounded-3xl border border-white/10 ring-1 ring-white/5 shadow-2xl/40 animate-modalFade slide-in overflow-hidden flex flex-col">
     <header class="flex flex-wrap items-center justify-between gap-4 px-8 py-5 border-b border-white/10 flex-shrink-0">
-      <div class="flex-1">
+      <div class="flex-1 flex items-center gap-4">
         <button id="voltarNovoProduto" class="btn-neutral px-4 py-2 rounded-lg text-white font-medium flex items-center gap-2">
           ← Voltar
         </button>
+        <span id="precoVendaTag" class="bg-green-500 text-white px-4 py-2 rounded-lg text-lg font-bold">R$ 0,00</span>
       </div>
       <h2 class="text-lg font-semibold text-white flex-1 text-center">INSERIR NOVO PRODUTO</h2>
       <div class="flex-1 flex items-center justify-end gap-3">

--- a/src/js/modals/produto-editar.js
+++ b/src/js/modals/produto-editar.js
@@ -76,6 +76,7 @@
     const updateRadios = Array.from(document.querySelectorAll('input[name="updateOption"]'));
     const statusRadios = Array.from(document.querySelectorAll('input[name="statusOption"]'));
     const precoVendaEl = document.getElementById('precoVenda');
+    const precoVendaTagEl = document.getElementById('precoVendaTag');
     const ultimaDataEl = document.getElementById('ultimaModificacaoData');
     const ultimaHoraEl = document.getElementById('ultimaModificacaoHora');
 
@@ -278,6 +279,7 @@
       if (impostoValorEl)        impostoValorEl.textContent       = formatCurrency(impostoVal);
       if (valorVendaEl)          valorVendaEl.textContent         = formatCurrency(valorVenda);
       if (precoVendaEl)          precoVendaEl.textContent         = formatCurrency(valorVenda);
+      if (precoVendaTagEl)       precoVendaTagEl.textContent      = formatCurrency(valorVenda);
       renderTotalBadges();
     }
 
@@ -636,6 +638,7 @@
             const pv = dados.preco_venda;
             const frac = Number.isInteger(pv) ? 0 : 2;
             precoVendaEl.textContent = pv.toLocaleString('pt-BR', { style:'currency', currency:'BRL', minimumFractionDigits: frac, maximumFractionDigits: frac });
+            if(precoVendaTagEl) precoVendaTagEl.textContent = pv.toLocaleString('pt-BR', { style:'currency', currency:'BRL', minimumFractionDigits: frac, maximumFractionDigits: frac });
           }
           const mod = dados.data || dados.ultima_modificacao || dados.updated_at;
           if(mod){

--- a/src/js/modals/produto-novo.js
+++ b/src/js/modals/produto-novo.js
@@ -17,11 +17,9 @@
   const embalagemInput  = document.getElementById('embalagemInput');
   const markupInput     = document.getElementById('markupInput');
   const commissionInput = document.getElementById('commissionInput');
-  const taxInput        = document.getElementById('taxInput');
-  const etapaSelect     = document.getElementById('etapaSelect');
-  const comecarBtn      = document.getElementById('comecarNovoProduto');
-
-  const precoVendaEl    = document.getElementById('precoVenda');
+    const precoVendaEl    = document.getElementById('precoVenda');
+  
+  const precoVendaTagEl = document.getElementById('precoVendaTag');
   const totalInsumosEl  = document.getElementById('totalInsumos');
   const totalMaoObraEl  = document.getElementById('totalMaoObra');
   const subTotalEl      = document.getElementById('subTotal');
@@ -68,6 +66,7 @@
     if(impostoValorEl) impostoValorEl.textContent = formatCurrency(impostoVal);
     if(precoVendaEl)   precoVendaEl.textContent   = formatCurrency(valorVenda);
     if(valorVendaEl)   valorVendaEl.textContent   = formatCurrency(valorVenda);
+    if(precoVendaTagEl) precoVendaTagEl.textContent = formatCurrency(valorVenda);
     renderTotalBadges();
   }
 


### PR DESCRIPTION
## Summary
- Display sale price as a green tag beside the back button in new and edit product modals
- Keep tag value in sync with live sale price calculations

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a76028eaa883229cb601aeefef6439