### PR TITLE
Abrir sites de prospecções no navegador padrão

### DIFF
--- a/main.js
+++ b/main.js
@@ -809,6 +809,11 @@ ipcMain.handle('open-pdf', (_event, { id, tipo }) => {
   return true;
 });
 
+ipcMain.handle('open-external', (_event, url) => {
+  shell.openExternal(url);
+  return true;
+});
+
 if (DEBUG) {
   ipcMain.on('debug-log', (_, m) => console.log('[popup]', m));
 }

--- a/preload.js
+++ b/preload.js
@@ -104,6 +104,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   getDisplays: () => ipcRenderer.invoke('get-displays'),
   setDisplay: (id) => ipcRenderer.invoke('set-display', id),
   openPdf: (id, tipo) => ipcRenderer.invoke('open-pdf', { id, tipo }),
+  openExternal: (url) => ipcRenderer.invoke('open-external', url),
     getSavedDisplay: () => ipcRenderer.invoke('get-saved-display'),
     onActivateTab: (callback) =>
       ipcRenderer.on('activate-tab', (_event, tab) => callback(tab)),

--- a/src/html/modals/prospeccoes/detalhes.html
+++ b/src/html/modals/prospeccoes/detalhes.html
@@ -154,7 +154,7 @@
                     </div>
                     <div>
                         <label class="block text-sm text-gray-400 mb-1">Site</label>
-                        <a href="https://acme.com" class="text-primary hover:text-primary-light">www.acme.com</a>
+                        <a href="https://acme.com" data-external target="_blank" rel="noopener noreferrer" class="text-primary hover:text-primary-light">www.acme.com</a>
                     </div>
                     <div class="md:col-span-2">
                         <label class="block text-sm text-gray-400 mb-1">Endereço</label>

--- a/src/html/prospeccoes-detalhes.html
+++ b/src/html/prospeccoes-detalhes.html
@@ -166,7 +166,7 @@
                     </div>
                     <div>
                         <label class="block text-sm text-gray-400 mb-1">Site</label>
-                        <a href="https://acme.com" class="text-primary hover:text-primary-light">www.acme.com</a>
+                        <a href="https://acme.com" data-external target="_blank" rel="noopener noreferrer" class="text-primary hover:text-primary-light">www.acme.com</a>
                     </div>
                     <div class="md:col-span-2">
                         <label class="block text-sm text-gray-400 mb-1">Endereço</label>

--- a/src/js/modals/prospeccao-detalhes.js
+++ b/src/js/modals/prospeccao-detalhes.js
@@ -74,4 +74,11 @@
       }
     });
   }
+
+  overlay.querySelectorAll('a[data-external]').forEach(a => {
+    a.addEventListener('click', e => {
+      e.preventDefault();
+      window.electronAPI.openExternal(a.href);
+    });
+  });
 })();

--- a/src/js/prospeccoes-detalhes.js
+++ b/src/js/prospeccoes-detalhes.js
@@ -66,6 +66,13 @@ function initDetalhesProspeccao() {
     });
   }
 
+  document.querySelectorAll('a[data-external]').forEach(a => {
+    a.addEventListener('click', e => {
+      e.preventDefault();
+      window.electronAPI.openExternal(a.href);
+    });
+  });
+
   document.getElementById('fecharDetalhesProspeccao')?.addEventListener('click', () => loadPage('prospeccoes'));
 }
 


### PR DESCRIPTION
## Summary
- Ensure prospect sites open in the system browser from the overview
- Add Electron bridge and main-process handler for external links

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad997128b48322bf844e1fa8eb9ecd