### PR TITLE
Prevent Sidebar Expansion On CRM Submenu Toggle

### DIFF
--- a/src/js/menu.js
+++ b/src/js/menu.js
@@ -103,7 +103,7 @@ function toggleCrmSubmenu() {
     if (crmExpanded) {
         crmSubmenu.classList.add('open');
         chevron.classList.add('rotated');
-        if (!sidebarExpanded) expandSidebar();
+        // CRM submenu should not trigger sidebar expansion
     } else {
         crmSubmenu.classList.remove('open');
         chevron.classList.remove('rotated');


### PR DESCRIPTION
## Summary
- avoid sidebar auto-expand when CRM submenu is toggled

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68acca02e6d8832293675056fe128e34