### PR TITLE
Fix duplicate material edit dialog OK button

### DIFF
--- a/src/js/modals/materia-prima-duplicado.js
+++ b/src/js/modals/materia-prima-duplicado.js
@@ -1,7 +1,16 @@
-const close = () => Modal.close('duplicado');
+;(function () {
+  const overlay = document.getElementById('duplicadoOverlay');
+  const close = () => Modal.close('duplicado');
 
-document.getElementById('fecharDuplicado')?.addEventListener('click', close);
-document.getElementById('duplicadoOverlay')?.addEventListener('click', e => {
-  if (e.target.id === 'duplicadoOverlay') close();
-});
+  document.getElementById('fecharDuplicado')?.addEventListener('click', close);
+  overlay?.addEventListener('click', e => {
+    if (e.target === overlay) close();
+  });
+  document.addEventListener('keydown', function esc(e) {
+    if (e.key === 'Escape') {
+      close();
+      document.removeEventListener('keydown', esc);
+    }
+  });
+})();
 


### PR DESCRIPTION
## Summary
- Wrap duplicate warning modal logic in an IIFE and add overlay, click and escape handlers to ensure the OK button properly closes the dialog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a7673fd0f0832292c81b82976b2221