### PR TITLE
Afastar ícone do botão de confirmar e ajustar pop up

### DIFF
--- a/src/html/modals/produtos/editar.html
+++ b/src/html/modals/produtos/editar.html
@@ -192,11 +192,11 @@
               <button id="confirmarOrdemBtn" type="button" class="confirmar-ordem-btn">
                 CONFIRMO POSIÇÃO PRODUTIVA DE CADA INSUMO
               </button>
-              <div class="absolute top-1/2 right-0 transform translate-x-full -translate-y-1/2 ml-2 group">
+              <div class="absolute top-1/2 right-0 transform translate-x-full -translate-y-1/2 ml-4 group">
                 <i class="fas fa-info-circle text-white cursor-pointer"></i>
-                <div class="hidden group-hover:block absolute top-1/2 left-full transform -translate-y-1/2 ml-2 w-72 p-4 glass-surface border border-white/10 rounded-lg text-xs text-white z-10">
-                  <h4 class="font-semibold mb-2">Botão de Extrema Importância</h4>
-                  <p>Para que o programa funcione corretamente cada insumo tem sua ordem para ser feito na produção da peça vinda de cenários reais. Por isso, deve ser colocada de maneira realmente certa - pelo amor de Deus, CONFIRA pois erros nessa ordem gerarão PROBELMAS, não de funcionamento, mas de relatórios utilizados na REALIDADE DIÁRIA DA EMPRESA,  podendo ser editada na própria tabela clicando no ícone das três barras e arrastando o item. Esse confirma que está tudo conferido e conforme a realidade, permitindo o registro do produto. Caso haja algum erro após registro, não se preocupe, pode ser editado em editar peça.</p>
+                <div class="hidden group-hover:block absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 w-72 p-4 bg-black rounded-lg text-base text-white z-10">
+                  <h4 class="font-bold text-red-500 mb-2 text-xl uppercase">Botão de Extrema Importância</h4>
+                  <p>Para que o programa funcione corretamente cada insumo tem sua ordem para ser feito na produção da peça vinda de cenários reais. Por isso, deve ser colocada de maneira realmente certa - pelo amor de Deus, <span class="font-bold text-red-500">CONFIRA</span> pois erros nessa ordem gerarão <span class="font-bold text-red-500">PROBELMAS</span>, não de funcionamento, mas de relatórios utilizados na <span class="font-bold text-red-500">REALIDADE DIÁRIA DA EMPRESA</span>,  podendo ser editada na própria tabela clicando no ícone das três barras e arrastando o item. Esse confirma que está tudo conferido e conforme a realidade, permitindo o registro do produto. Caso haja algum erro após registro, não se preocupe, pode ser editado em editar peça.</p>
                 </div>
               </div>
             </div>

--- a/src/html/modals/produtos/novo.html
+++ b/src/html/modals/produtos/novo.html
@@ -161,11 +161,11 @@
               <button id="confirmarOrdemBtn" type="button" class="confirmar-ordem-btn">
                 CONFIRMO POSIÇÃO PRODUTIVA DE CADA INSUMO
               </button>
-              <div class="absolute top-1/2 right-0 transform translate-x-full -translate-y-1/2 ml-2 group">
+              <div class="absolute top-1/2 right-0 transform translate-x-full -translate-y-1/2 ml-4 group">
                 <i class="fas fa-info-circle text-white cursor-pointer"></i>
-                <div class="hidden group-hover:block absolute top-1/2 left-full transform -translate-y-1/2 ml-2 w-72 p-4 glass-surface border border-white/10 rounded-lg text-xs text-white z-10">
-                  <h4 class="font-semibold mb-2">Botão de Extrema Importância</h4>
-                  <p>Para que o programa funcione corretamente cada insumo tem sua ordem para ser feito na produção da peça vinda de cenários reais. Por isso, deve ser colocada de maneira realmente certa - pelo amor de Deus, CONFIRA pois erros nessa ordem gerarão PROBELMAS, não de funcionamento, mas de relatórios utilizados na REALIDADE DIÁRIA DA EMPRESA,  podendo ser editada na própria tabela clicando no ícone das três barras e arrastando o item. Esse confirma que está tudo conferido e conforme a realidade, permitindo o registro do produto. Caso haja algum erro após registro, não se preocupe, pode ser editado em editar peça.</p>
+                <div class="hidden group-hover:block absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 w-72 p-4 bg-black rounded-lg text-base text-white z-10">
+                  <h4 class="font-bold text-red-500 mb-2 text-xl uppercase">Botão de Extrema Importância</h4>
+                  <p>Para que o programa funcione corretamente cada insumo tem sua ordem para ser feito na produção da peça vinda de cenários reais. Por isso, deve ser colocada de maneira realmente certa - pelo amor de Deus, <span class="font-bold text-red-500">CONFIRA</span> pois erros nessa ordem gerarão <span class="font-bold text-red-500">PROBELMAS</span>, não de funcionamento, mas de relatórios utilizados na <span class="font-bold text-red-500">REALIDADE DIÁRIA DA EMPRESA</span>,  podendo ser editada na própria tabela clicando no ícone das três barras e arrastando o item. Esse confirma que está tudo conferido e conforme a realidade, permitindo o registro do produto. Caso haja algum erro após registro, não se preocupe, pode ser editado em editar peça.</p>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- Afasta ícone informativo do botão de confirmação
- Ajusta tooltip para surgir acima com fundo preto e texto em destaque

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8999bafac83228d587507f8dd39db