### PR TITLE
Ocultar Botão Confirmar Ordem Até Registrar Ou Salvar

### DIFF
--- a/src/html/modals/produtos/editar.html
+++ b/src/html/modals/produtos/editar.html
@@ -188,9 +188,18 @@
               </table>
           </div>
           <div class="mt-6 flex justify-center">
-            <button id="confirmarOrdemBtn" type="button" class="confirmar-ordem-btn">
-              CONFIRMO POSIÇÃO PRODUTIVA DE CADA INSUMO
-            </button>
+            <div id="confirmarOrdemContainer" class="relative inline-block hidden">
+              <button id="confirmarOrdemBtn" type="button" class="confirmar-ordem-btn">
+                CONFIRMO POSIÇÃO PRODUTIVA DE CADA INSUMO
+              </button>
+              <div class="absolute top-1/2 right-0 transform translate-x-full -translate-y-1/2 ml-2 group">
+                <i class="fas fa-info-circle text-white cursor-pointer"></i>
+                <div class="hidden group-hover:block absolute top-1/2 left-full transform -translate-y-1/2 ml-2 w-72 p-4 glass-surface border border-white/10 rounded-lg text-xs text-white z-10">
+                  <h4 class="font-semibold mb-2">Botão de Extrema Importância</h4>
+                  <p>Para que o programa funcione corretamente cada insumo tem sua ordem para ser feito na produção da peça vinda de cenários reais. Por isso, deve ser colocada de maneira realmente certa - pelo amor de Deus, CONFIRA pois erros nessa ordem gerarão PROBELMAS, não de funcionamento, mas de relatórios utilizados na REALIDADE DIÁRIA DA EMPRESA,  podendo ser editada na própria tabela clicando no ícone das três barras e arrastando o item. Esse confirma que está tudo conferido e conforme a realidade, permitindo o registro do produto. Caso haja algum erro após registro, não se preocupe, pode ser editado em editar peça.</p>
+                </div>
+              </div>
+            </div>
           </div>
           <!-- Observações removidas -->
         </div>

--- a/src/html/modals/produtos/novo.html
+++ b/src/html/modals/produtos/novo.html
@@ -157,9 +157,18 @@
             </table>
           </div>
           <div class="mt-6 flex justify-center">
-            <button id="confirmarOrdemBtn" type="button" class="confirmar-ordem-btn">
-              CONFIRMO POSIÇÃO PRODUTIVA DE CADA INSUMO
-            </button>
+            <div id="confirmarOrdemContainer" class="relative inline-block hidden">
+              <button id="confirmarOrdemBtn" type="button" class="confirmar-ordem-btn">
+                CONFIRMO POSIÇÃO PRODUTIVA DE CADA INSUMO
+              </button>
+              <div class="absolute top-1/2 right-0 transform translate-x-full -translate-y-1/2 ml-2 group">
+                <i class="fas fa-info-circle text-white cursor-pointer"></i>
+                <div class="hidden group-hover:block absolute top-1/2 left-full transform -translate-y-1/2 ml-2 w-72 p-4 glass-surface border border-white/10 rounded-lg text-xs text-white z-10">
+                  <h4 class="font-semibold mb-2">Botão de Extrema Importância</h4>
+                  <p>Para que o programa funcione corretamente cada insumo tem sua ordem para ser feito na produção da peça vinda de cenários reais. Por isso, deve ser colocada de maneira realmente certa - pelo amor de Deus, CONFIRA pois erros nessa ordem gerarão PROBELMAS, não de funcionamento, mas de relatórios utilizados na REALIDADE DIÁRIA DA EMPRESA,  podendo ser editada na própria tabela clicando no ícone das três barras e arrastando o item. Esse confirma que está tudo conferido e conforme a realidade, permitindo o registro do produto. Caso haja algum erro após registro, não se preocupe, pode ser editado em editar peça.</p>
+                </div>
+              </div>
+            </div>
           </div>
           <!-- Observações removidas -->
         </div>

--- a/src/js/modals/produto-editar.js
+++ b/src/js/modals/produto-editar.js
@@ -234,9 +234,11 @@
     const totals = {};
     const processOrder = [];
     let etapasOrdem = [];
+    const ordemContainer = document.getElementById('confirmarOrdemContainer');
     const ordemBtn = document.getElementById('confirmarOrdemBtn');
     let ordemConfirmada = false;
     if (ordemBtn) {
+      ordemContainer?.classList.add('hidden');
       ordemBtn.addEventListener('click', () => {
         ordemConfirmada = !ordemConfirmada;
         ordemBtn.classList.toggle('active', ordemConfirmada);
@@ -553,6 +555,10 @@
       clonarBtn.addEventListener('click', async () => {
         try {
           if(!ordemConfirmada){
+            if(ordemContainer){
+              ordemContainer.classList.remove('hidden');
+              ordemContainer.scrollIntoView({ behavior: 'smooth', block: 'end' });
+            }
             if(typeof showToast === 'function') showToast('Confirme a posição produtiva de insumos', 'error');
             return;
           }
@@ -610,6 +616,10 @@
       form.addEventListener('submit', async e => {
         e.preventDefault();
         if(!ordemConfirmada){
+          if(ordemContainer){
+            ordemContainer.classList.remove('hidden');
+            ordemContainer.scrollIntoView({ behavior: 'smooth', block: 'end' });
+          }
           if(typeof showToast === 'function') showToast('Confirme a posição produtiva de insumos', 'error');
           return;
         }

--- a/src/js/modals/produto-novo.js
+++ b/src/js/modals/produto-novo.js
@@ -107,9 +107,11 @@
   }
 
   const tableBody = document.querySelector('#itensTabela tbody');
+  const ordemContainer = document.getElementById('confirmarOrdemContainer');
   const ordemBtn = document.getElementById('confirmarOrdemBtn');
   let ordemConfirmada = false;
   if (ordemBtn) {
+    ordemContainer?.classList.add('hidden');
     ordemBtn.addEventListener('click', () => {
       ordemConfirmada = !ordemConfirmada;
       ordemBtn.classList.toggle('active', ordemConfirmada);
@@ -322,6 +324,10 @@
   form.addEventListener('submit', async e => {
     e.preventDefault();
     if(!ordemConfirmada){
+      if(ordemContainer){
+        ordemContainer.classList.remove('hidden');
+        ordemContainer.scrollIntoView({ behavior: 'smooth', block: 'end' });
+      }
       if(typeof showToast === 'function') showToast('Confirme a posição produtiva de insumos', 'error');
       return;
     }


### PR DESCRIPTION
## Summary
- esconder botão de confirmação de ordem até tentativa de registrar ou salvar
- adicionar ícone informativo [i] com tooltip explicativo ao lado do botão
- rolar página automaticamente ao mostrar botão quando não confirmado

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8965bc0e08322842201566591bfc4