### PR TITLE
Replicate Budgets Layout in Orders Module

### DIFF
--- a/src/html/pedidos.html
+++ b/src/html/pedidos.html
@@ -1,109 +1,106 @@
-<!-- Tela de Pedidos: lista e controle de pedidos -->
-<!DOCTYPE html>
-<html lang="pt-BR">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Pedidos - Santíssimo Decor</title>
-    <!-- Tailwind e ícones carregados no documento principal -->
-    <link rel="stylesheet" href="../styles/scroll.css">
-</head>
-<body class="text-white">
-  <div class="modulo-container">
-    <div>
-        <div class="mb-8 animate-fade-in-up">
+<!-- Página de pedidos: lista e filtros -->
+<div class="modulo-container">
+    <!-- Header -->
+    <div class="flex justify-between items-center mb-8 animate-fade-in-up">
+        <div>
             <h1 class="text-2xl font-semibold mb-2">Pedidos</h1>
             <p style="color: var(--color-violet)">Acompanhe o status de produção e entrega dos pedidos</p>
         </div>
-        <div class="glass-surface rounded-xl p-6 mb-6 animate-fade-in-up">
-            <div class="flex flex-wrap xl:flex-nowrap items-center gap-4">
-                <div class="flex-1 min-w-[180px]">
-                    <label class="block text-sm font-medium mb-2 text-white">Status</label>
-                    <select class="input-glass text-white rounded-md px-4 py-3 w-full">
-                        <option>Todos os Status</option>
-                        <option>Rascunho</option>
-                        <option>Em Produção</option>
-                        <option>Concluído</option>
-                        <option>Cancelado</option>
-                    </select>
-                </div>
-                <div class="flex-1 min-w-[150px]">
-                    <label class="block text-sm font-medium mb-2 text-white">Período</label>
-                    <select class="input-glass text-white rounded-md px-4 py-3 w-full">
-                        <option>Mês</option>
-                        <option>Semana</option>
-                        <option>Trimestre</option>
-                        <option>Ano</option>
-                    </select>
-                </div>
+        <button id="converterOrcamentoBtn" class="btn-primary text-white rounded-md px-6 py-3 font-medium">
+            <i class="fas fa-plus mr-2"></i>Converter Orçamento
+        </button>
+    </div>
+
+    <!-- Filters -->
+    <div class="glass-surface rounded-xl p-6 mb-6 animate-fade-in-up">
+        <div class="filter-bar flex flex-col md:flex-row md:flex-nowrap items-center">
+            <!-- Status Filter -->
+            <div class="flex-1 min-w-0">
+                <label class="block text-sm font-medium mb-2 text-white">Status</label>
+                <select id="filterStatus" class="input-glass text-white rounded-md px-4 py-3 w-full">
+                    <option value="">Todos os Status</option>
+                    <option value="Rascunho">Rascunho</option>
+                    <option value="Em Produção">Em Produção</option>
+                    <option value="Concluído">Concluído</option>
+                    <option value="Cancelado">Cancelado</option>
+                </select>
+            </div>
+
+            <!-- Period Filter -->
+            <div class="flex-1 min-w-0">
+                <label class="block text-sm font-medium mb-2 text-white">Período</label>
+                <select id="filterPeriod" class="input-glass text-white rounded-md px-4 py-3 w-full">
+                    <option value="">Todos os Períodos</option>
+                    <option value="Semana">Semana</option>
+                    <option value="Mês">Mês</option>
+                    <option value="Trimestre">Trimestre</option>
+                    <option value="Ano">Ano</option>
+                    <option value="Personalizado">Personalizado</option>
+                </select>
+            </div>
+
+            <!-- Salesperson Filter -->
+            <div class="flex-1 min-w-0">
+                <label class="block text-sm font-medium mb-2 text-white">Dono</label>
+                <select id="filterOwner" class="input-glass text-white rounded-md px-4 py-3 w-full">
+                    <option value="">Todos os Donos</option>
+                </select>
+            </div>
+
+            <!-- Client Filter -->
+            <div class="flex-1 min-w-0">
+                <label class="block text-sm font-medium mb-2 text-white">Cliente</label>
+                <select id="filterClient" class="input-glass text-white rounded-md px-4 py-3 w-full">
+                    <option value="">Todos os Clientes</option>
+                </select>
+            </div>
+
+            <!-- Action Buttons -->
+            <div id="bt-actions" class="flex items-center gap-2 flex-shrink-0">
+                <button id="btnFiltrar" class="btn-secondary text-white rounded-md px-4 py-3 text-sm font-medium">
+                    Filtrar
+                </button>
+                <button id="btnLimpar" class="btn-warning text-white rounded-md px-4 py-3 text-sm font-medium">
+                    Limpar
+                </button>
             </div>
         </div>
