### PR TITLE
Handle Product Deletion When Present In Budgets

### DIFF
--- a/backend/produtos.js
+++ b/backend/produtos.js
@@ -333,7 +333,7 @@ async function excluirProduto(id) {
       [id]
     );
     if (orcamentoCount > 0) {
-      throw new Error('Produto existe em orçamento, não é possível realizar a ação');
+      throw new Error('Produto existe em Orçamentos, não é possível realizar a ação!');
     }
 
     await client.query(

--- a/main.js
+++ b/main.js
@@ -507,8 +507,12 @@ ipcMain.handle('atualizar-produto', async (_e, { id, dados }) => {
   return atualizarProduto(id, dados);
 });
 ipcMain.handle('excluir-produto', async (_e, id) => {
-  await excluirProduto(id);
-  return true;
+  try {
+    await excluirProduto(id);
+    return true;
+  } catch (err) {
+    return { error: err.message };
+  }
 });
 ipcMain.handle('listar-detalhes-produto', async (_e, { produtoCodigo, produtoId }) => {
   try {

--- a/preload.js
+++ b/preload.js
@@ -39,7 +39,13 @@ contextBridge.exposeInMainWorld('electronAPI', {
   obterProduto: (codigo) => ipcRenderer.invoke('obter-produto', codigo),
   adicionarProduto: (dados) => ipcRenderer.invoke('adicionar-produto', dados),
   atualizarProduto: (id, dados) => ipcRenderer.invoke('atualizar-produto', { id, dados }),
-  excluirProduto: (id) => ipcRenderer.invoke('excluir-produto', id),
+  excluirProduto: async (id) => {
+    const result = await ipcRenderer.invoke('excluir-produto', id);
+    if (result && result.error) {
+      throw new Error(result.error);
+    }
+    return result;
+  },
   listarDetalhesProduto: (params) => ipcRenderer.invoke('listar-detalhes-produto', params),
   inserirLoteProduto: (dados) => ipcRenderer.invoke('inserir-lote-produto', dados),
   atualizarLoteProduto: (dados) => ipcRenderer.invoke('atualizar-lote-produto', dados),

--- a/src/js/modals/produto-excluir.js
+++ b/src/js/modals/produto-excluir.js
@@ -20,7 +20,6 @@
       close();
       carregarProdutos();
     }catch(err){
-      console.error(err);
       close();
       showErrorDialog(err.message || 'Erro ao excluir produto');
     }


### PR DESCRIPTION
## Summary
- Prevent terminal errors when deleting products tied to budgets
- Return descriptive error without logging to console
- Update frontend to display clean message

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a761abad30832299dbc70b26fbdbc1