### PR TITLE
Implementar Ordenação De Insumos Em Produtos

### DIFF
--- a/backend/atualizarMateriaAtualizaProdutos.test.js
+++ b/backend/atualizarMateriaAtualizaProdutos.test.js
@@ -33,7 +33,8 @@ function setupDb() {
   db.public.none(`CREATE TABLE produtos_insumos (
     produto_codigo text,
     insumo_id int,
-    quantidade numeric
+    quantidade numeric,
+    ordem_insumo integer
   );`);
   return db;
 }
@@ -54,7 +55,7 @@ test('atualizarMateria atualiza precos de produtos relacionados', async () => {
 
   await pool.query(`INSERT INTO materia_prima (id, nome, categoria, quantidade, unidade, preco_unitario, processo, infinito, descricao, data_preco, data_estoque) VALUES (1,'Insumo A','Cat',0,'kg',10,'Proc',false,'desc',NOW(),NOW())`);
   await pool.query(`INSERT INTO produtos (codigo, pct_fabricacao, pct_acabamento, pct_montagem, pct_embalagem, pct_markup, pct_comissao, pct_imposto, preco_base, preco_venda, data) VALUES ('P1',10,5,0,0,20,5,10,0,0,NOW())`);
-  await pool.query(`INSERT INTO produtos_insumos (produto_codigo, insumo_id, quantidade) VALUES ('P1',1,2)`);
+  await pool.query(`INSERT INTO produtos_insumos (produto_codigo, insumo_id, quantidade, ordem_insumo) VALUES ('P1',1,2,1)`);
 
   await atualizarMateria(1, { nome:'Insumo A', categoria:'Cat', quantidade:0, unidade:'kg', preco_unitario:15, processo:'Proc', infinito:false, descricao:'desc' });
 

--- a/backend/atualizarPrecoMateriaPrima.test.js
+++ b/backend/atualizarPrecoMateriaPrima.test.js
@@ -26,7 +26,8 @@ function setupDb() {
   db.public.none(`CREATE TABLE produtos_insumos (
     produto_codigo text,
     insumo_id int,
-    quantidade numeric
+    quantidade numeric,
+    ordem_insumo integer
   );`);
   return db;
 }
@@ -51,7 +52,7 @@ test('atualizarPreco atualiza precos de produtos relacionados', async () => {
   await pool.query('INSERT INTO materia_prima (id, nome, preco_unitario, data_preco) VALUES (1, $1, 10, NOW())', ['Insumo A']);
   await pool.query(`INSERT INTO produtos (codigo, pct_fabricacao, pct_acabamento, pct_montagem, pct_embalagem, pct_markup, pct_comissao, pct_imposto, preco_base, preco_venda, data)
                     VALUES ('P1',10,5,0,0,20,5,10,0,0,NOW())`);
-  await pool.query(`INSERT INTO produtos_insumos (produto_codigo, insumo_id, quantidade) VALUES ('P1',1,2)`);
+  await pool.query(`INSERT INTO produtos_insumos (produto_codigo, insumo_id, quantidade, ordem_insumo) VALUES ('P1',1,2,1)`);
 
   await atualizarPreco(1, 15);
 

--- a/backend/excluirProduto.test.js
+++ b/backend/excluirProduto.test.js
@@ -10,7 +10,8 @@ function setup() {
   );`);
   db.public.none(`CREATE TABLE produtos_insumos (
     id serial primary key,
-    produto_codigo text
+    produto_codigo text,
+    ordem_insumo integer
   );`);
   db.public.none(`CREATE TABLE produtos_em_cada_ponto (
     id serial primary key,
@@ -21,7 +22,7 @@ function setup() {
     produto_id int
   );`);
   db.public.none("INSERT INTO produtos (id, codigo) VALUES (1, 'P001');");
-  db.public.none("INSERT INTO produtos_insumos (produto_codigo) VALUES ('P001');");
+  db.public.none("INSERT INTO produtos_insumos (produto_codigo, ordem_insumo) VALUES ('P001',1);");
   db.public.none('INSERT INTO produtos_em_cada_ponto (produto_id) VALUES (1);');
   const { Pool } = db.adapters.createPg();
   const pool = new Pool();

--- a/backend/produtosDuplicados.test.js
+++ b/backend/produtosDuplicados.test.js
@@ -26,7 +26,8 @@ function setup() {
     id serial primary key,
     produto_codigo text,
     insumo_id int,
-    quantidade numeric
+    quantidade numeric,
+    ordem_insumo integer
   );`);
   const { Pool } = db.adapters.createPg();
   const pool = new Pool();
@@ -77,7 +78,7 @@ test('atualizarProduto atualiza produtos_insumos ao mudar codigo', async () => {
     status: 'ativo'
   });
   await pool.query(
-    "INSERT INTO produtos_insumos (produto_codigo, insumo_id, quantidade) VALUES ('P1',1,1)"
+    "INSERT INTO produtos_insumos (produto_codigo, insumo_id, quantidade, ordem_insumo) VALUES ('P1',1,1,1)"
   );
   await atualizarProduto(id, {
     codigo: 'P2',

--- a/backend/salvarProdutoDetalhado.test.js
+++ b/backend/salvarProdutoDetalhado.test.js
@@ -24,6 +24,7 @@ function createMockDb() {
     produto_codigo text references produtos(codigo),
     insumo_id integer,
     quantidade numeric,
+    ordem_insumo integer,
     UNIQUE (produto_codigo, insumo_id)
   );`);
   db.public.none(`INSERT INTO produtos (codigo, pct_fabricacao, pct_acabamento, pct_montagem, pct_embalagem, pct_markup, pct_comissao, pct_imposto, preco_base, preco_venda)
@@ -52,7 +53,7 @@ test('salvarProdutoDetalhado preenche produto_codigo ao inserir insumo', async (
     preco_base: 10,
     preco_venda: 20
   }, {
-    inseridos: [{ insumo_id: 5, quantidade: 2 }]
+    inseridos: [{ insumo_id: 5, quantidade: 2, ordem_insumo: 1 }]
   });
 
   const res = await pool.query('SELECT produto_codigo FROM produtos_insumos');
@@ -70,7 +71,7 @@ test('salvarProdutoDetalhado atualiza codigo e mantém vínculos', async () => {
   delete require.cache[require.resolve('./produtos')];
   const { salvarProdutoDetalhado } = require('./produtos');
 
-  await pool.query('INSERT INTO produtos_insumos (produto_codigo, insumo_id, quantidade) VALUES ($1,$2,$3)', ['P001', 1, 1]);
+  await pool.query('INSERT INTO produtos_insumos (produto_codigo, insumo_id, quantidade, ordem_insumo) VALUES ($1,$2,$3,$4)', ['P001', 1, 1, 1]);
 
   await salvarProdutoDetalhado('P001', {
     pct_fabricacao: 0,
@@ -107,8 +108,8 @@ test('salvarProdutoDetalhado substitui insumo existente sem erro de duplicidade'
   const { salvarProdutoDetalhado } = require('./produtos');
 
   await pool.query(
-    'INSERT INTO produtos_insumos (produto_codigo, insumo_id, quantidade) VALUES ($1,$2,$3)',
-    ['P001', 7, 1]
+    'INSERT INTO produtos_insumos (produto_codigo, insumo_id, quantidade, ordem_insumo) VALUES ($1,$2,$3,$4)',
+    ['P001', 7, 1, 1]
   );
 
   await salvarProdutoDetalhado(
@@ -124,7 +125,7 @@ test('salvarProdutoDetalhado substitui insumo existente sem erro de duplicidade'
       preco_base: 0,
       preco_venda: 0
     },
-    { inseridos: [{ insumo_id: 7, quantidade: 5 }] }
+    { inseridos: [{ insumo_id: 7, quantidade: 5, ordem_insumo: 1 }] }
   );
 
   const { rows } = await pool.query(

--- a/src/html/modals/produtos/editar.html
+++ b/src/html/modals/produtos/editar.html
@@ -169,7 +169,13 @@
         <div class="glass-surface rounded-xl p-6 border border-white/10">
           <div class="flex items-center justify-between mb-4">
             <h3 class="text-lg font-semibold text-white">ITENS</h3>
-            <span id="totalInsumosTitulo" class="flex flex-wrap justify-end gap-2"></span>
+            <div class="flex items-center gap-4">
+              <span id="totalInsumosTitulo" class="flex flex-wrap justify-end gap-2"></span>
+              <label class="flex items-center gap-2 text-white text-sm">
+                confirmo posição produtiva de insumos
+                <input id="confirmarOrdemToggle" type="checkbox" class="component-toggle" />
+              </label>
+            </div>
           </div>
           <div class="glass-surface rounded-xl shadow-lg animate-fade-in-up mt-6 table-scroll">
               <table id="itensTabela" class="w-full text-sm">

--- a/src/html/modals/produtos/novo.html
+++ b/src/html/modals/produtos/novo.html
@@ -139,7 +139,13 @@
         <div class="glass-surface rounded-xl p-6 border border-white/10">
           <div class="flex items-center justify-between mb-4">
             <h3 class="text-lg font-semibold text-white">ITENS</h3>
-            <span id="totalInsumosTitulo" class="flex flex-wrap justify-end gap-2"></span>
+            <div class="flex items-center gap-4">
+              <span id="totalInsumosTitulo" class="flex flex-wrap justify-end gap-2"></span>
+              <label class="flex items-center gap-2 text-white text-sm">
+                confirmo posição produtiva de insumos
+                <input id="confirmarOrdemToggle" type="checkbox" class="component-toggle" />
+              </label>
+            </div>
           </div>
           <div class="glass-surface rounded-xl shadow-lg animate-fade-in-up mt-6 table-scroll">
             <table id="itensTabela" class="w-full text-sm">


### PR DESCRIPTION
## Summary
- adicionar coluna de ordem de insumo na persistência e consultas
- permitir reorganizar insumos por arraste com alça azul
- exigir confirmação da ordem antes de registrar, salvar ou clonar

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a889bc4c3c8322926a7a3f6d80cdd7