### PR TITLE
Fetch pedidos from database for table display

### DIFF
--- a/backend/pedidosController.js
+++ b/backend/pedidosController.js
@@ -1,0 +1,23 @@
+const express = require('express');
+const db = require('./db');
+
+const router = express.Router();
+
+// Lista todos os pedidos
+router.get('/', async (_req, res) => {
+  try {
+    const { rows } = await db.query(
+      `SELECT p.id, p.numero, c.nome_fantasia AS cliente, to_char(p.data_emissao,'DD/MM/YYYY') AS data_emissao,
+              p.valor_final, p.parcelas, p.situacao, p.dono
+         FROM pedidos p
+         LEFT JOIN clientes c ON c.id = p.cliente_id
+        ORDER BY p.id DESC`
+    );
+    res.json(rows);
+  } catch (err) {
+    console.error('Erro ao listar pedidos:', err);
+    res.status(500).json({ error: 'Erro ao listar pedidos' });
+  }
+});
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -10,6 +10,7 @@ const passwordResetRouter   = require('./passwordResetRoutes');
 const usuariosRouter        = require('./usuariosController');
 const transportadorasRouter = require('./transportadorasController');
 const orcamentosRouter      = require('./orcamentosController');
+const pedidosRouter         = require('./pedidosController');
 
 const app = express();
 app.use(cors());
@@ -19,6 +20,7 @@ app.use('/api/clientes', clientesRouter);
 app.use('/api/usuarios', usuariosRouter);
 app.use('/api/transportadoras', transportadorasRouter);
 app.use('/api/orcamentos', orcamentosRouter);
+app.use('/api/pedidos', pedidosRouter);
 app.use(passwordResetRouter);
 app.use('/pdf', express.static(path.join(__dirname, '../src/pdf')));
 

--- a/src/js/pedidos.js
+++ b/src/js/pedidos.js
@@ -33,11 +33,8 @@ function showFunctionUnavailableDialog(message) {
 
 async function carregarPedidos() {
     try {
-        const data = [
-            { id: 1, numero: 'PED001', cliente: 'Ana Carolina Mendes', data_emissao: '15/03/2024', valor_final: 3450, parcelas: 1, situacao: 'Em Produção', dono: 'Carlos' },
-            { id: 2, numero: 'PED002', cliente: 'Roberto Silva Santos', data_emissao: '14/03/2024', valor_final: 1890, parcelas: 3, situacao: 'Concluído', dono: 'Mariana' },
-            { id: 3, numero: 'PED003', cliente: 'Mariana Costa Lima', data_emissao: '13/03/2024', valor_final: 2340, parcelas: 1, situacao: 'Rascunho', dono: 'João' }
-        ];
+        const resp = await fetch('http://localhost:3000/api/pedidos');
+        const data = await resp.json();
         const tbody = document.getElementById('pedidosTabela');
         tbody.innerHTML = '';
         const statusClasses = {
@@ -60,8 +57,8 @@ async function carregarPedidos() {
             const valor = Number(p.valor_final || 0).toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
             tr.innerHTML = `
                 <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-white">${p.numero}</td>
-                <td class="px-6 py-4 whitespace-nowrap text-sm text-white">${p.cliente}</td>
-                <td class="px-6 py-4 whitespace-nowrap text-sm" style="color: var(--color-violet)">${p.data_emissao}</td>
+                <td class="px-6 py-4 whitespace-nowrap text-sm text-white">${p.cliente || ''}</td>
+                <td class="px-6 py-4 whitespace-nowrap text-sm" style="color: var(--color-violet)">${p.data_emissao || ''}</td>
                 <td class="px-6 py-4 whitespace-nowrap text-sm text-white">${valor}</td>
                 <td class="px-6 py-4 whitespace-nowrap text-sm" style="color: var(--color-violet)">${condicao}</td>
                 <td class="px-6 py-4 whitespace-nowrap"><span class="${badgeClass} px-3 py-1 rounded-full text-xs font-medium">${p.situacao}</span></td>


### PR DESCRIPTION
## Summary
- add pedidos API endpoint to query database
- hook pedidos routes into server
- load pedidos via API in frontend

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a777f5cacc8322a614cd16b9a40900