### PR TITLE
Padronizar foco e aviso nativo nos modais

### DIFF
--- a/src/html/modals/orcamentos/novo.html
+++ b/src/html/modals/orcamentos/novo.html
@@ -1,27 +1,27 @@
 <div id="novoOrcamentoOverlay" class="fixed inset-x-0 bottom-0 top-14 z-[1002] bg-black/50 flex items-start justify-center p-4 overflow-y-auto">
   <div role="dialog" aria-modal="true" tabindex="0" class="w-full max-w-5xl h-full max-h-full glass-surface backdrop-blur-xl rounded-3xl border border-white/10 ring-1 ring-white/5 shadow-2xl/40 animate-modalFade slide-in overflow-hidden flex flex-col relative">
     <header class="relative flex items-center justify-between px-8 py-5 border-b border-white/10 flex-shrink-0">
-      <div class="flex items-center gap-3">
-        <button id="voltarNovoOrcamento" class="btn-neutral px-4 py-2 rounded-lg text-white font-medium flex items-center gap-2">← Voltar</button>
-        <div class="relative">
-          <select id="novoDono" class="peer w-48 appearance-none bg-input border border-inputBorder rounded-lg px-4 pr-12 py-2 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition" data-filled="false">
-            <option value="" disabled selected hidden></option>
-          </select>
-          <label for="novoDono" class="absolute left-4 top-1/2 -translate-y-1/2 text-base text-gray-300 pointer-events-none transition-all duration-150 peer-focus:top-0 peer-focus:-translate-y-full peer-focus:text-xs peer-focus:text-primary peer-data-[filled=true]:top-0 peer-data-[filled=true]:-translate-y-full peer-data-[filled=true]:text-xs">Dono</label>
-          <i class="fas fa-chevron-down absolute right-4 top-1/2 -translate-y-1/2 text-gray-300 pointer-events-none"></i>
+        <div class="flex items-center gap-3">
+          <button id="voltarNovoOrcamento" class="btn-neutral px-4 py-2 rounded-lg text-white font-medium flex items-center gap-2">← Voltar</button>
+          <div class="relative">
+            <select id="novoDono" name="dono" form="novoOrcamentoForm" required class="peer w-48 appearance-none bg-input border border-inputBorder rounded-lg px-4 pr-12 py-2 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition" data-filled="false">
+              <option value="" disabled selected hidden></option>
+            </select>
+            <label for="novoDono" class="absolute left-4 top-1/2 -translate-y-1/2 text-base text-gray-300 pointer-events-none transition-all duration-150 peer-focus:top-0 peer-focus:-translate-y-full peer-focus:text-xs peer-focus:text-primary peer-data-[filled=true]:top-0 peer-data-[filled=true]:-translate-y-full peer-data-[filled=true]:text-xs">Dono</label>
+            <i class="fas fa-chevron-down absolute right-4 top-1/2 -translate-y-1/2 text-gray-300 pointer-events-none"></i>
+          </div>
         </div>
-      </div>
-      <h2 class="absolute left-1/2 -translate-x-1/2 text-lg font-semibold text-white">NOVO ORÇAMENTO</h2>
-      <div class="flex items-center gap-3">
-        <button id="salvarNovoOrcamento" class="btn-success px-4 py-2 rounded-lg text-white font-medium">Salvar</button>
-        <button id="limparNovoOrcamento" class="btn-danger px-4 py-2 rounded-lg text-white font-medium">Limpar Tudo</button>
-      </div>
-    </header>
-    <div class="flex-1 overflow-y-auto modal-scroll"><!-- Scroll do Novo Orçamento restrito ao corpo (entre header e footer), igual Editar Orçamento -->
+        <h2 class="absolute left-1/2 -translate-x-1/2 text-lg font-semibold text-white">NOVO ORÇAMENTO</h2>
+        <div class="flex items-center gap-3">
+          <button type="submit" id="salvarNovoOrcamento" form="novoOrcamentoForm" data-status="Rascunho" class="btn-success px-4 py-2 rounded-lg text-white font-medium">Salvar</button>
+          <button type="button" id="limparNovoOrcamento" class="btn-danger px-4 py-2 rounded-lg text-white font-medium">Limpar Tudo</button>
+        </div>
+      </header>
+      <form id="novoOrcamentoForm" class="flex-1 overflow-y-auto modal-scroll"><!-- Scroll do Novo Orçamento restrito ao corpo (entre header e footer), igual Editar Orçamento -->
       <div class="px-8 py-6 space-y-6">
         <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
           <div class="relative">
-            <select id="novoCliente" class="peer w-full appearance-none bg-input border border-inputBorder rounded-lg px-4 pr-12 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition" data-filled="false">
+            <select id="novoCliente" name="cliente" required class="peer w-full appearance-none bg-input border border-inputBorder rounded-lg px-4 pr-12 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition" data-filled="false">
               <option value="" disabled selected hidden></option>
               <!-- Options preenchidas dinamicamente -->
             </select>
