### PR TITLE
Implement Modal De Detalhes Do Cliente - via Codex

### DIFF
--- a/src/css/clientes.css
+++ b/src/css/clientes.css
@@ -7,6 +7,8 @@
     --color-bordeaux: #6a152c;
     --color-bg-deep: #310017;
     --color-surface: rgba(255,255,255,0.08);
+    --color-input: rgba(0,0,0,0.3);
+    --color-inputBorder: rgba(255,255,255,0.15);
     --color-green: #a2ffa6;
     --color-red: #ff5858;
     --color-blue: #8aa7f3;
@@ -124,3 +126,25 @@ body {
 #bt-actions {
     margin-top: 1vw;
 }
+
+.text-primary { color: var(--color-primary); }
+.bg-input { background: var(--color-input); }
+.border-inputBorder { border-color: var(--color-inputBorder); }
+.focus\:border-primary:focus { border-color: var(--color-primary); }
+.focus\:ring-primary\/50:focus { box-shadow: 0 0 0 2px rgba(182,160,62,0.5); }
+.select-arrow {
+    background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 20 20'%3e%3cpath stroke='%236b7280' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='m6 8 4 4 4-4'/%3e%3c/svg%3e");
+    background-position: right 0.5rem center;
+    background-repeat: no-repeat;
+    background-size: 1.5em 1.5em;
+    padding-right: 2.5rem;
+}
+.tab-active {
+    color: var(--color-primary) !important;
+    border-bottom-color: var(--color-primary) !important;
+}
+.animate-modalFade { animation: modalFade 0.3s ease-out forwards; }
+.slide-in { animation: slideIn 0.3s ease-out forwards; }
+@keyframes modalFade { from { opacity: 0; } to { opacity: 1; } }
+@keyframes slideIn { from { transform: translateY(16px); opacity: 0; } to { transform: translateY(0); opacity: 1; } }
+

