### PR TITLE
Modal Detalhes De Contatos Com Dados Do Banco

### DIFF
--- a/backend/orcamentosController.js
+++ b/backend/orcamentosController.js
@@ -71,16 +71,22 @@ async function converterParaPedido(orcamentoId) {
   }
 }
 
-// Lista todos os orçamentos
-router.get('/', async (_req, res) => {
+// Lista orçamentos com filtro opcional por cliente
+router.get('/', async (req, res) => {
+  const { clienteId } = req.query;
   try {
-    const { rows } = await db.query(
+    let query =
       `SELECT o.id, o.numero, c.nome_fantasia AS cliente, to_char(o.data_emissao,'DD/MM/YYYY') AS data_emissao,
               o.valor_final, o.parcelas, o.situacao, o.dono
          FROM orcamentos o
-         LEFT JOIN clientes c ON c.id = o.cliente_id
-        ORDER BY o.id DESC`
-    );
+         LEFT JOIN clientes c ON c.id = o.cliente_id`;
+    const params = [];
+    if (clienteId) {
+      params.push(clienteId);
+      query += ' WHERE o.cliente_id = $1';
+    }
+    query += ' ORDER BY o.id DESC';
+    const { rows } = await db.query(query, params);
     res.json(rows);
   } catch (err) {
     console.error('Erro ao listar orçamentos:', err);

--- a/src/html/modals/clientes/detalhes.html
+++ b/src/html/modals/clientes/detalhes.html
@@ -78,7 +78,7 @@
                   <th class="text-center py-4 px-4 text-gray-300 font-medium">AÇÕES</th>
                 </tr>
               </thead>
-              <tbody>
+              <tbody id="contatosTabela">
                 <tr>
                   <td colspan="6" class="py-12 text-center text-gray-400">Nenhum contato cadastrado</td>
                 </tr>
@@ -94,27 +94,27 @@
           <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div class="md:col-span-2">
               <label class="block text-sm font-medium text-gray-300 mb-2">Rua</label>
-              <input type="text" placeholder="Nome da rua" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+              <input id="regRua" type="text" placeholder="Nome da rua" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
             </div>
             <div>
               <label class="block text-sm font-medium text-gray-300 mb-2">Número</label>
-              <input type="text" placeholder="123" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+              <input id="regNumero" type="text" placeholder="123" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
             </div>
             <div>
               <label class="block text-sm font-medium text-gray-300 mb-2">Complemento</label>
-              <input type="text" placeholder="Sala 101" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+              <input id="regComplemento" type="text" placeholder="Sala 101" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
             </div>
             <div>
               <label class="block text-sm font-medium text-gray-300 mb-2">Bairro</label>
-              <input type="text" placeholder="Centro" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+              <input id="regBairro" type="text" placeholder="Centro" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
             </div>
             <div>
               <label class="block text-sm font-medium text-gray-300 mb-2">Cidade</label>
-              <input type="text" placeholder="São Paulo" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+              <input id="regCidade" type="text" placeholder="São Paulo" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
             </div>
             <div>
               <label class="block text-sm font-medium text-gray-300 mb-2">Estado</label>
-              <select class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition select-arrow appearance-none">
+              <select id="regEstado" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition select-arrow appearance-none">
                 <option value="">Selecione</option>
                 <option value="SP">São Paulo</option>
                 <option value="RJ">Rio de Janeiro</option>
@@ -123,7 +123,7 @@
             </div>
             <div>
               <label class="block text-sm font-medium text-gray-300 mb-2">CEP</label>
-              <input type="text" placeholder="00000-000" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+              <input id="regCep" type="text" placeholder="00000-000" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
             </div>
           </div>
         </div>
@@ -131,23 +131,44 @@
         <div class="mb-8">
           <div class="flex items-center justify-between mb-4">
             <h3 class="text-lg font-semibold text-white">Endereço de Cobrança</h3>
-            <label class="flex items-center gap-2">
-              <input type="checkbox" class="text-primary focus:ring-primary/50" />
+            <div class="flex items-center gap-3">
               <span class="text-sm text-gray-300">Igual ao de Registro</span>
-            </label>
+              <input id="cobrancaIgual" type="checkbox" class="component-toggle" />
+            </div>
           </div>
-          <div class="grid grid-cols-1 md:grid-cols-2 gap-4 opacity-50">
+          <div id="cobrancaFields" class="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div class="md:col-span-2">
               <label class="block text-sm font-medium text-gray-300 mb-2">Rua</label>
-              <input type="text" disabled class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+              <input id="cobRua" type="text" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
             </div>
             <div>
               <label class="block text-sm font-medium text-gray-300 mb-2">Número</label>
-              <input type="text" disabled class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+              <input id="cobNumero" type="text" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
             </div>
             <div>
               <label class="block text-sm font-medium text-gray-300 mb-2">Complemento</label>
-              <input type="text" disabled class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+              <input id="cobComplemento" type="text" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-300 mb-2">Bairro</label>
+              <input id="cobBairro" type="text" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-300 mb-2">Cidade</label>
+              <input id="cobCidade" type="text" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-300 mb-2">Estado</label>
+              <select id="cobEstado" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition select-arrow appearance-none">
+                <option value="">Selecione</option>
+                <option value="SP">São Paulo</option>
+                <option value="RJ">Rio de Janeiro</option>
+                <option value="MG">Minas Gerais</option>
+              </select>
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-300 mb-2">CEP</label>
+              <input id="cobCep" type="text" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
             </div>
           </div>
         </div>
@@ -155,23 +176,44 @@
         <div>
           <div class="flex items-center justify-between mb-4">
             <h3 class="text-lg font-semibold text-white">Endereço de Entrega</h3>
-            <label class="flex items-center gap-2">
-              <input type="checkbox" class="text-primary focus:ring-primary/50" />
+            <div class="flex items-center gap-3">
               <span class="text-sm text-gray-300">Igual ao de Registro</span>
-            </label>
+              <input id="entregaIgual" type="checkbox" class="component-toggle" />
+            </div>
           </div>
-          <div class="grid grid-cols-1 md:grid-cols-2 gap-4 opacity-50">
+          <div id="entregaFields" class="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div class="md:col-span-2">
               <label class="block text-sm font-medium text-gray-300 mb-2">Rua</label>
-              <input type="text" disabled class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+              <input id="entRua" type="text" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
             </div>
             <div>
               <label class="block text-sm font-medium text-gray-300 mb-2">Número</label>
-              <input type="text" disabled class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+              <input id="entNumero" type="text" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
             </div>
             <div>
               <label class="block text-sm font-medium text-gray-300 mb-2">Complemento</label>
-              <input type="text" disabled class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+              <input id="entComplemento" type="text" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-300 mb-2">Bairro</label>
+              <input id="entBairro" type="text" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-300 mb-2">Cidade</label>
+              <input id="entCidade" type="text" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-300 mb-2">Estado</label>
+              <select id="entEstado" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition select-arrow appearance-none">
+                <option value="">Selecione</option>
+                <option value="SP">São Paulo</option>
+                <option value="RJ">Rio de Janeiro</option>
+                <option value="MG">Minas Gerais</option>
+              </select>
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-300 mb-2">CEP</label>
+              <input id="entCep" type="text" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
             </div>
           </div>
         </div>
@@ -196,7 +238,7 @@
                   <th class="text-center py-4 px-4 text-gray-300 font-medium">AÇÕES</th>
                 </tr>
               </thead>
-              <tbody>
+              <tbody id="ordensTabela">
                 <tr>
                   <td colspan="7" class="py-12 text-center text-gray-400">Criar no banco de dados</td>
                 </tr>


### PR DESCRIPTION
## Summary
- enable optional `clienteId` filter for pedidos and orçamentos APIs
- populate client details modal with DB data and address toggles
- list client orders and budgets in modal

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68acccded5c08322a7df9d981feb55bc