@@ -29,19 +29,19 @@
             <i class="fas fa-chevron-down absolute right-4 top-1/2 -translate-y-1/2 text-gray-300 pointer-events-none"></i>
           </div>
           <div class="relative">
-            <select id="novoContato" class="peer w-full appearance-none bg-input border border-inputBorder rounded-lg px-4 pr-12 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition" data-filled="false">
+            <select id="novoContato" name="contato" required class="peer w-full appearance-none bg-input border border-inputBorder rounded-lg px-4 pr-12 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition" data-filled="false">
               <option value="" disabled selected hidden></option>
             </select>
             <label for="novoContato" class="absolute left-4 top-1/2 -translate-y-1/2 text-base text-gray-300 pointer-events-none transition-all duration-150 peer-focus:top-0 peer-focus:-translate-y-full peer-focus:text-xs peer-focus:text-primary peer-data-[filled=true]:top-0 peer-data-[filled=true]:-translate-y-full peer-data-[filled=true]:text-xs">Contato</label>
             <i class="fas fa-chevron-down absolute right-4 top-1/2 -translate-y-1/2 text-gray-300 pointer-events-none"></i>
           </div>
           <div class="relative">
-            <input id="novoValidade" type="date" placeholder=" " class="peer w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+            <input id="novoValidade" name="validade" type="date" placeholder=" " required class="peer w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
             <label for="novoValidade" class="absolute left-4 top-1/2 -translate-y-1/2 text-base text-gray-300 pointer-events-none transition-all duration-150 peer-focus:top-0 peer-focus:-translate-y-full peer-focus:text-xs peer-focus:text-primary peer-valid:top-0 peer-valid:-translate-y-full peer-valid:text-xs">Validade</label>
             <i class="fas fa-calendar-alt absolute right-4 top-1/2 -translate-y-1/2 text-gray-300 pointer-events-none"></i>
           </div>
           <div class="relative">
-            <select id="novoCondicao" class="peer w-full appearance-none bg-input border border-inputBorder rounded-lg px-4 pr-12 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition" data-filled="false">
+            <select id="novoCondicao" name="condicao" required class="peer w-full appearance-none bg-input border border-inputBorder rounded-lg px-4 pr-12 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition" data-filled="false">
               <option value="" disabled selected hidden></option>
               <option value="vista">À vista</option>
               <option value="prazo">À prazo</option>
@@ -50,14 +50,14 @@
             <i class="fas fa-chevron-down absolute right-4 top-1/2 -translate-y-1/2 text-gray-300 pointer-events-none"></i>
           </div>
           <div class="relative">
-            <select id="novoTransportadora" class="peer w-full appearance-none bg-input border border-inputBorder rounded-lg px-4 pr-12 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition" data-filled="false">
+            <select id="novoTransportadora" name="transportadora" required class="peer w-full appearance-none bg-input border border-inputBorder rounded-lg px-4 pr-12 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition" data-filled="false">
               <option value="" disabled selected hidden></option>
             </select>
             <label for="novoTransportadora" class="absolute left-4 top-1/2 -translate-y-1/2 text-base text-gray-300 pointer-events-none transition-all duration-150 peer-focus:top-0 peer-focus:-translate-y-full peer-focus:text-xs peer-focus:text-primary peer-data-[filled=true]:top-0 peer-data-[filled=true]:-translate-y-full peer-data-[filled=true]:text-xs">Transportadora</label>
             <i class="fas fa-chevron-down absolute right-4 top-1/2 -translate-y-1/2 text-gray-300 pointer-events-none"></i>
           </div>
           <div class="relative">
-            <select id="novoFormaPagamento" class="peer w-full appearance-none bg-input border border-inputBorder rounded-lg px-4 pr-12 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition" data-filled="false">
+            <select id="novoFormaPagamento" name="formaPagamento" required class="peer w-full appearance-none bg-input border border-inputBorder rounded-lg px-4 pr-12 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition" data-filled="false">
               <option value="" disabled selected hidden></option>
               <option value="boleto">Boleto</option>
               <option value="pix">Pix</option>
@@ -120,15 +120,15 @@
             </table>
           </div>
         </div>
-      </div>
-    </div>
-    <footer class="flex items-center justify-between gap-3 px-8 py-6 border-t border-white/10 flex-shrink-0">
+        </div>
+      </form>
+      <footer class="flex items-center justify-between gap-3 px-8 py-6 border-t border-white/10 flex-shrink-0">
       <span class="badge-success px-6 py-3 rounded-full text-lg font-semibold">Valor Total: <span id="novoTotalFooter">R$ 0,00</span></span>
       <div class="flex gap-3">
