### PR TITLE
Update Activities Buttons Colors And Order

### DIFF
--- a/src/html/modals/prospeccoes/detalhes.html
+++ b/src/html/modals/prospeccoes/detalhes.html
@@ -199,14 +199,14 @@
         <section data-panel="activities" class="space-y-6 hidden">
             <!-- Ações -->
             <div class="flex gap-3 mb-6">
+                <button class="btn-warning px-4 py-2 rounded-lg text-white font-medium">
+                    + Nova Tarefa
+                </button>
                 <button class="btn-primary px-4 py-2 rounded-lg text-white font-medium">
                     Registrar Ligação
                 </button>
-                <button class="btn-ghost px-4 py-2 rounded-lg text-white font-medium">
-                    Nova Tarefa
-                </button>
-                <button class="btn-ghost px-4 py-2 rounded-lg text-white font-medium">
-                    Enviar E-mail
+                <button class="btn-primary px-4 py-2 rounded-lg text-white font-medium">
+                    Registrar E-mail
                 </button>
             </div>
 

--- a/src/html/prospeccoes-detalhes.html
+++ b/src/html/prospeccoes-detalhes.html
@@ -211,14 +211,14 @@
         <section data-panel="activities" class="space-y-6 hidden">
             <!-- Ações -->
             <div class="flex gap-3 mb-6">
+                <button class="btn-warning px-4 py-2 rounded-lg text-white font-medium">
+                    + Nova Tarefa
+                </button>
                 <button class="btn-primary px-4 py-2 rounded-lg text-white font-medium">
                     Registrar Ligação
                 </button>
-                <button class="btn-ghost px-4 py-2 rounded-lg text-white font-medium">
-                    Nova Tarefa
-                </button>
-                <button class="btn-ghost px-4 py-2 rounded-lg text-white font-medium">
-                    Enviar E-mail
+                <button class="btn-primary px-4 py-2 rounded-lg text-white font-medium">
+                    Registrar E-mail
                 </button>
             </div>
 


### PR DESCRIPTION
## Summary
- reorder activity buttons prioritizing new task
- style new task button in yellow with a plus icon
- unify register call and email buttons in blue and rename email action

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad9d9010708322bc82673404528ae3