### PR TITLE
Corrigir estilos de detalhes do prospecto

### DIFF
--- a/src/css/prospeccoes-detalhes.css
+++ b/src/css/prospeccoes-detalhes.css
@@ -1,1 +1,13 @@
 /* Estilos para detalhes de prospecções */
+
+.text-primary { color: var(--color-primary); }
+.text-violet { color: var(--color-violet); }
+
+.border-primary\/20 { border-color: rgba(182, 160, 62, 0.2); }
+.border-violet\/20 { border-color: rgba(163, 148, 167, 0.2); }
+
+.bg-primary\/20 { background: rgba(182, 160, 62, 0.2); }
+
+.bg-surface\/80 { background: rgba(255, 255, 255, 0.08); }
+.bg-surface\/60 { background: rgba(255, 255, 255, 0.06); }
+.bg-surface\/40 { background: rgba(255, 255, 255, 0.04); }

--- a/src/html/prospeccoes-detalhes.html
+++ b/src/html/prospeccoes-detalhes.html
@@ -6,6 +6,7 @@
     <title>Detalhes da Prospecção</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="../css/prospeccoes.css">
     <link rel="stylesheet" href="../css/prospeccoes-detalhes.css">
     <link rel="stylesheet" href="../styles/scroll.css">
 </head>
@@ -271,6 +272,7 @@
                                 <th class="text-left py-3 text-gray-300">Estágio</th>
                                 <th class="text-right py-3 text-gray-300">Valor</th>
                                 <th class="text-left py-3 text-gray-300">Data de Fechamento</th>
+                                <th class="text-center py-3 text-gray-300">Ações</th>
                             </tr>
                         </thead>
                         <tbody>
@@ -279,6 +281,11 @@
                                 <td class="py-3"><span class="badge-warning px-2 py-1 rounded text-xs">Proposta</span></td>
                                 <td class="py-3 text-right text-white">R$ 45.000</td>
                                 <td class="py-3 text-gray-300">15/02/2024</td>
+                                <td class="py-3 text-center">
+                                    <div class="flex items-center justify-center space-x-2">
+                                        <i class="fas fa-edit w-5 h-5 cursor-pointer p-1 rounded transition-colors duration-150 hover:bg-white/10" style="color: var(--color-primary)" title="Editar"></i>
+                                    </div>
+                                </td>
                             </tr>
                         </tbody>
                     </table>


### PR DESCRIPTION
## Summary
- Ativa estilos compartilhados para detalhes de prospecções, restaurando cores e hovers
- Adiciona coluna de ações com botão de edição na tabela de ordens
- Define utilitários de cor e fundo para botões, abas e histórico

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad97123dd483228a4f168d62a868f0