### PR TITLE
Fechar tela de edição de orçamento ao mudar status ou converter

### DIFF
--- a/src/js/modals/orcamento-editar.js
+++ b/src/js/modals/orcamento-editar.js
@@ -298,6 +298,7 @@
     'Expirado': 'badge-neutral'
   };
   let currentStatus = data.situacao || 'Rascunho';
+  const initialStatus = currentStatus;
   const statusTag = document.getElementById('statusTag');
   const statusOptions = document.getElementById('statusOptions');
   const converterBtn = document.getElementById('converterOrcamento');
@@ -710,7 +711,7 @@
   if (form) {
     form.addEventListener('submit', e => {
       e.preventDefault();
-      const closeAfter = e.submitter?.id === 'salvarFecharOrcamento';
+      const closeAfter = e.submitter?.id === 'salvarFecharOrcamento' || currentStatus !== initialStatus;
       const proceed = () => saveChanges(closeAfter);
       if (currentStatus === 'Aprovado') {
         showActionDialog('Tem certeza que deseja converter este orçamento em pedido?', ok => {


### PR DESCRIPTION
## Summary
- Close edit modal when orçamento status changes and user saves
- Ensure conversion to pedido also closes the edit modal automatically

## Testing
- `npm test` *(fails: Cannot find module '/workspace/App-Gestao/backend')*

------
https://chatgpt.com/codex/tasks/task_e_68a8659447308322a57f89acc6cb19c8