### PR TITLE
Suppress Terminal Error When Removing Linked Insumo

### DIFF
--- a/main.js
+++ b/main.js
@@ -383,8 +383,12 @@ ipcMain.handle('atualizar-materia-prima', async (_e, { id, dados }) => {
   }
 });
 ipcMain.handle('excluir-materia-prima', async (_e, id) => {
-  await excluirMateria(id);
-  return true;
+  try {
+    await excluirMateria(id);
+    return { success: true };
+  } catch (err) {
+    return { success: false, message: err.message, code: err.code };
+  }
 });
 ipcMain.handle('registrar-entrada-materia-prima', async (_e, { id, quantidade }) => {
   return registrarEntrada(id, quantidade);

--- a/preload.js
+++ b/preload.js
@@ -76,7 +76,15 @@ contextBridge.exposeInMainWorld('electronAPI', {
     }
     return result.materia;
   },
-  excluirMateriaPrima: (id) => ipcRenderer.invoke('excluir-materia-prima', id),
+  excluirMateriaPrima: async (id) => {
+    const result = await ipcRenderer.invoke('excluir-materia-prima', id);
+    if (result && result.success === false) {
+      const err = new Error(result.message);
+      if (result.code) err.code = result.code;
+      throw err;
+    }
+    return result;
+  },
   registrarEntrada: (id, quantidade) => ipcRenderer.invoke('registrar-entrada-materia-prima', { id, quantidade }),
   registrarSaida: (id, quantidade) => ipcRenderer.invoke('registrar-saida-materia-prima', { id, quantidade }),
   atualizarPreco: (id, preco) => ipcRenderer.invoke('atualizar-preco-materia-prima', { id, preco }),


### PR DESCRIPTION
## Summary
- Add try/catch to `excluir-materia-prima` handler, returning structured success/failure to avoid logging foreign key violations
- Propagate deletion errors through preload so renderer keeps showing user-friendly failure message

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a767ecc5c88322acb64637b0cc7acc