### PR TITLE
Suppress Duplicate Materia Prima Error Logs

### DIFF
--- a/main.js
+++ b/main.js
@@ -367,10 +367,20 @@ ipcMain.handle('listar-materia-prima', async (_e, { filtro }) => {
   return listarMaterias(filtro);
 });
 ipcMain.handle('adicionar-materia-prima', async (_e, dados) => {
-  return adicionarMateria(dados);
+  try {
+    const materia = await adicionarMateria(dados);
+    return { success: true, materia };
+  } catch (err) {
+    return { success: false, message: err.message, code: err.code };
+  }
 });
 ipcMain.handle('atualizar-materia-prima', async (_e, { id, dados }) => {
-  return atualizarMateria(id, dados);
+  try {
+    const materia = await atualizarMateria(id, dados);
+    return { success: true, materia };
+  } catch (err) {
+    return { success: false, message: err.message, code: err.code };
+  }
 });
 ipcMain.handle('excluir-materia-prima', async (_e, id) => {
   await excluirMateria(id);

--- a/preload.js
+++ b/preload.js
@@ -58,8 +58,24 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.invoke('listar-itens-processo-produto', { codigo, etapa, busca }),
   salvarProdutoDetalhado: (codigo, produto, itens) =>
     ipcRenderer.invoke('salvar-produto-detalhado', { codigo, produto, itens }),
-  adicionarMateriaPrima: (dados) => ipcRenderer.invoke('adicionar-materia-prima', dados),
-  atualizarMateriaPrima: (id, dados) => ipcRenderer.invoke('atualizar-materia-prima', { id, dados }),
+  adicionarMateriaPrima: async (dados) => {
+    const result = await ipcRenderer.invoke('adicionar-materia-prima', dados);
+    if (result && result.success === false) {
+      const err = new Error(result.message);
+      if (result.code) err.code = result.code;
+      throw err;
+    }
+    return result.materia;
+  },
+  atualizarMateriaPrima: async (id, dados) => {
+    const result = await ipcRenderer.invoke('atualizar-materia-prima', { id, dados });
+    if (result && result.success === false) {
+      const err = new Error(result.message);
+      if (result.code) err.code = result.code;
+      throw err;
+    }
+    return result.materia;
+  },
   excluirMateriaPrima: (id) => ipcRenderer.invoke('excluir-materia-prima', id),
   registrarEntrada: (id, quantidade) => ipcRenderer.invoke('registrar-entrada-materia-prima', { id, quantidade }),
   registrarSaida: (id, quantidade) => ipcRenderer.invoke('registrar-saida-materia-prima', { id, quantidade }),


### PR DESCRIPTION
## Summary
- Handle duplicate errors in materia-prima handlers without throwing, preventing terminal logs
- Propagate handler errors through preload API for renderer try/catch logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a7659fa23c832295113d2284b5c325