### PR TITLE
Restaurar cores de ícones nas tabelas de produto

### DIFF
--- a/src/html/produtos.html
+++ b/src/html/produtos.html
@@ -108,11 +108,11 @@
 </div>
 
  <template id="action-icons-template">
-        <div class="flex items-center justify-center space-x-2">
-            <i class="fas fa-eye w-5 h-5 cursor-pointer p-1 rounded transition-colors duration-150 hover:bg-white/10" style="color: var(--color-pen)" title="Visualizar"></i>
-            <i class="fas fa-edit w-5 h-5 cursor-pointer p-1 rounded transition-colors duration-150 hover:bg-white/10" style="color: var(--color-pen)" title="Editar"></i>
-            <i class="fas fa-trash w-5 h-5 cursor-pointer p-1 rounded transition-colors duration-150 hover:bg-white/10 hover:text-white" style="color: var(--color-pen)" title="Excluir"></i>
-        </div>
+      <div class="flex items-center justify-center space-x-2">
+          <i class="fas fa-eye w-5 h-5 cursor-pointer p-1 rounded transition-colors duration-150 hover:bg-white/10" style="color: var(--color-primary)" title="Visualizar"></i>
+          <i class="fas fa-edit w-5 h-5 cursor-pointer p-1 rounded transition-colors duration-150 hover:bg-white/10" style="color: var(--color-primary)" title="Editar"></i>
+          <i class="fas fa-trash w-5 h-5 cursor-pointer p-1 rounded transition-colors duration-150 hover:bg-white/10 hover:text-white" style="color: var(--color-red)" title="Excluir"></i>
+      </div>
   </template>
   <script src="../utils/colorParser.js"></script>
   <script src="../utils/colors.js"></script>

--- a/src/js/modals/produto-editar.js
+++ b/src/js/modals/produto-editar.js
@@ -311,8 +311,8 @@
       actionCell.innerHTML = `
         <div class="flex items-center justify-center space-x-2">
           <i class="fas fa-bars w-5 h-5 cursor-move p-1 rounded drag-handle" style="color: var(--color-pen)" title="Reordenar"></i>
-          <i class="fas fa-edit w-5 h-5 cursor-pointer p-1 rounded transition-colors duration-150 hover:bg-white/10 edit-item" style="color: var(--color-pen)" title="Editar"></i>
-          <i class="fas fa-trash w-5 h-5 cursor-pointer p-1 rounded transition-colors duration-150 hover:bg-white/10 hover:text-white delete-item" style="color: var(--color-pen)" title="Excluir"></i>
+          <i class="fas fa-edit w-5 h-5 cursor-pointer p-1 rounded transition-colors duration-150 hover:bg-white/10 edit-item" style="color: var(--color-primary)" title="Editar"></i>
+          <i class="fas fa-trash w-5 h-5 cursor-pointer p-1 rounded transition-colors duration-150 hover:bg-white/10 hover:text-white delete-item" style="color: var(--color-red)" title="Excluir"></i>
         </div>`;
       actionCell.querySelector('.edit-item').addEventListener('click', () => startEdit(item));
       actionCell.querySelector('.delete-item').addEventListener('click', () => startDelete(item));

--- a/src/js/modals/produto-novo.js
+++ b/src/js/modals/produto-novo.js
@@ -128,8 +128,8 @@
       cell.innerHTML = `
         <div class="flex items-center justify-center space-x-2">
           <i class="fas fa-bars w-5 h-5 cursor-move p-1 rounded drag-handle" style="color: var(--color-pen)" title="Reordenar"></i>
-          <i class="fas fa-edit w-5 h-5 cursor-pointer p-1 rounded transition-colors duration-150 hover:bg-white/10 edit-item" style="color: var(--color-pen)" title="Editar"></i>
-          <i class="fas fa-trash w-5 h-5 cursor-pointer p-1 rounded transition-colors duration-150 hover:bg-white/10 hover:text-white delete-item" style="color: var(--color-pen)" title="Excluir"></i>
+          <i class="fas fa-edit w-5 h-5 cursor-pointer p-1 rounded transition-colors duration-150 hover:bg-white/10 edit-item" style="color: var(--color-primary)" title="Editar"></i>
+          <i class="fas fa-trash w-5 h-5 cursor-pointer p-1 rounded transition-colors duration-150 hover:bg-white/10 hover:text-white delete-item" style="color: var(--color-red)" title="Excluir"></i>
         </div>`;
     cell.querySelector('.edit-item').addEventListener('click', () => startEdit(item));
     cell.querySelector('.delete-item').addEventListener('click', () => startDelete(item));


### PR DESCRIPTION
## Summary
- Restore original color scheme for product table action icons
- Keep drag handle icon blue while reverting edit and delete icons

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a893333c648322b21a4605e77b959d