### PR TITLE
Remove placeholder text from empty validity field

### DIFF
--- a/src/css/orcamentos.css
+++ b/src/css/orcamentos.css
@@ -136,6 +136,14 @@ body {
 .focus\:ring-primary\/50:focus { box-shadow: 0 0 0 2px rgba(182,160,62,0.5); }
 .appearance-none { appearance: none; }
 
+input[type="date"]:required:invalid::-webkit-datetime-edit {
+    color: transparent;
+}
+input[type="date"]:focus::-webkit-datetime-edit,
+input[type="date"]:valid::-webkit-datetime-edit {
+    color: inherit;
+}
+
 .select-arrow {
     background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 20 20'%3e%3cpath stroke='%236b7280' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='m6 8 4 4 4-4'/%3e%3c/svg%3e");
     background-position: right 0.5rem center;


### PR DESCRIPTION
## Summary
- hide default date placeholder on empty validity fields

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a76cf1840883228c307ff3cb314357