--- a/src/html/modals/clientes/detalhes.html
+++ b/src/html/modals/clientes/detalhes.html
@@ -1,0 +1,222 @@
+<div id="detalhesClienteOverlay" class="hidden fixed inset-0 bg-black/50 flex items-center justify-center p-4">
+  <div class="w-full max-w-6xl max-h-[90vh] glass-surface backdrop-blur-xl rounded-3xl border border-white/10 ring-1 ring-white/5 shadow-2xl/40 animate-modalFade slide-in overflow-hidden flex flex-col">
+    <header class="flex items-center justify-between px-8 py-5 border-b border-white/10 flex-shrink-0">
+      <button id="voltarDetalhesCliente" class="btn-neutral px-4 py-2 rounded-lg text-white font-medium flex items-center gap-2">← Voltar</button>
+      <h2 id="clienteDetalhesTitulo" class="text-lg font-semibold text-white">Detalhes – João Silva Ltda</h2>
+      <button class="btn-primary px-6 py-2 rounded-lg text-white font-medium">Salvar</button>
+    </header>
+
+    <nav class="px-8 border-b border-white/10 flex-shrink-0" role="tablist">
+      <div class="flex gap-8 overflow-x-auto scrollbar-hide">
+        <button id="tab-dados-empresa" role="tab" aria-selected="true" aria-controls="panel-dados-empresa" tabindex="0" class="py-4 px-2 text-sm font-medium border-b-2 tab-active whitespace-nowrap transition">Dados Empresa</button>
+        <button id="tab-contatos" role="tab" aria-selected="false" aria-controls="panel-contatos" tabindex="-1" class="py-4 px-2 text-sm font-medium text-gray-400 border-b-2 border-transparent hover:text-white transition whitespace-nowrap">Contatos</button>
+        <button id="tab-enderecos" role="tab" aria-selected="false" aria-controls="panel-enderecos" tabindex="-1" class="py-4 px-2 text-sm font-medium text-gray-400 border-b-2 border-transparent hover:text-white transition whitespace-nowrap">Endereços</button>
+        <button id="tab-ordens" role="tab" aria-selected="false" aria-controls="panel-ordens" tabindex="-1" class="py-4 px-2 text-sm font-medium text-gray-400 border-b-2 border-transparent hover:text-white transition whitespace-nowrap">Ordens</button>
+        <button id="tab-notas" role="tab" aria-selected="false" aria-controls="panel-notas" tabindex="-1" class="py-4 px-2 text-sm font-medium text-gray-400 border-b-2 border-transparent hover:text-white transition whitespace-nowrap">Notas</button>
+      </div>
+    </nav>
+
+    <div class="flex-1 overflow-y-auto modal-scroll">
+      <section id="panel-dados-empresa" role="tabpanel" aria-labelledby="tab-dados-empresa" class="px-8 py-6">
+        <div class="grid grid-cols-1 md:grid-cols-12 gap-8">
+          <div class="md:col-span-3 flex flex-col items-center">
+            <div class="w-32 h-32 glass-surface rounded-full flex items-center justify-center text-4xl font-bold text-primary border-2 border-primary/20">JS</div>
+            <button class="mt-4 btn-neutral px-4 py-2 rounded-lg text-white text-sm">Trocar</button>
+          </div>
+          <div class="md:col-span-9">
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+              <div>
+                <label class="block text-sm font-medium text-gray-300 mb-2">Razão Social</label>
+                <input type="text" placeholder="João Silva Comércio Ltda" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+              </div>
+              <div>
+                <label class="block text-sm font-medium text-gray-300 mb-2">Nome Fantasia</label>
+                <input type="text" placeholder="Silva & Cia" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+              </div>
+              <div>
+                <label class="block text-sm font-medium text-gray-300 mb-2">CNPJ</label>
+                <input type="text" placeholder="00.000.000/0001-00" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+              </div>
+              <div>
+                <label class="block text-sm font-medium text-gray-300 mb-2">Segmento</label>
+                <select class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition select-arrow appearance-none">
+                  <option value="">Selecione o segmento</option>
+                  <option value="varejo">Varejo</option>
+                  <option value="atacado">Atacado</option>
+                  <option value="servicos">Serviços</option>
+                  <option value="industria">Indústria</option>
+                </select>
+              </div>
+              <div>
+                <label class="block text-sm font-medium text-gray-300 mb-2">Inscrição Estadual</label>
+                <input type="text" placeholder="000.000.000.000" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+              </div>
+              <div>
+                <label class="block text-sm font-medium text-gray-300 mb-2">Site</label>
+                <input type="url" placeholder="https://www.exemplo.com.br" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section id="panel-contatos" role="tabpanel" aria-labelledby="tab-contatos" class="px-8 py-6 hidden">
+        <div class="flex justify-between items-center mb-6">
+          <h3 class="text-lg font-semibold text-white">Contatos</h3>
+          <button class="btn-primary px-4 py-2 rounded-lg text-white font-medium">+ Novo Contato</button>
+        </div>
+        <div class="glass-surface rounded-xl border border-white/10 overflow-hidden">
+          <div class="overflow-x-auto">
+            <table class="w-full text-sm">
+              <thead class="glass-surface">
+                <tr class="border-b border-white/10">
+                  <th class="text-left py-4 px-4 text-gray-300 font-medium">NOME</th>
+                  <th class="text-left py-4 px-4 text-gray-300 font-medium">CARGO</th>
+                  <th class="text-left py-4 px-4 text-gray-300 font-medium">E-MAIL</th>
+                  <th class="text-left py-4 px-4 text-gray-300 font-medium">TEL. CELULAR</th>
+                  <th class="text-left py-4 px-4 text-gray-300 font-medium">TEL. FIXO</th>
+                  <th class="text-center py-4 px-4 text-gray-300 font-medium">AÇÕES</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td colspan="6" class="py-12 text-center text-gray-400">Nenhum contato cadastrado</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </section>
+
+      <section id="panel-enderecos" role="tabpanel" aria-labelledby="tab-enderecos" class="px-8 py-6 hidden">
+        <div class="mb-8">
+          <h3 class="text-lg font-semibold text-white mb-4">Endereço de Registro</h3>
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div class="md:col-span-2">
+              <label class="block text-sm font-medium text-gray-300 mb-2">Rua</label>
+              <input type="text" placeholder="Nome da rua" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-300 mb-2">Número</label>
+              <input type="text" placeholder="123" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-300 mb-2">Complemento</label>
+              <input type="text" placeholder="Sala 101" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-300 mb-2">Bairro</label>
+              <input type="text" placeholder="Centro" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-300 mb-2">Cidade</label>
+              <input type="text" placeholder="São Paulo" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-300 mb-2">Estado</label>
+              <select class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition select-arrow appearance-none">
+                <option value="">Selecione</option>
+                <option value="SP">São Paulo</option>
+                <option value="RJ">Rio de Janeiro</option>
+                <option value="MG">Minas Gerais</option>
+              </select>
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-300 mb-2">CEP</label>
+              <input type="text" placeholder="00000-000" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+            </div>
+          </div>
+        </div>
+
+        <div class="mb-8">
+          <div class="flex items-center justify-between mb-4">
+            <h3 class="text-lg font-semibold text-white">Endereço de Cobrança</h3>
+            <label class="flex items-center gap-2">
+              <input type="checkbox" class="text-primary focus:ring-primary/50" />
+              <span class="text-sm text-gray-300">Igual ao de Registro</span>
+            </label>
+          </div>
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-4 opacity-50">
+            <div class="md:col-span-2">
+              <label class="block text-sm font-medium text-gray-300 mb-2">Rua</label>
+              <input type="text" disabled class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-300 mb-2">Número</label>
+              <input type="text" disabled class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-300 mb-2">Complemento</label>
+              <input type="text" disabled class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+            </div>
+          </div>
+        </div>
+
+        <div>
+          <div class="flex items-center justify-between mb-4">
+            <h3 class="text-lg font-semibold text-white">Endereço de Entrega</h3>
+            <label class="flex items-center gap-2">
+              <input type="checkbox" class="text-primary focus:ring-primary/50" />
+              <span class="text-sm text-gray-300">Igual ao de Registro</span>
+            </label>
+          </div>
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-4 opacity-50">
+            <div class="md:col-span-2">
+              <label class="block text-sm font-medium text-gray-300 mb-2">Rua</label>
+              <input type="text" disabled class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-300 mb-2">Número</label>
+              <input type="text" disabled class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-300 mb-2">Complemento</label>
+              <input type="text" disabled class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section id="panel-ordens" role="tabpanel" aria-labelledby="tab-ordens" class="px-8 py-6 hidden">
+        <div class="flex justify-between items-center mb-6">
+          <h3 class="text-lg font-semibold text-white">Ordens</h3>
+          <button class="btn-primary px-4 py-2 rounded-lg text-white font-medium">+ Nova Ordem</button>
+        </div>
+        <div class="glass-surface rounded-xl border border-white/10 overflow-hidden">
+          <div class="overflow-x-auto">
+            <table class="w-full text-sm">
+              <thead class="glass-surface">
+                <tr class="border-b border-white/10">
+                  <th class="text-left py-4 px-4 text-gray-300 font-medium">Nº ORDEM</th>
+                  <th class="text-left py-4 px-4 text-gray-300 font-medium">TIPO</th>
+                  <th class="text-left py-4 px-4 text-gray-300 font-medium">INÍCIO</th>
+                  <th class="text-left py-4 px-4 text-gray-300 font-medium">FIM</th>
+                  <th class="text-right py-4 px-4 text-gray-300 font-medium">VALOR</th>
+                  <th class="text-center py-4 px-4 text-gray-300 font-medium">STATUS</th>
+                  <th class="text-center py-4 px-4 text-gray-300 font-medium">AÇÕES</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td colspan="7" class="py-12 text-center text-gray-400">Criar no banco de dados</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </section>
+
+      <section id="panel-notas" role="tabpanel" aria-labelledby="tab-notas" class="px-8 py-6 hidden">
+        <div>
+          <label class="block text-sm font-medium text-gray-300 mb-2">Observações</label>
+          <textarea rows="12" placeholder="Digite suas observações sobre o cliente..." class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition resize-none"></textarea>
+        </div>
+      </section>
+    </div>
+
+    <footer class="flex justify-end items-center gap-4 px-8 py-5 border-t border-white/10 flex-shrink-0">
+      <button class="btn-neutral px-6 py-2 rounded-lg text-white font-medium min-w-[120px]">Cancelar</button>
+      <button class="btn-primary px-6 py-2 rounded-lg text-white font-medium min-w-[120px]">Salvar</button>
+    </footer>
+  </div>
+</div>

