### PR TITLE
Não Deve Ser Possível Inserir Insumos Duplicados Em Matéria Prima

### DIFF
--- a/backend/materiaDuplicada.test.js
+++ b/backend/materiaDuplicada.test.js
@@ -1,0 +1,112 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { newDb } = require('pg-mem');
+
+function setupDb() {
+  const db = newDb();
+  db.public.none(`CREATE TABLE materia_prima (
+    id serial primary key,
+    nome text,
+    categoria text,
+    quantidade numeric,
+    unidade text,
+    preco_unitario numeric,
+    processo text,
+    infinito boolean,
+    descricao text,
+    data_preco timestamp,
+    data_estoque timestamp
+  );`);
+  return db;
+}
+
+test('adicionarMateria rejeita nomes duplicados', async () => {
+  const mem = setupDb();
+  const { Pool } = mem.adapters.createPg();
+  const pool = new Pool();
+  const dbModulePath = require.resolve('./db');
+  require.cache[dbModulePath] = {
+    exports: {
+      query: (text, params) => pool.query(text, params),
+      connect: () => pool.connect(),
+    },
+  };
+  delete require.cache[require.resolve('./materiaPrima')];
+  const { adicionarMateria } = require('./materiaPrima');
+
+  await adicionarMateria({
+    nome: 'Insumo A',
+    quantidade: 1,
+    preco_unitario: 0,
+    categoria: 'Cat',
+    unidade: 'kg',
+    infinito: false,
+    processo: 'Proc',
+    descricao: ''
+  });
+
+  await assert.rejects(
+    adicionarMateria({
+      nome: 'Insumo A',
+      quantidade: 1,
+      preco_unitario: 0,
+      categoria: 'Cat',
+      unidade: 'kg',
+      infinito: false,
+      processo: 'Proc',
+      descricao: ''
+    }),
+    /DUPLICADO/
+  );
+});
+
+test('atualizarMateria rejeita nomes duplicados', async () => {
+  const mem = setupDb();
+  const { Pool } = mem.adapters.createPg();
+  const pool = new Pool();
+  const dbModulePath = require.resolve('./db');
+  require.cache[dbModulePath] = {
+    exports: {
+      query: (text, params) => pool.query(text, params),
+      connect: () => pool.connect(),
+    },
+  };
+  delete require.cache[require.resolve('./materiaPrima')];
+  const { adicionarMateria, atualizarMateria } = require('./materiaPrima');
+
+  const ins1 = await adicionarMateria({
+    nome: 'Insumo A',
+    quantidade: 1,
+    preco_unitario: 0,
+    categoria: 'Cat',
+    unidade: 'kg',
+    infinito: false,
+    processo: 'Proc',
+    descricao: ''
+  });
+  const ins2 = await adicionarMateria({
+    nome: 'Insumo B',
+    quantidade: 1,
+    preco_unitario: 0,
+    categoria: 'Cat',
+    unidade: 'kg',
+    infinito: false,
+    processo: 'Proc',
+    descricao: ''
+  });
+
+  await assert.rejects(
+    atualizarMateria(ins2.id, {
+      nome: 'Insumo A',
+      categoria: 'Cat',
+      quantidade: 1,
+      unidade: 'kg',
+      preco_unitario: 0,
+      processo: 'Proc',
+      infinito: false,
+      descricao: ''
+    }),
+    /DUPLICADO/
+  );
+});
+

