### PR TITLE
Implement PDF Generation for Pedidos

### DIFF
--- a/main.js
+++ b/main.js
@@ -801,9 +801,10 @@ ipcMain.handle('get-saved-display', () => {
   return currentDisplayId || null;
 });
 
-ipcMain.handle('open-pdf', (_event, id) => {
+ipcMain.handle('open-pdf', (_event, { id, tipo }) => {
   const url = new URL('http://localhost:3000/pdf');
   url.searchParams.set('id', id);
+  if (tipo) url.searchParams.set('tipo', tipo);
   shell.openExternal(url.toString());
   return true;
 });

--- a/preload.js
+++ b/preload.js
@@ -103,7 +103,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   reloadWindow: () => ipcRenderer.invoke('reload-window'),
   getDisplays: () => ipcRenderer.invoke('get-displays'),
   setDisplay: (id) => ipcRenderer.invoke('set-display', id),
-  openPdf: (id) => ipcRenderer.invoke('open-pdf', id),
+  openPdf: (id, tipo) => ipcRenderer.invoke('open-pdf', { id, tipo }),
     getSavedDisplay: () => ipcRenderer.invoke('get-saved-display'),
     onActivateTab: (callback) =>
       ipcRenderer.on('activate-tab', (_event, tab) => callback(tab)),

--- a/src/js/orcamentos.js
+++ b/src/js/orcamentos.js
@@ -170,7 +170,7 @@ async function carregarOrcamentos() {
                     showPdfUnavailableDialog(id);
                 } else {
                     if (window.electronAPI?.openPdf) {
-                        window.electronAPI.openPdf(id);
+                        window.electronAPI.openPdf(id, 'orcamento');
                     }
                 }
             });


### PR DESCRIPTION
## Summary
- expose pedido details API including items and parcel data
- allow pdf IPC to specify document type
- enable PDF download in pedidos view and adapt document content for pedidos

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a868b1b28c83228d5ce51f399031e2