### PR TITLE
Adiciona ações de relatório e concluir nos pedidos

### DIFF
--- a/src/js/pedidos.js
+++ b/src/js/pedidos.js
@@ -68,7 +68,8 @@ async function carregarPedidos() {
                 <td class="px-6 py-4 whitespace-nowrap text-center">
                     <div class="flex items-center justify-center space-x-2">
                         <i class="fas fa-eye w-5 h-5 cursor-pointer p-1 rounded transition-colors duration-150 hover:bg-white/10" style="color: var(--color-primary)" title="Visualizar"></i>
-                        <i class="fas fa-edit w-5 h-5 cursor-pointer p-1 rounded transition-colors duration-150 hover:bg-white/10" style="color: var(--color-primary)" title="Editar"></i>
+                        <i class="fas fa-check w-5 h-5 cursor-pointer p-1 rounded transition-colors duration-150 hover:bg-white/10" style="color: var(--color-primary)" title="Concluir"></i>
+                        <i class="fas fa-clipboard w-5 h-5 cursor-pointer p-1 rounded transition-colors duration-150 hover:bg-white/10" style="color: var(--color-primary)" title="Relatório"></i>
                         <i class="fas fa-download w-5 h-5 cursor-pointer p-1 rounded transition-colors duration-150 hover:bg-white/10" style="color: var(--color-primary)" title="Download"></i>
                     </div>
                 </td>`;
@@ -79,7 +80,7 @@ async function carregarPedidos() {
             ownerSelect.innerHTML = '<option value="">Todos os Donos</option>' +
                 [...owners].map(d => `<option value="${d}">${d}</option>`).join('');
         }
-        tbody.querySelectorAll('.fa-eye, .fa-edit, .fa-download').forEach(icon => {
+        tbody.querySelectorAll('.fa-eye, .fa-check, .fa-clipboard, .fa-download').forEach(icon => {
             icon.addEventListener('click', e => {
                 e.stopPropagation();
                 showFunctionUnavailableDialog('Função em desenvolvimento.');


### PR DESCRIPTION
## Summary
- adiciona botão de relatório com ícone de prancheta nas ações dos pedidos
- substitui o botão de edição por concluir

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a7739c98c08322bbc6d6f03b9a3b6a