### PR TITLE
Padroniza barra de filtros de pedidos com orçamentos

### DIFF
--- a/src/css/pedidos.css
+++ b/src/css/pedidos.css
@@ -7,3 +7,28 @@
 .input-glass:focus { background: rgba(255, 255, 255, 0.2); outline: none; border-color: var(--color-primary); }
 .animate-fade-in-up { animation: fadeInUp 0.6s ease-out forwards; opacity: 0; transform: translateY(20px); }
 @keyframes fadeInUp { to { opacity: 1; transform: translateY(0); } }
+
+/* Barra de filtros e layout da tabela - espelha estilos de Orçamentos */
+.filter-bar {
+    gap: 24px;
+    flex-wrap: nowrap;
+}
+
+@media (max-width: 767px) {
+    .filter-bar {
+        flex-direction: column;
+        align-items: stretch;
+    }
+}
+
+.table-scroll {
+    max-height: calc(var(--module-height) - 260px) !important;
+}
+
+.table-scroll thead {
+    z-index: 1;
+}
+
+#bt-actions {
+    margin-top: 1vw;
+}


### PR DESCRIPTION
## Summary
- replica estilos de filtro de orçamentos para pedidos, mantendo espaçamento e layout consistentes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a76d8ca840832287aeef2924a762f7