-        <button id="enviarNovoOrcamento" class="btn-secondary px-4 py-2 rounded-lg text-white font-medium">Salvar e Enviar</button>
-        <button id="cancelarNovoOrcamento" class="btn-danger-light px-4 py-2 rounded-lg font-medium">Cancelar</button>
-      </div>
-    </footer>
+          <button type="submit" id="enviarNovoOrcamento" form="novoOrcamentoForm" data-status="Pendente" class="btn-secondary px-4 py-2 rounded-lg text-white font-medium">Salvar e Enviar</button>
+          <button type="button" id="cancelarNovoOrcamento" class="btn-danger-light px-4 py-2 rounded-lg font-medium">Cancelar</button>
+        </div>
+      </footer>
+    </div>
   </div>
-</div>
 

--- a/src/html/modals/produtos/novo.html
+++ b/src/html/modals/produtos/novo.html
@@ -8,12 +8,12 @@
         <span id="precoVendaTag" class="bg-green-500 text-white px-4 py-2 rounded-lg text-lg font-bold">R$ 0,00</span>
       </div>
       <h2 class="text-lg font-semibold text-white flex-1 text-center">INSERIR NOVO PRODUTO</h2>
-      <div class="flex-1 flex items-center justify-end gap-3">
-        <button id="registrarNovoProduto" class="btn-success px-4 py-2 rounded-lg text-white font-medium">Registrar</button>
-        <button id="limparNovoProduto" class="btn-danger px-4 py-2 rounded-lg text-white font-medium">Limpar Tudo</button>
-      </div>
-    </header>
-    <div class="flex-1 overflow-y-auto modal-scroll">
+        <div class="flex-1 flex items-center justify-end gap-3">
+          <button type="submit" form="novoProdutoForm" class="btn-success px-4 py-2 rounded-lg text-white font-medium">Registrar</button>
+          <button type="button" id="limparNovoProduto" class="btn-danger px-4 py-2 rounded-lg text-white font-medium">Limpar Tudo</button>
+        </div>
+      </header>
+      <form id="novoProdutoForm" class="flex-1 overflow-y-auto modal-scroll">
       <div class="px-8 py-6 border-b border-white/10">
         <div class="flex items-center justify-between mb-6">
           <div>
@@ -26,19 +26,19 @@
           </div>
         </div>
         <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
-          <div class="md:col-span-2">
-            <input id="nomeInput" type="text" placeholder="Nome do Produto" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
-          </div>
-          <div>
-            <input id="codigoInput" type="text" placeholder="Código" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
-          </div>
-          <div>
-            <input id="ncmInput" type="text" placeholder="00000000" maxlength="8" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
-          </div>
-          <div class="relative">
-            <select id="colecaoSelect" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 pr-12 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition">
-              <option value="">Selecionar Coleção</option>
-            </select>
+            <div class="md:col-span-2">
+              <input id="nomeInput" name="nome" type="text" placeholder="Nome do Produto" required class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+            </div>
+            <div>
+              <input id="codigoInput" name="codigo" type="text" placeholder="Código" required class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+            </div>
+            <div>
+              <input id="ncmInput" name="ncm" type="text" placeholder="00000000" maxlength="8" required class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+            </div>
+            <div class="relative">
+              <select id="colecaoSelect" name="categoria" required class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 pr-12 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition">
+                <option value="">Selecionar Coleção</option>
+              </select>
             <button type="button" id="delColecaoNovo" class="absolute right-10 top-1/2 -translate-y-1/2 btn-neutral icon-only text-gray-300 hover:text-white" aria-label="Excluir coleção">
               <i class="fas fa-minus"></i>
             </button>
@@ -64,34 +64,34 @@
           <div class="bg-surface/40 rounded-xl p-6 border border-white/10 h-full">
             <h3 class="text-lg font-semibold mb-4 text-white">PERCENTAGENS</h3>
             <div class="space-y-4">