--- a/backend/materiaPrima.js
+++ b/backend/materiaPrima.js
@@ -35,6 +35,12 @@ async function listarMaterias(filtro = '') {
 
 async function adicionarMateria(dados) {
   const { nome, quantidade, preco_unitario, categoria, unidade, infinito, processo, descricao } = dados;
+  const dup = await pool.query('SELECT 1 FROM materia_prima WHERE lower(nome)=lower($1) LIMIT 1', [nome]);
+  if (dup.rowCount > 0) {
+    const err = new Error('DUPLICADO');
+    err.code = 'DUPLICADO';
+    throw err;
+  }
   const res = await pool.query(
     `INSERT INTO materia_prima
       (nome, quantidade, preco_unitario, data_estoque, data_preco, categoria, unidade, infinito, processo, descricao)
@@ -56,6 +62,12 @@ async function atualizarMateria(id, dados) {
     infinito,
     descricao
   } = dados;
+  const dup = await pool.query('SELECT 1 FROM materia_prima WHERE lower(nome)=lower($1) AND id<>$2 LIMIT 1', [nome, id]);
+  if (dup.rowCount > 0) {
+    const err = new Error('DUPLICADO');
+    err.code = 'DUPLICADO';
+    throw err;
+  }
   const res = await pool.query(
     `UPDATE materia_prima
         SET nome=$1,

--- a/src/html/modals/materia-prima/duplicado.html
+++ b/src/html/modals/materia-prima/duplicado.html
@@ -1,0 +1,12 @@
+<div id="duplicadoOverlay" class="fixed inset-0 bg-black/50 flex items-center justify-center p-4">
+  <div class="max-w-sm w-full glass-surface backdrop-blur-xl rounded-2xl border border-yellow-500/20 ring-1 ring-yellow-500/30 shadow-2xl/40 animate-modalFade">
+    <div class="p-6 text-center">
+      <h3 class="text-lg font-semibold mb-4 text-yellow-400">Atenção</h3>
+      <p class="text-sm text-gray-300">Já existe um insumo com este nome.</p>
+      <div class="flex justify-center mt-6">
+        <button id="fecharDuplicado" class="btn-warning px-6 py-2 rounded-lg text-white font-medium active:scale-95">OK</button>
+      </div>
+    </div>
+  </div>
+</div>
+

--- a/src/js/modals/materia-prima-duplicado.js
+++ b/src/js/modals/materia-prima-duplicado.js
@@ -1,0 +1,7 @@
+const close = () => Modal.close('duplicado');
+
+document.getElementById('fecharDuplicado')?.addEventListener('click', close);
+document.getElementById('duplicadoOverlay')?.addEventListener('click', e => {
+  if (e.target.id === 'duplicadoOverlay') close();
+});
+

--- a/src/js/modals/materia-prima-editar.js
+++ b/src/js/modals/materia-prima-editar.js
@@ -116,7 +116,11 @@
       carregarMateriais();
     }catch(err){
       console.error(err);
-      showToast('Erro ao atualizar insumo', 'error');
+      if (err.message === 'DUPLICADO' || err.code === 'DUPLICADO') {
+        Modal.open('modals/materia-prima/duplicado.html', '../js/modals/materia-prima-duplicado.js', 'duplicado', true);
+      } else {
+        showToast('Erro ao atualizar insumo', 'error');
+      }
     }
   });
 })();

--- a/src/js/modals/materia-prima-novo.js
+++ b/src/js/modals/materia-prima-novo.js
@@ -81,9 +81,14 @@
       await window.electronAPI.adicionarMateriaPrima(dados);
       showToast('Insumo registrado com sucesso!', 'success');
       close();
+      carregarMateriais();
     }catch(err){
       console.error(err);
-      showToast('Erro ao registrar insumo', 'error');
+      if (err.message === 'DUPLICADO' || err.code === 'DUPLICADO') {
+        Modal.open('modals/materia-prima/duplicado.html', '../js/modals/materia-prima-duplicado.js', 'duplicado', true);
+      } else {
+        showToast('Erro ao registrar insumo', 'error');
+      }
     }
   });
 


### PR DESCRIPTION
## Summary
- prevent duplicate raw material names in backend with validation
- show duplicate warning modal and refresh material list on create or update
- add tests covering duplicate name scenarios

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a763fb5a48832282abd7cd83e6a2f4