-        <div class="glass-surface rounded-xl shadow-lg animate-fade-in-up table-scroll">
-            <table class="w-full">
-                <thead class="bg-gray-50 sticky top-0">
-                        <tr>
-                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Codigo</th>
-                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Cliente</th>
-                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Data</th>
-                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Valor Total</th>
-                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
-                            <th class="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">Ações</th>
-                        </tr>
-                </thead>
-                <tbody class="divide-y divide-white/10">
-                        <tr class="transition-colors duration-150" style="cursor: pointer;" onmouseover="this.style.background='rgba(163, 148, 167, 0.05)'" onmouseout="this.style.background='transparent'">
-                            <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-white">PED001</td>
-                            <td class="px-6 py-4 whitespace-nowrap text-sm text-white">Ana Carolina Mendes</td>
-                            <td class="px-6 py-4 whitespace-nowrap text-sm" style="color: var(--color-violet)">15/03/2024</td>
-                            <td class="px-6 py-4 whitespace-nowrap text-sm text-white">R$ 3.450,00</td>
-                            <td class="px-6 py-4 whitespace-nowrap">
-                                <span class="badge-warning px-3 py-1 rounded-full text-xs font-medium">Em Produção</span>
-                            </td>
-                            <td class="px-6 py-4 whitespace-nowrap text-center">
-                                <div class="flex items-center justify-center space-x-2">
-                                    <i class="fas fa-eye w-5 h-5 cursor-pointer p-1 rounded transition-colors duration-150 hover:bg-white/10" style="color: var(--color-primary)" title="Visualizar"></i>
-                                    <i class="fas fa-edit w-5 h-5 cursor-pointer p-1 rounded transition-colors duration-150 hover:bg-white/10" style="color: var(--color-primary)" title="Editar"></i>
-                                    <i class="fas fa-download w-5 h-5 cursor-pointer p-1 rounded transition-colors duration-150 hover:bg-white/10" style="color: var(--color-primary)" title="Download"></i>
-                                </div>
-                            </td>
-                        </tr>
-                        <tr class="transition-colors duration-150" style="cursor: pointer;" onmouseover="this.style.background='rgba(163, 148, 167, 0.05)'" onmouseout="this.style.background='transparent'">
-                            <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-white">PED002</td>
-                            <td class="px-6 py-4 whitespace-nowrap text-sm text-white">Roberto Silva Santos</td>
-                            <td class="px-6 py-4 whitespace-nowrap text-sm" style="color: var(--color-violet)">14/03/2024</td>
-                            <td class="px-6 py-4 whitespace-nowrap text-sm text-white">R$ 1.890,00</td>
-                            <td class="px-6 py-4 whitespace-nowrap">
-                                <span class="badge-success px-3 py-1 rounded-full text-xs font-medium">Concluído</span>
-                            </td>
-                            <td class="px-6 py-4 whitespace-nowrap text-center">
-                                <div class="flex items-center justify-center space-x-2">
-                                    <i class="fas fa-eye w-5 h-5 cursor-pointer p-1 rounded transition-colors duration-150 hover:bg-white/10" style="color: var(--color-primary)" title="Visualizar"></i>
-                                    <i class="fas fa-edit w-5 h-5 cursor-pointer p-1 rounded transition-colors duration-150 hover:bg-white/10" style="color: var(--color-primary)" title="Editar"></i>
-                                    <i class="fas fa-download w-5 h-5 cursor-pointer p-1 rounded transition-colors duration-150 hover:bg-white/10" style="color: var(--color-primary)" title="Download"></i>
-                                </div>
-                            </td>
-                        </tr>
-                        <tr class="transition-colors duration-150" style="cursor: pointer;" onmouseover="this.style.background='rgba(163, 148, 167, 0.05)'" onmouseout="this.style.background='transparent'">
-                            <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-white">PED003</td>
-                            <td class="px-6 py-4 whitespace-nowrap text-sm text-white">Mariana Costa Lima</td>
-                            <td class="px-6 py-4 whitespace-nowrap text-sm" style="color: var(--color-violet)">13/03/2024</td>
-                            <td class="px-6 py-4 whitespace-nowrap text-sm text-white">R$ 2.340,00</td>
-                            <td class="px-6 py-4 whitespace-nowrap">
-                                <span class="badge-danger px-3 py-1 rounded-full text-xs font-medium">Rascunho</span>
-                            </td>
-                            <td class="px-6 py-4 whitespace-nowrap text-center">
-                                <div class="flex items-center justify-center space-x-2">
-                                    <i class="fas fa-eye w-5 h-5 cursor-pointer p-1 rounded transition-colors duration-150 hover:bg-white/10" style="color: var(--color-primary)" title="Visualizar"></i>
-                                    <i class="fas fa-edit w-5 h-5 cursor-pointer p-1 rounded transition-colors duration-150 hover:bg-white/10" style="color: var(--color-primary)" title="Editar"></i>
-                                    <i class="fas fa-download w-5 h-5 cursor-pointer p-1 rounded transition-colors duration-150 hover:bg-white/10" style="color: var(--color-primary)" title="Download"></i>
-                                </div>
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
-        </div>
     </div>
