### PR TITLE
Exibir Datas De Status Do Pedido Em Pop-Up Ao Passar O Mouse

### DIFF
--- a/backend/pedidoStatusDates.test.js
+++ b/backend/pedidoStatusDates.test.js
@@ -10,7 +10,9 @@ function setupDb() {
       id integer primary key,
       situacao text,
       data_envio timestamp,
-      data_entrega timestamp
+      data_entrega timestamp,
+      data_aprovacao timestamp,
+      data_cancelamento timestamp
     );
   `);
   return db;

--- a/backend/pedidosController.js
+++ b/backend/pedidosController.js
@@ -8,7 +8,11 @@ router.get('/', async (_req, res) => {
   try {
     const { rows } = await db.query(
       `SELECT p.id, p.numero, c.nome_fantasia AS cliente, to_char(p.data_emissao,'DD/MM/YYYY') AS data_emissao,
-              p.valor_final, p.parcelas, p.situacao, p.dono
+              p.valor_final, p.parcelas, p.situacao, p.dono,
+              to_char(p.data_aprovacao,'DD/MM/YYYY') AS data_aprovacao,
+              to_char(p.data_envio,'DD/MM/YYYY') AS data_envio,
+              to_char(p.data_entrega,'DD/MM/YYYY') AS data_entrega,
+              to_char(p.data_cancelamento,'DD/MM/YYYY') AS data_cancelamento
          FROM pedidos p
          LEFT JOIN clientes c ON c.id = p.cliente_id
         ORDER BY p.id DESC`

--- a/src/css/pedidos.css
+++ b/src/css/pedidos.css
@@ -332,3 +332,13 @@ input[type="date"]:valid::-webkit-datetime-edit {
 .toast-error { background-color: #dc2626; }
 .toast-info { background-color: #2563eb; }
 
+/* Tooltip de status */
+.status-tooltip {
+    position: absolute;
+    z-index: 50;
+    pointer-events: none;
+}
+.status-tooltip div + div {
+    margin-top: 0.25rem;
+}
+


### PR DESCRIPTION
## Summary
- add status date fields to pedido listing API
- show tooltip with status dates when hovering order status
- style tooltip for status date display

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a873e27ff88322b3ef1223912ea353