### PR TITLE
Fix Item Reordering Loss On Product Edit

### DIFF
--- a/src/js/modals/produto-editar.js
+++ b/src/js/modals/produto-editar.js
@@ -358,7 +358,7 @@
         ordered.forEach((r,idx)=>{
           const it = itens.find(i=>i.row===r);
           it.ordem = idx+1;
-          if(it.id) it.status = 'updated';
+          if(it.id && it.status !== 'new') it.status = 'updated';
         });
         updateProcessTotal(item.processo);
         updateTotals();
@@ -382,7 +382,7 @@
       itens = (data || []).map(d => ({
         ...d,
         quantidade: parseFloat(d.quantidade) || 0,
-        ordem: parseInt(d.ordem_insumo,10) || 0,
+        ordem: d.ordem !== undefined ? d.ordem : parseInt(d.ordem_insumo,10) || 0,
         status: d.status || 'unchanged'
       }));
 
@@ -474,7 +474,7 @@
           ordered.forEach((r,idx)=>{
             const it = itens.find(i=>i.row===r);
             it.ordem = idx+1;
-            if(it.id) it.status = 'updated';
+            if(it.id && it.status !== 'new') it.status = 'updated';
           });
           dragging = null;
         });


### PR DESCRIPTION
## Summary
- ensure new product items keep their order when inserted
- prevent new items from being treated as updates during reorder/delete

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8920a523883228169e6fe557624c5