### PR TITLE
Refine Client Details Modal and Orders Table

### DIFF
--- a/backend/clientesController.js
+++ b/backend/clientesController.js
@@ -63,6 +63,7 @@ router.get('/:id', async (req, res) => {
       razao_social: row.razao_social,
       cnpj: row.cnpj,
       inscricao_estadual: row.inscricao_estadual,
+      site: row.site,
       comprador_nome: row.comprador_nome,
       telefone_fixo: row.telefone_fixo,
       telefone_celular: row.telefone_celular,

--- a/src/html/modals/clientes/detalhes.html
+++ b/src/html/modals/clientes/detalhes.html
@@ -20,8 +20,7 @@
       <section id="panel-dados-empresa" role="tabpanel" aria-labelledby="tab-dados-empresa" class="px-8 py-6">
         <div class="grid grid-cols-1 md:grid-cols-12 gap-8">
           <div class="md:col-span-3 flex flex-col items-center">
-            <div class="w-32 h-32 glass-surface rounded-full flex items-center justify-center text-4xl font-bold text-primary border-2 border-primary/20">JS</div>
-            <button class="mt-4 btn-neutral px-4 py-2 rounded-lg text-white text-sm">Trocar</button>
+            <div id="empresaAvatar" class="w-32 h-32 glass-surface rounded-full flex items-center justify-center text-4xl font-bold text-primary border-2 border-primary/20"></div>
           </div>
           <div class="md:col-span-9">
             <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
@@ -229,16 +228,17 @@
             <table class="w-full text-sm table-fixed">
               <thead class="glass-surface">
                 <tr class="border-b border-white/10">
-                  <th class="w-1/5 text-left py-4 px-4 text-gray-300 font-medium">Nº ORDEM</th>
-                  <th class="w-1/5 text-left py-4 px-4 text-gray-300 font-medium">TIPO</th>
-                  <th class="w-1/5 text-left py-4 px-4 text-gray-300 font-medium">INÍCIO</th>
-                  <th class="w-1/5 text-right py-4 px-4 text-gray-300 font-medium">VALOR</th>
-                  <th class="w-1/5 text-center py-4 px-4 text-gray-300 font-medium">STATUS</th>
+                  <th class="w-1/6 text-left py-4 px-4 text-gray-300 font-medium">Nº ORDEM</th>
+                  <th class="w-1/6 text-left py-4 px-4 text-gray-300 font-medium">TIPO</th>
+                  <th class="w-1/6 text-left py-4 px-4 text-gray-300 font-medium">INÍCIO</th>
+                  <th class="w-1/6 text-left py-4 px-4 text-gray-300 font-medium">COND. PAGAMENTO</th>
+                  <th class="w-1/6 text-left py-4 px-4 text-gray-300 font-medium">VALOR</th>
+                  <th class="w-1/6 text-left py-4 px-4 text-gray-300 font-medium">STATUS</th>
                 </tr>
               </thead>
               <tbody id="ordensTabela">
                 <tr>
-                  <td colspan="5" class="py-12 text-center text-gray-400">Criar no banco de dados</td>
+                  <td colspan="6" class="py-12 text-center text-gray-400">Criar no banco de dados</td>
                 </tr>
               </tbody>
             </table>

--- a/src/js/modals/cliente-detalhes.js
+++ b/src/js/modals/cliente-detalhes.js
@@ -106,6 +106,12 @@
       const el = document.getElementById(id);
       if(el) el.value = cli[map[id]] || '';
     }
+    const avatar = document.getElementById('empresaAvatar');
+    if(avatar){
+      const name = cli.nome_fantasia || cli.razao_social || '';
+      const initials = name.split(' ').filter(Boolean).map(n=>n[0]).join('').substring(0,2).toUpperCase();
+      avatar.textContent = initials;
+    }
   }
 
   function preencherEnderecos(cli){
@@ -174,8 +180,22 @@
       const pedidos = await pedidosRes.json();
       const orcamentos = await orcamentosRes.json();
       const ordens = [
-        ...pedidos.map(p => ({ numero:p.numero, tipo:'Pedido', inicio:p.data_emissao, valor:p.valor_final, status:p.situacao })),
-        ...orcamentos.map(o => ({ numero:o.numero, tipo:'Orçamento', inicio:o.data_emissao, valor:o.valor_final, status:o.situacao }))
+        ...pedidos.map(p => ({
+          numero:p.numero,
+          tipo:'Pedido',
+          inicio:p.data_emissao,
+          condicao: p.parcelas > 1 ? `${p.parcelas}x` : 'À vista',
+          valor:p.valor_final,
+          status:p.situacao
+        })),
+        ...orcamentos.map(o => ({
+          numero:o.numero,
+          tipo:'Orçamento',
+          inicio:o.data_emissao,
+          condicao: o.parcelas > 1 ? `${o.parcelas}x` : 'À vista',
+          valor:o.valor_final,
+          status:o.situacao
+        }))
       ];
       renderOrdens(ordens);
     }catch(err){
@@ -188,18 +208,19 @@
     if(!tbody) return;
     tbody.innerHTML = '';
     if(!ordens.length){
-      tbody.innerHTML = '<tr><td colspan="5" class="py-12 text-center text-gray-400">Nenhuma ordem encontrada</td></tr>';
+      tbody.innerHTML = '<tr><td colspan="6" class="py-12 text-center text-gray-400">Nenhuma ordem encontrada</td></tr>';
       return;
     }
     const formatCurrency = v => new Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL' }).format(v || 0);
     ordens.forEach(o => {
       const tr = document.createElement('tr');
       tr.innerHTML = `
-        <td class="w-1/5 py-4 px-4 text-white">${o.numero}</td>
-        <td class="w-1/5 py-4 px-4 text-white">${o.tipo}</td>
-        <td class="w-1/5 py-4 px-4 text-white">${o.inicio || ''}</td>
-        <td class="w-1/5 py-4 px-4 text-right text-white">${formatCurrency(o.valor)}</td>
-        <td class="w-1/5 py-4 px-4 text-center text-white">${o.status || ''}</td>`;
+        <td class="w-1/6 py-4 px-4 text-left text-white">${o.numero}</td>
+        <td class="w-1/6 py-4 px-4 text-left text-white">${o.tipo}</td>
+        <td class="w-1/6 py-4 px-4 text-left text-white">${o.inicio || ''}</td>
+        <td class="w-1/6 py-4 px-4 text-left text-white">${o.condicao || ''}</td>
+        <td class="w-1/6 py-4 px-4 text-left text-white">${formatCurrency(o.valor)}</td>
+        <td class="w-1/6 py-4 px-4 text-left text-white">${o.status || ''}</td>`;
       tbody.appendChild(tr);
     });
   }


### PR DESCRIPTION
## Summary
- Display client initials in details modal and remove unused change button
- Add payment condition column to orders and left-align table content
- Expose client website field via API for company data

## Testing
- `node --test backend/*.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68acd6403a448322a6e9d1ca89ecc0d0