### PR TITLE
Ajusta cores dos botões no cabeçalho de detalhes de prospecções

### DIFF
--- a/src/css/prospeccoes.css
+++ b/src/css/prospeccoes.css
@@ -78,6 +78,27 @@ body {
     transform: scale(1.05);
 }
 
+.btn-success {
+    background: var(--color-green);
+    color: #000;
+    transition: all 150ms ease;
+}
+
+.btn-success:hover {
+    background: rgba(162, 255, 166, 0.8);
+    transform: scale(1.05);
+}
+
+.btn-dark-blue {
+    background: #1e3a8a;
+    transition: all 150ms ease;
+}
+
+.btn-dark-blue:hover {
+    background: #1e40af;
+    transform: scale(1.05);
+}
+
 .badge-success {
     background: rgba(162, 255, 166, 0.2);
     color: var(--color-green);

--- a/src/html/modals/prospeccoes/detalhes.html
+++ b/src/html/modals/prospeccoes/detalhes.html
@@ -18,22 +18,22 @@
                 </div>
 
                 <div class="flex items-center gap-3">
-                    <button class="btn-ghost px-4 py-2 rounded-lg text-white font-medium">
+                    <button class="btn-primary px-4 py-2 rounded-lg text-white font-medium">
                         Editar
                     </button>
                     <button id="prospectDelete" class="btn-danger px-4 py-2 rounded-lg text-white font-medium">
                         Deletar
                     </button>
-                    <button class="btn-ghost px-4 py-2 rounded-lg text-white font-medium">
+                    <button class="btn-dark-blue px-4 py-2 rounded-lg text-white font-medium">
                         Alterar Responsável
                     </button>
                     <button id="toggleNotify" aria-pressed="false" class="btn-ghost px-4 py-2 rounded-lg text-white font-medium">
                         Notificações
                     </button>
-                    <button class="btn-primary px-6 py-2 rounded-lg text-white font-medium">
+                    <button class="btn-success px-6 py-2 rounded-lg font-medium text-black">
                         Converter
                     </button>
-                    <button id="fecharDetalhesProspeccao" class="btn-ghost p-2 rounded-lg text-white">
+                    <button id="fecharDetalhesProspeccao" class="btn-danger p-2 rounded-lg text-white">
                         ✕
                     </button>
                 </div>

--- a/src/html/prospeccoes-detalhes.html
+++ b/src/html/prospeccoes-detalhes.html
@@ -30,22 +30,22 @@
                 </div>
 
                 <div class="flex items-center gap-3">
-                    <button class="btn-ghost px-4 py-2 rounded-lg text-white font-medium">
+                    <button class="btn-primary px-4 py-2 rounded-lg text-white font-medium">
                         Editar
                     </button>
                     <button id="prospectDelete" class="btn-danger px-4 py-2 rounded-lg text-white font-medium">
                         Deletar
                     </button>
-                    <button class="btn-ghost px-4 py-2 rounded-lg text-white font-medium">
+                    <button class="btn-dark-blue px-4 py-2 rounded-lg text-white font-medium">
                         Alterar Responsável
                     </button>
                     <button id="toggleNotify" aria-pressed="false" class="btn-ghost px-4 py-2 rounded-lg text-white font-medium">
                         Notificações
                     </button>
-                    <button class="btn-primary px-6 py-2 rounded-lg text-white font-medium">
+                    <button class="btn-success px-6 py-2 rounded-lg font-medium text-black">
                         Converter
                     </button>
-                    <button id="fecharDetalhesProspeccao" class="btn-ghost p-2 rounded-lg text-white">
+                    <button id="fecharDetalhesProspeccao" class="btn-danger p-2 rounded-lg text-white">
                         ✕
                     </button>
                 </div>


### PR DESCRIPTION
## Summary
- define estilos btn-success e btn-dark-blue
- aplica novas cores aos botões Editar, Converter, Alterar Responsável e Fechar nos detalhes de prospecções

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad9e49747c8322b9195819f724b500