### PR TITLE
Improve Client Detail Modal Layout

### DIFF
--- a/src/css/clientes.css
+++ b/src/css/clientes.css
@@ -148,3 +148,48 @@ body {
 @keyframes modalFade { from { opacity: 0; } to { opacity: 1; } }
 @keyframes slideIn { from { transform: translateY(16px); opacity: 0; } to { transform: translateY(0); opacity: 1; } }
 
+.btn-danger {
+    background: var(--color-red);
+    transition: all 150ms ease;
+}
+
+.btn-danger:hover {
+    background: rgba(255,88,88,0.8);
+    transform: scale(1.1);
+}
+
+.btn-danger:active {
+    transform: scale(0.95);
+}
+
+.component-toggle {
+    appearance: none;
+    width: 48px;
+    height: 24px;
+    background: rgba(255,255,255,0.2);
+    border-radius: 12px;
+    position: relative;
+    cursor: pointer;
+    transition: all 150ms ease;
+}
+
+.component-toggle::after {
+    content: '';
+    position: absolute;
+    top: 2px;
+    left: 2px;
+    width: 20px;
+    height: 20px;
+    background: white;
+    border-radius: 50%;
+    transition: all 150ms ease;
+}
+
+.component-toggle:checked {
+    background: var(--color-primary);
+}
+
+.component-toggle:checked::after {
+    transform: translateX(24px);
+}
+

--- a/src/html/modals/clientes/detalhes.html
+++ b/src/html/modals/clientes/detalhes.html
@@ -1,8 +1,9 @@
 <div id="detalhesClienteOverlay" class="hidden fixed inset-0 bg-black/50 flex items-center justify-center p-4">
   <div class="w-full max-w-6xl max-h-[90vh] glass-surface backdrop-blur-xl rounded-3xl border border-white/10 ring-1 ring-white/5 shadow-2xl/40 animate-modalFade slide-in overflow-hidden flex flex-col">
-    <header class="flex items-center justify-between px-8 py-5 border-b border-white/10 flex-shrink-0">
-      <button id="voltarDetalhesCliente" class="btn-neutral px-4 py-2 rounded-lg text-white font-medium flex items-center gap-2">← Voltar</button>
-      <h2 id="clienteDetalhesTitulo" class="text-lg font-semibold text-white">Detalhes – João Silva Ltda</h2>
+    <header class="grid grid-cols-3 items-center px-8 py-5 border-b border-white/10 flex-shrink-0">
+      <button id="voltarDetalhesCliente" class="btn-neutral px-4 py-2 rounded-lg text-white font-medium flex items-center gap-2 justify-self-start">← Voltar</button>
+      <h2 id="clienteDetalhesTitulo" class="text-lg font-semibold text-white text-center">Detalhes – João Silva Ltda</h2>
+      <span></span>
     </header>
 
     <nav class="px-8 border-b border-white/10 flex-shrink-0" role="tablist">
@@ -52,7 +53,7 @@
               </div>
               <div>
                 <label class="block text-sm font-medium text-gray-300 mb-2">Site</label>
-                <input id="clienteSite" type="url" placeholder="https://www.exemplo.com.br" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+                <input id="empresaSite" type="url" placeholder="https://www.exemplo.com.br" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
               </div>
             </div>
           </div>
@@ -225,14 +226,14 @@
         </div>
         <div class="glass-surface rounded-xl border border-white/10 overflow-hidden">
           <div class="overflow-x-auto">
-            <table class="w-full text-sm">
+            <table class="w-full text-sm table-fixed">
               <thead class="glass-surface">
                 <tr class="border-b border-white/10">
-                  <th class="text-left py-4 px-4 text-gray-300 font-medium">Nº ORDEM</th>
-                  <th class="text-left py-4 px-4 text-gray-300 font-medium">TIPO</th>
-                  <th class="text-left py-4 px-4 text-gray-300 font-medium">INÍCIO</th>
-                  <th class="text-right py-4 px-4 text-gray-300 font-medium">VALOR</th>
-                  <th class="text-center py-4 px-4 text-gray-300 font-medium">STATUS</th>
+                  <th class="w-1/5 text-left py-4 px-4 text-gray-300 font-medium">Nº ORDEM</th>
+                  <th class="w-1/5 text-left py-4 px-4 text-gray-300 font-medium">TIPO</th>
+                  <th class="w-1/5 text-left py-4 px-4 text-gray-300 font-medium">INÍCIO</th>
+                  <th class="w-1/5 text-right py-4 px-4 text-gray-300 font-medium">VALOR</th>
+                  <th class="w-1/5 text-center py-4 px-4 text-gray-300 font-medium">STATUS</th>
                 </tr>
               </thead>
               <tbody id="ordensTabela">

--- a/src/js/modals/cliente-detalhes.js
+++ b/src/js/modals/cliente-detalhes.js
@@ -20,8 +20,6 @@
         preencherEnderecos(data.cliente);
         renderContatos(data.contatos || []);
         inicializarToggles(data.cliente);
-        const siteInput = document.getElementById('clienteSite');
-        if(siteInput) siteInput.value = data.cliente.site || '';
         const notas = document.getElementById('clienteNotas');
         if(notas) notas.value = data.cliente.anotacoes || '';
       }
@@ -139,7 +137,12 @@
         <td class="py-4 px-4 text-white">${c.email || ''}</td>
         <td class="py-4 px-4 text-white">${c.telefone_celular || ''}</td>
         <td class="py-4 px-4 text-white">${c.telefone_fixo || ''}</td>
-        <td class="py-4 px-4 text-center text-white">-</td>`;
+        <td class="py-4 px-4 text-center text-white">
+          <div class="flex items-center justify-center gap-2">
+            <i class="fas fa-edit w-5 h-5 cursor-pointer p-1 rounded transition-colors duration-150 hover:bg-white/10" style="color: var(--color-primary)" title="Editar"></i>
+            <i class="fas fa-trash w-5 h-5 cursor-pointer p-1 rounded transition-colors duration-150 hover:bg-white/10 hover:text-white" style="color: var(--color-red)" title="Excluir"></i>
+          </div>
+        </td>`;
       tbody.appendChild(tr);
     });
   }
@@ -192,11 +195,11 @@
     ordens.forEach(o => {
       const tr = document.createElement('tr');
       tr.innerHTML = `
-        <td class="py-4 px-4 text-white">${o.numero}</td>
-        <td class="py-4 px-4 text-white">${o.tipo}</td>
-        <td class="py-4 px-4 text-white">${o.inicio || ''}</td>
-        <td class="py-4 px-4 text-right text-white">${formatCurrency(o.valor)}</td>
-        <td class="py-4 px-4 text-center text-white">${o.status || ''}</td>`;
+        <td class="w-1/5 py-4 px-4 text-white">${o.numero}</td>
+        <td class="w-1/5 py-4 px-4 text-white">${o.tipo}</td>
+        <td class="w-1/5 py-4 px-4 text-white">${o.inicio || ''}</td>
+        <td class="w-1/5 py-4 px-4 text-right text-white">${formatCurrency(o.valor)}</td>
+        <td class="w-1/5 py-4 px-4 text-center text-white">${o.status || ''}</td>`;
       tbody.appendChild(tr);
     });
   }


### PR DESCRIPTION
## Summary
- Center client name in details modal and ensure cancel button uses standard red styling
- Add edit and delete actions to contacts and make orders table columns fill available space
- Map site field correctly and style address toggles consistently

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68acd4101ee483229e221d675fa1c3d2