### PR TITLE
Ensure sidebar icon text appears when expanded

### DIFF
--- a/src/js/menu.js
+++ b/src/js/menu.js
@@ -62,11 +62,14 @@ function expandSidebar() {
         if (companyName) companyName.classList.remove('collapsed');
 
         // Aguarda a animação de expansão finalizar para exibir o texto
+        const showText = () => sidebar.classList.add('sidebar-text-visible');
         sidebar.addEventListener('transitionend', (e) => {
             if (e.propertyName === 'width') {
-                sidebar.classList.add('sidebar-text-visible');
+                showText();
             }
         }, { once: true });
+        // Fallback caso o evento transitionend não seja disparado
+        setTimeout(showText, 300);
 
         sidebarExpanded = true;
     }


### PR DESCRIPTION
## Summary
- ensure sidebar text becomes visible even if `transitionend` fails by adding fallback timeout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68accc0765d883228dcd1a459b9029c9