### PR TITLE
Registrar datas de envio e entrega ao alterar status do pedido

### DIFF
--- a/backend/pedidoStatusDates.test.js
+++ b/backend/pedidoStatusDates.test.js
@@ -1,0 +1,66 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const express = require('express');
+const { newDb } = require('pg-mem');
+
+function setupDb() {
+  const db = newDb();
+  db.public.none(`
+    CREATE TABLE pedidos (
+      id integer primary key,
+      situacao text,
+      data_envio timestamp,
+      data_entrega timestamp
+    );
+  `);
+  return db;
+}
+
+test('PUT /api/pedidos/:id/status atualiza datas de envio e entrega', async () => {
+  const mem = setupDb();
+  const { Pool } = mem.adapters.createPg();
+  const pool = new Pool();
+
+  await pool.query(`INSERT INTO pedidos (id, situacao) VALUES (1, 'Em Produção');`);
+
+  const dbModulePath = require.resolve('./db');
+  require.cache[dbModulePath] = {
+    exports: {
+      query: (text, params) => pool.query(text, params),
+      connect: () => pool.connect()
+    }
+  };
+  delete require.cache[require.resolve('./pedidosController')];
+  const pedidosRouter = require('./pedidosController');
+
+  const app = express();
+  app.use(express.json());
+  app.use('/api/pedidos', pedidosRouter);
+  const server = app.listen(0);
+  await new Promise((resolve) => server.once('listening', resolve));
+  const port = server.address().port;
+
+  let res = await fetch(`http://localhost:${port}/api/pedidos/1/status`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ status: 'Enviado' })
+  });
+  assert.strictEqual(res.status, 200);
+  const { rows: afterSend } = await pool.query('SELECT data_envio, data_entrega FROM pedidos WHERE id=1');
+  assert(afterSend[0].data_envio);
+  assert.strictEqual(afterSend[0].data_entrega, null);
+  const envioDate = afterSend[0].data_envio;
+
+  res = await fetch(`http://localhost:${port}/api/pedidos/1/status`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ status: 'Entregue' })
+  });
+  assert.strictEqual(res.status, 200);
+  const { rows: afterDeliver } = await pool.query('SELECT data_envio, data_entrega FROM pedidos WHERE id=1');
+  assert(afterDeliver[0].data_entrega);
+  assert.strictEqual(afterDeliver[0].data_envio.toISOString(), envioDate.toISOString());
+
+  server.close();
+});
+

--- a/backend/pedidosController.js
+++ b/backend/pedidosController.js
@@ -25,7 +25,15 @@ router.put('/:id/status', async (req, res) => {
   const { status } = req.body;
   const { id } = req.params;
   try {
-    await db.query('UPDATE pedidos SET situacao = $1 WHERE id = $2', [status, id]);
+    const baseQuery = 'UPDATE pedidos SET situacao = $1';
+    let query = baseQuery;
+    if (status === 'Enviado') {
+      query += ', data_envio = NOW()';
+    } else if (status === 'Entregue') {
+      query += ', data_entrega = NOW()';
+    }
+    query += ' WHERE id = $2';
+    await db.query(query, [status, id]);
     res.json({ success: true });
   } catch (err) {
     console.error('Erro ao atualizar status do pedido:', err);


### PR DESCRIPTION
## Summary
- Atualiza `pedidosController` para gravar data de envio ou entrega ao mudar status.
- Adiciona testes verificando gravação das datas de envio e entrega.

## Testing
- `npm test` *(falhou: Cannot find module '/workspace/App-Gestao/backend')*
- `node --test backend/*.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a8730082508322a721c369a56b459a