### PR TITLE
Implementar Função Do Botão Concluir De Pedidos

### DIFF
--- a/backend/pedidosController.js
+++ b/backend/pedidosController.js
@@ -20,4 +20,17 @@ router.get('/', async (_req, res) => {
   }
 });
 
+// Atualiza o status de um pedido
+router.put('/:id/status', async (req, res) => {
+  const { status } = req.body;
+  const { id } = req.params;
+  try {
+    await db.query('UPDATE pedidos SET situacao = $1 WHERE id = $2', [status, id]);
+    res.json({ success: true });
+  } catch (err) {
+    console.error('Erro ao atualizar status do pedido:', err);
+    res.status(500).json({ error: 'Erro ao atualizar status do pedido' });
+  }
+});
+
 module.exports = router;


### PR DESCRIPTION
## Summary
- allow updating order status via API endpoint
- add UI confirmation and progression from production to delivery

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a86998e104832282d256c5864d61b0