--- a/src/js/clientes.js
+++ b/src/js/clientes.js
@@ -100,8 +100,18 @@ function renderClientes(clientes) {
                     <i class="fas fa-trash w-5 h-5 cursor-pointer p-1 rounded transition-colors duration-150 hover:bg-white/10" style="color: var(--color-red)" title="Excluir"></i>
                 </div>
             </td>`;
+        const eyeBtn = tr.querySelector('.fa-eye');
+        if (eyeBtn) eyeBtn.addEventListener('click', (e) => {
+            e.stopPropagation();
+            abrirDetalhesCliente(c);
+        });
         tbody.appendChild(tr);
     });
+}
+
+function abrirDetalhesCliente(cliente) {
+    window.clienteDetalhes = cliente;
+    Modal.open('modals/clientes/detalhes.html', '../js/modals/cliente-detalhes.js', 'detalhesCliente');
 }
 
 function renderTotais(clientes) {

--- a/src/js/modals/cliente-detalhes.js
+++ b/src/js/modals/cliente-detalhes.js
@@ -1,0 +1,86 @@
+(function(){
+  const overlay = document.getElementById('detalhesClienteOverlay');
+  if(!overlay) return;
+  const close = () => Modal.close('detalhesCliente');
+  overlay.addEventListener('click', e => { if(e.target === overlay) close(); });
+  const voltar = document.getElementById('voltarDetalhesCliente');
+  if(voltar) voltar.addEventListener('click', close);
+  document.addEventListener('keydown', function esc(e){ if(e.key==='Escape'){ close(); document.removeEventListener('keydown', esc); }});
+
+  const cliente = window.clienteDetalhes;
+  if(cliente){
+    const titulo = document.getElementById('clienteDetalhesTitulo');
+    if(titulo) titulo.textContent = `Detalhes – ${cliente.nome_fantasia || ''}`;
+  }
+
+  const tablist = overlay.querySelector('[role="tablist"]');
+  const tabs = Array.from(overlay.querySelectorAll('[role="tab"]'));
+  const panels = Array.from(overlay.querySelectorAll('[role="tabpanel"]'));
+
+  function activateTab(targetTab, { setFocus = true } = {}) {
+    tabs.forEach(tab => {
+      tab.setAttribute('aria-selected', 'false');
+      tab.setAttribute('tabindex', '-1');
+      tab.classList.remove('tab-active');
+      tab.classList.add('text-gray-400', 'border-transparent');
+      tab.classList.remove('hover:text-white');
+    });
+    panels.forEach(panel => panel.classList.add('hidden'));
+    targetTab.setAttribute('aria-selected', 'true');
+    targetTab.setAttribute('tabindex', '0');
+    targetTab.classList.add('tab-active');
+    targetTab.classList.remove('text-gray-400', 'border-transparent');
+    targetTab.classList.add('hover:text-white');
+    const targetPanel = overlay.querySelector('#'+targetTab.getAttribute('aria-controls'));
+    if(targetPanel) targetPanel.classList.remove('hidden');
+    if(setFocus) targetTab.focus();
+    localStorage.setItem('clientDetailsTab', targetTab.id);
+  }
+
+  tabs.forEach(tab => {
+    tab.addEventListener('click', e => {
+      e.preventDefault();
+      activateTab(tab);
+    });
+  });
+
+  if(tablist){
+    tablist.addEventListener('keydown', e => {
+      const currentIndex = tabs.findIndex(t => t === document.activeElement);
+      let targetIndex;
+      switch(e.key){
+        case 'ArrowRight':
+          e.preventDefault();
+          targetIndex = currentIndex < tabs.length - 1 ? currentIndex + 1 : 0;
+          activateTab(tabs[targetIndex]);
+          break;
+        case 'ArrowLeft':
+          e.preventDefault();
+          targetIndex = currentIndex > 0 ? currentIndex - 1 : tabs.length - 1;
+          activateTab(tabs[targetIndex]);
+          break;
+        case 'Home':
+          e.preventDefault();
+          activateTab(tabs[0]);
+          break;
+        case 'End':
+          e.preventDefault();
+          activateTab(tabs[tabs.length - 1]);
+          break;
+        case 'Enter':
+        case ' ': 
+          e.preventDefault();
+          if(currentIndex >= 0) activateTab(tabs[currentIndex]);
+          break;
+      }
+    });
+  }
+
+  const savedTabId = localStorage.getItem('clientDetailsTab');
+  let initialTab = tabs[0];
+  if(savedTabId){
+    const savedTab = overlay.querySelector('#'+savedTabId);
+    if(savedTab && tabs.includes(savedTab)) initialTab = savedTab;
+  }
+  activateTab(initialTab, { setFocus: false });
+})();


### PR DESCRIPTION
## Summary
- add client details modal with tabbed layout and placeholder sections
- wire clients table eye action to open details modal
- extend client styles for new modal components

## Testing
- `npm test` (failed: test failed)


------
https://chatgpt.com/codex/tasks/task_e_68acc5dffc5c8322aa6b1c19db5a00af