+
+    <!-- Orders Table -->
+    <div class="glass-surface rounded-xl shadow-lg animate-fade-in-up table-scroll">
+        <table class="w-full">
+            <thead class="bg-gray-50 sticky top-0">
+                <tr>
+                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Codigo</th>
+                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Cliente</th>
+                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Data</th>
+                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Valor Total</th>
+                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Condição</th>
+                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
+                        <th class="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">Ações</th>
+                    </tr>
+            </thead>
+            <tbody id="pedidosTabela" class="divide-y divide-white/10"></tbody>
+            </table>
     </div>
 </div>
-</body>
-</html>
+
+<!-- Modal de período personalizado -->
+<div id="periodModal" class="hidden fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+    <div class="glass-surface backdrop-blur-xl rounded-xl p-6 text-white w-full max-w-md">
+        <div class="flex gap-4 mb-4">
+            <div>
+                <label for="startDate" class="block text-sm mb-1">De</label>
+                <input type="date" id="startDate" class="input-glass text-white rounded px-2 py-1" />
+            </div>
+            <div>
+                <label for="endDate" class="block text-sm mb-1">Até</label>
+                <input type="date" id="endDate" class="input-glass text-white rounded px-2 py-1" />
+            </div>
+        </div>
+        <div class="text-right">
+            <button id="periodConfirm" class="btn-primary text-white px-4 py-2 rounded">Confirmar</button>
+        </div>
+    </div>
+</div>