-              <div class="flex justify-between items-center">
-                <span class="text-gray-300">Marcenaria</span>
-                <input id="fabricacaoInput" type="number" value="0" class="w-20 bg-input border border-inputBorder rounded px-3 py-1 text-white text-sm focus:border-primary focus:ring-1 focus:ring-primary/50 transition" />
-              </div>
-              <div class="flex justify-between items-center">
-                <span class="text-gray-300">Acabamento</span>
-                <input id="acabamentoInput" type="number" value="0" class="w-20 bg-input border border-inputBorder rounded px-3 py-1 text-white text-sm focus:border-primary focus:ring-1 focus:ring-primary/50 transition" />
-              </div>
-              <div class="flex justify-between items-center">
-                <span class="text-gray-300">Montagem</span>
-                <input id="montagemInput" type="number" value="0" class="w-20 bg-input border border-inputBorder rounded px-3 py-1 text-white text-sm focus:border-primary focus:ring-1 focus:ring-primary/50 transition" />
-              </div>
-              <div class="flex justify-between items-center">
-                <span class="text-gray-300">Embalagem</span>
-                <input id="embalagemInput" type="number" value="0" class="w-20 bg-input border border-inputBorder rounded px-3 py-1 text-white text-sm focus:border-primary focus:ring-1 focus:ring-primary/50 transition" />
-              </div>
-              <div class="flex justify-between items-center">
-                <span class="text-gray-300">Markup</span>
-                <input id="markupInput" type="number" value="0" class="w-20 bg-input border border-inputBorder rounded px-3 py-1 text-white text-sm focus:border-primary focus:ring-1 focus:ring-primary/50 transition" />
-              </div>
-              <div class="flex justify-between items-center">
-                <span class="text-gray-300">Comissão</span>
-                <input id="commissionInput" type="number" value="0" class="w-20 bg-input border border-inputBorder rounded px-3 py-1 text-white text-sm focus:border-primary focus:ring-1 focus:ring-primary/50 transition" />
-              </div>
-              <div class="flex justify-between items-center">
-                <span class="text-gray-300">Imposto</span>
-                <input id="taxInput" type="number" value="0" class="w-20 bg-input border border-inputBorder rounded px-3 py-1 text-white text-sm focus:border-primary focus:ring-1 focus:ring-primary/50 transition" />
-              </div>
+                <div class="flex justify-between items-center">
+                  <span class="text-gray-300">Marcenaria</span>
+                  <input id="fabricacaoInput" name="fabricacao" type="number" value="0" required class="w-20 bg-input border border-inputBorder rounded px-3 py-1 text-white text-sm focus:border-primary focus:ring-1 focus:ring-primary/50 transition" />
+                </div>
+                <div class="flex justify-between items-center">
+                  <span class="text-gray-300">Acabamento</span>
+                  <input id="acabamentoInput" name="acabamento" type="number" value="0" required class="w-20 bg-input border border-inputBorder rounded px-3 py-1 text-white text-sm focus:border-primary focus:ring-1 focus:ring-primary/50 transition" />
+                </div>
+                <div class="flex justify-between items-center">
+                  <span class="text-gray-300">Montagem</span>
+                  <input id="montagemInput" name="montagem" type="number" value="0" required class="w-20 bg-input border border-inputBorder rounded px-3 py-1 text-white text-sm focus:border-primary focus:ring-1 focus:ring-primary/50 transition" />
+                </div>
+                <div class="flex justify-between items-center">
+                  <span class="text-gray-300">Embalagem</span>
+                  <input id="embalagemInput" name="embalagem" type="number" value="0" required class="w-20 bg-input border border-inputBorder rounded px-3 py-1 text-white text-sm focus:border-primary focus:ring-1 focus:ring-primary/50 transition" />
+                </div>
+                <div class="flex justify-between items-center">
+                  <span class="text-gray-300">Markup</span>
+                  <input id="markupInput" name="markup" type="number" value="0" required class="w-20 bg-input border border-inputBorder rounded px-3 py-1 text-white text-sm focus:border-primary focus:ring-1 focus:ring-primary/50 transition" />
+                </div>
+                <div class="flex justify-between items-center">
+                  <span class="text-gray-300">Comissão</span>
+                  <input id="commissionInput" name="commission" type="number" value="0" required class="w-20 bg-input border border-inputBorder rounded px-3 py-1 text-white text-sm focus:border-primary focus:ring-1 focus:ring-primary/50 transition" />
+                </div>
+                <div class="flex justify-between items-center">
+                  <span class="text-gray-300">Imposto</span>
+                  <input id="taxInput" name="tax" type="number" value="0" required class="w-20 bg-input border border-inputBorder rounded px-3 py-1 text-white text-sm focus:border-primary focus:ring-1 focus:ring-primary/50 transition" />
+                </div>
             </div>
           </div>
         </div>
@@ -130,11 +130,11 @@
               <div class="flex justify-between border-t border-white/10 pt-3">
                 <span class="text-gray-300">Valor de Venda da Peça</span>
                 <span id="valorVenda" class="text-white font-semibold">R$ 0,00</span>
-              </div>
-            </div>
-          </div>
         </div>
       </div>
+    </form>
+    </div>
+  </div>
       <div class="px-8 py-6 border-t border-white/10">
         <div class="bg-surface/40 rounded-xl p-6 border border-white/10">
           <div class="flex items-center justify-between mb-4">
@@ -159,6 +159,6 @@
           <!-- Observações removidas -->
         </div>
       </div>
-    </div>
+    </form>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- Convertir modais de produto e orçamento para `<form>` com campos `required`
- Processar ações via evento `submit` e reset com `form.reset()`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a769d04b8c8322881de02918989794