--- a/src/js/pedidos.js
+++ b/src/js/pedidos.js
@@ -1,11 +1,192 @@
-// Script de gerenciamento da tela de pedidos
-// Responsável por carregar dados, filtrar e controlar etapas
+// Lógica de interação para o módulo de Pedidos
+window.customStartDate = null;
+window.customEndDate = null;
+
+async function popularClientes() {
+    const select = document.getElementById('filterClient');
+    if (!select) return;
+    try {
+        const resp = await fetch('http://localhost:3000/api/clientes/lista');
+        const data = await resp.json();
+        select.innerHTML = '<option value="">Todos os Clientes</option>' +
+            data.map(c => `<option value="${c.nome_fantasia}">${c.nome_fantasia}</option>`).join('');
+    } catch (err) {
+        console.error('Erro ao carregar clientes', err);
+    }
+}
+
+function showFunctionUnavailableDialog(message) {
+    const overlay = document.createElement('div');
+    overlay.className = 'fixed inset-0 bg-black/50 flex items-center justify-center p-4';
+    overlay.innerHTML = `<div class="max-w-sm w-full glass-surface backdrop-blur-xl rounded-2xl border border-yellow-500/20 ring-1 ring-yellow-500/30 shadow-2xl/40 animate-modalFade">
+        <div class="p-6 text-center">
+            <h3 class="text-lg font-semibold mb-4 text-yellow-400">Função Indisponível</h3>
+            <p class="text-sm text-gray-300 mb-6">${message}</p>
+            <div class="flex justify-center">
+                <button id="funcUnavailableOk" class="btn-neutral px-4 py-2 rounded-lg text-white font-medium">OK</button>
+            </div>
+        </div>
+    </div>`;
+    document.body.appendChild(overlay);
+    overlay.querySelector('#funcUnavailableOk').addEventListener('click', () => overlay.remove());
+}
+
+async function carregarPedidos() {
+    try {
+        const data = [
+            { id: 1, numero: 'PED001', cliente: 'Ana Carolina Mendes', data_emissao: '15/03/2024', valor_final: 3450, parcelas: 1, situacao: 'Em Produção', dono: 'Carlos' },
+            { id: 2, numero: 'PED002', cliente: 'Roberto Silva Santos', data_emissao: '14/03/2024', valor_final: 1890, parcelas: 3, situacao: 'Concluído', dono: 'Mariana' },
+            { id: 3, numero: 'PED003', cliente: 'Mariana Costa Lima', data_emissao: '13/03/2024', valor_final: 2340, parcelas: 1, situacao: 'Rascunho', dono: 'João' }
+        ];
+        const tbody = document.getElementById('pedidosTabela');
+        tbody.innerHTML = '';
+        const statusClasses = {
+            'Rascunho': 'badge-info',
+            'Em Produção': 'badge-warning',
+            'Concluído': 'badge-success',
+            'Cancelado': 'badge-danger'
+        };
+        const owners = new Set();
+        data.forEach(p => {
+            const tr = document.createElement('tr');
+            tr.className = 'transition-colors duration-150';
+            tr.style.cursor = 'pointer';
+            tr.setAttribute('onmouseover', "this.style.background='rgba(163, 148, 167, 0.05)'");
+            tr.setAttribute('onmouseout', "this.style.background='transparent'");
+            tr.dataset.dono = p.dono || '';
+            owners.add(p.dono);
+            const condicao = p.parcelas > 1 ? `${p.parcelas}x` : 'À vista';
+            const badgeClass = statusClasses[p.situacao] || 'badge-neutral';
+            const valor = Number(p.valor_final || 0).toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
+            tr.innerHTML = `
+                <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-white">${p.numero}</td>
+                <td class="px-6 py-4 whitespace-nowrap text-sm text-white">${p.cliente}</td>
+                <td class="px-6 py-4 whitespace-nowrap text-sm" style="color: var(--color-violet)">${p.data_emissao}</td>
+                <td class="px-6 py-4 whitespace-nowrap text-sm text-white">${valor}</td>
+                <td class="px-6 py-4 whitespace-nowrap text-sm" style="color: var(--color-violet)">${condicao}</td>
+                <td class="px-6 py-4 whitespace-nowrap"><span class="${badgeClass} px-3 py-1 rounded-full text-xs font-medium">${p.situacao}</span></td>
+                <td class="px-6 py-4 whitespace-nowrap text-center">
+                    <div class="flex items-center justify-center space-x-2">
+                        <i class="fas fa-eye w-5 h-5 cursor-pointer p-1 rounded transition-colors duration-150 hover:bg-white/10" style="color: var(--color-primary)" title="Visualizar"></i>
+                        <i class="fas fa-edit w-5 h-5 cursor-pointer p-1 rounded transition-colors duration-150 hover:bg-white/10" style="color: var(--color-primary)" title="Editar"></i>
+                        <i class="fas fa-download w-5 h-5 cursor-pointer p-1 rounded transition-colors duration-150 hover:bg-white/10" style="color: var(--color-primary)" title="Download"></i>
+                    </div>
+                </td>`;
+            tbody.appendChild(tr);
+        });
+        const ownerSelect = document.getElementById('filterOwner');
+        if (ownerSelect) {
+            ownerSelect.innerHTML = '<option value="">Todos os Donos</option>' +
+                [...owners].map(d => `<option value="${d}">${d}</option>`).join('');
+        }
+        tbody.querySelectorAll('.fa-eye, .fa-edit, .fa-download').forEach(icon => {
+            icon.addEventListener('click', e => {
+                e.stopPropagation();
+                showFunctionUnavailableDialog('Função em desenvolvimento.');
+            });
+        });
+        await popularClientes();
+    } catch (err) {
+        console.error('Erro ao carregar pedidos', err);
+    }
+}
+
+function aplicarFiltro() {
+    const status = document.getElementById('filterStatus')?.value || '';
+    const periodo = document.getElementById('filterPeriod')?.value || '';
+    const dono = document.getElementById('filterOwner')?.value || '';
+    const cliente = document.getElementById('filterClient')?.value.toLowerCase() || '';
+    const now = new Date();
+    document.querySelectorAll('#pedidosTabela tr').forEach(row => {
+        const rowStatus = row.cells[5]?.innerText.trim() || '';
+        const rowCliente = row.cells[1]?.innerText.trim().toLowerCase() || '';
+        const rowDono = (row.dataset.dono || '').toLowerCase();
+        const dateText = row.cells[2]?.innerText.trim();
+        let show = true;
+
+        if (status) show &&= rowStatus === status;
+        if (dono) show &&= rowDono === dono.toLowerCase();
+        if (cliente) show &&= rowCliente === cliente;
+        if (periodo) {
+            const [d, m, y] = dateText.split('/').map(Number);
+            const rowDate = new Date(y, m - 1, d);
+            if (periodo === 'Personalizado' && window.customStartDate && window.customEndDate) {
+                const inicio = new Date(window.customStartDate);
+                const fim = new Date(window.customEndDate);
+                show &&= rowDate >= inicio && rowDate <= fim;
+            } else {
+                const diff = (now - rowDate) / (1000 * 60 * 60 * 24);
+                if (periodo === 'Semana') show &&= diff <= 7;
+                else if (periodo === 'Mês') show &&= diff <= 30;
+                else if (periodo === 'Trimestre') show &&= diff <= 90;
+                else if (periodo === 'Ano') show &&= diff <= 365;
+            }
+        }
+
+        row.style.display = show ? '' : 'none';
+    });
+}
+
+function limparFiltros() {
+    document.getElementById('filterStatus').value = '';
+    const periodSel = document.getElementById('filterPeriod');
+    periodSel.value = '';
+    const customOpt = periodSel.querySelector('option[value="Personalizado"]');
+    if (customOpt) customOpt.textContent = 'Personalizado';
+    document.getElementById('filterOwner').value = '';
+    document.getElementById('filterClient').value = '';
+    window.customStartDate = null;
+    window.customEndDate = null;
+    aplicarFiltro();
+}
 
 function initPedidos() {
-    const statusFilter = document.querySelector('select');
-    statusFilter?.addEventListener('change', () => {
-        console.log('Filtro de status alterado:', statusFilter.value);
+    document.querySelectorAll('.animate-fade-in-up').forEach((el, index) => {
+        setTimeout(() => {
+            el.style.opacity = '1';
+            el.style.transform = 'translateY(0)';
+        }, index * 100);
     });
+
+    const converterBtn = document.getElementById('converterOrcamentoBtn');
+    if (converterBtn) {
+        converterBtn.addEventListener('click', () => {
+            showFunctionUnavailableDialog('Conversão de orçamento ainda não implementada.');
+        });
+    }
+
+    const filtrar = document.getElementById('btnFiltrar');
+    const limpar = document.getElementById('btnLimpar');
+    if (filtrar) filtrar.addEventListener('click', aplicarFiltro);
+    if (limpar) limpar.addEventListener('click', limparFiltros);
+
+    const periodSelect = document.getElementById('filterPeriod');
+    const periodModal = document.getElementById('periodModal');
+    const periodConfirm = document.getElementById('periodConfirm');
+    periodSelect?.addEventListener('change', () => {
+        if (periodSelect.value === 'Personalizado') {
+            periodModal.classList.remove('hidden');
+        } else {
+            const customOpt = periodSelect.querySelector('option[value="Personalizado"]');
+            if (customOpt) customOpt.textContent = 'Personalizado';
+            window.customStartDate = null;
+            window.customEndDate = null;
+        }
+    });
+    periodConfirm?.addEventListener('click', () => {
+        window.customStartDate = document.getElementById('startDate').value;
+        window.customEndDate = document.getElementById('endDate').value;
+        periodModal.classList.add('hidden');
+        const customOpt = periodSelect.querySelector('option[value="Personalizado"]');
+        if (customOpt && window.customStartDate && window.customEndDate) {
+            const fmt = d => d.split('-').reverse().join('/');
+            customOpt.textContent = `${fmt(window.customStartDate)} - ${fmt(window.customEndDate)}`;
+        }
+        periodSelect.value = 'Personalizado';
+        aplicarFiltro();
+    });
+
+    carregarPedidos();
 }
 
 if (document.readyState === 'loading') {


### PR DESCRIPTION
## Summary
- mirror budget page header, filters, and table structure in orders module
- implement front-end logic for filtering and sample data population
- add **+ Converter Orçamento** button with placeholder handler

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a76ba5a32083228086f803441895ee