### PR TITLE
Padronize O Cabeçalho Do Prospect

### DIFF
--- a/src/html/modals/prospeccoes/detalhes.html
+++ b/src/html/modals/prospeccoes/detalhes.html
@@ -43,38 +43,46 @@
 
     <!-- Summary Card -->
     <div class="px-6 py-6">
-        <div class="bg-surface/60 backdrop-blur-xl rounded-2xl border border-white/10 p-6">
-            <div class="flex items-center justify-between">
+        <section class="w-full rounded-2xl bg-[--color-surface] backdrop-blur p-6 lg:p-8 shadow-lg">
+            <div class="grid gap-6 lg:grid-cols-[1.1fr_auto_0.9fr] items-center">
+                <!-- Identidade -->
                 <div class="flex items-center gap-4">
-                    <div class="w-16 h-16 bg-gradient-to-br from-primary/20 to-primary/5 rounded-full flex items-center justify-center text-xl font-bold text-primary border-2 border-primary/20">
-                        JW
+                    <div class="h-16 w-16 rounded-full ring-2 ring-[--color-primary] grid place-items-center text-[--color-primary] font-semibold shrink-0">
+                        {{initials}}
                     </div>
-                    <div>
-                        <h2 class="text-xl font-semibold text-white">Jennifer Wilson</h2>
-                        <p class="text-gray-300">Acme Corporation</p>
+                    <div class="min-w-0">
+                        <h2 class="text-xl lg:text-2xl font-semibold text-white truncate" title="{{name}}">{{name}}</h2>
+                        <p class="text-sm text-white/70 truncate" title="{{company}}">{{company}}</p>
                     </div>
                 </div>
 
-                <div class="text-right space-y-2">
-                    <div class="flex items-center gap-4">
-                        <span class="text-gray-400">Responsável:</span>
-                        <span class="text-white">Carlos Silva</span>
+                <!-- Divisor Vertical -->
+                <div class="hidden lg:block h-16 w-px bg-white/10 justify-self-center"></div>
+
+                <!-- Metadados -->
+                <div class="grid grid-cols-2 gap-4">
+                    <div class="rounded-xl bg-white/5 p-3">
+                        <span class="text-[11px] uppercase tracking-wide text-white/60">Responsável</span>
+                        <p class="text-sm text-white">{{ownerName}}</p>
                     </div>
-                    <div class="flex items-center gap-4">
-                        <span class="text-gray-400">Telefone:</span>
-                        <span class="text-white">(11) 99999-9999</span>
-                    </div>
-                    <div class="flex items-center gap-4">
-                        <span class="text-gray-400">E-mail:</span>
-                        <span class="text-white">jennifer@acme.com</span>
-                    </div>
-                    <div class="flex items-center gap-4">
-                        <span class="text-gray-400">Status:</span>
-                        <span class="badge-success px-3 py-1 rounded-full text-sm font-medium">Qualificado</span>
+                    <a href="mailto:{{email}}" aria-label="Enviar e-mail para {{name}}" class="rounded-xl bg-white/5 hover:bg-white/10 p-3">
+                        <span class="text-[11px] uppercase tracking-wide text-white/60">E-mail</span>
+                        <p class="text-sm text-white truncate" title="{{email}}">{{email}}</p>
+                    </a>
+                    <a href="tel:{{phone}}" aria-label="Ligar para {{name}}" class="rounded-xl bg-white/5 hover:bg-white/10 p-3">
+                        <span class="text-[11px] uppercase tracking-wide text-white/60">Telefone</span>
+                        <p class="text-sm text-white">{{phone}}</p>
+                    </a>
+                    <div class="rounded-xl bg-white/5 p-3">
+                        <span class="text-[11px] uppercase tracking-wide text-white/60">Status</span>
+                        <div class="text-sm text-white">
+                            <span class="inline-flex mt-1 px-2.5 py-1 rounded-full text-xs font-medium bg-emerald-500/20 text-emerald-200">{{status}}</span>
+                        </div>
                     </div>
                 </div>
             </div>
-        </div>
+            <div class="mt-6 lg:hidden h-px w-full bg-white/10"></div>
+        </section>
     </div>
 
     <!-- Sticky Tabs -->

--- a/src/html/prospeccoes-detalhes.html
+++ b/src/html/prospeccoes-detalhes.html
@@ -55,38 +55,46 @@
 
     <!-- Summary Card -->
     <div class="px-6 py-6">
-        <div class="bg-surface/60 backdrop-blur-xl rounded-2xl border border-white/10 p-6">
-            <div class="flex items-center justify-between">
+        <section class="w-full rounded-2xl bg-[--color-surface] backdrop-blur p-6 lg:p-8 shadow-lg">
+            <div class="grid gap-6 lg:grid-cols-[1.1fr_auto_0.9fr] items-center">
+                <!-- Identidade -->
                 <div class="flex items-center gap-4">
-                    <div class="w-16 h-16 bg-gradient-to-br from-primary/20 to-primary/5 rounded-full flex items-center justify-center text-xl font-bold text-primary border-2 border-primary/20">
-                        JW
+                    <div class="h-16 w-16 rounded-full ring-2 ring-[--color-primary] grid place-items-center text-[--color-primary] font-semibold shrink-0">
+                        {{initials}}
                     </div>
-                    <div>
-                        <h2 class="text-xl font-semibold text-white">Jennifer Wilson</h2>
-                        <p class="text-gray-300">Acme Corporation</p>
+                    <div class="min-w-0">
+                        <h2 class="text-xl lg:text-2xl font-semibold text-white truncate" title="{{name}}">{{name}}</h2>
+                        <p class="text-sm text-white/70 truncate" title="{{company}}">{{company}}</p>
                     </div>
                 </div>
 
-                <div class="text-right space-y-2">
-                    <div class="flex items-center gap-4">
-                        <span class="text-gray-400">Responsável:</span>
-                        <span class="text-white">Carlos Silva</span>
+                <!-- Divisor Vertical -->
+                <div class="hidden lg:block h-16 w-px bg-white/10 justify-self-center"></div>
+
+                <!-- Metadados -->
+                <div class="grid grid-cols-2 gap-4">
+                    <div class="rounded-xl bg-white/5 p-3">
+                        <span class="text-[11px] uppercase tracking-wide text-white/60">Responsável</span>
+                        <p class="text-sm text-white">{{ownerName}}</p>
                     </div>
-                    <div class="flex items-center gap-4">
-                        <span class="text-gray-400">Telefone:</span>
-                        <span class="text-white">(11) 99999-9999</span>
-                    </div>
-                    <div class="flex items-center gap-4">
-                        <span class="text-gray-400">E-mail:</span>
-                        <span class="text-white">jennifer@acme.com</span>
-                    </div>
-                    <div class="flex items-center gap-4">
-                        <span class="text-gray-400">Status:</span>
-                        <span class="badge-success px-3 py-1 rounded-full text-sm font-medium">Qualificado</span>
+                    <a href="mailto:{{email}}" aria-label="Enviar e-mail para {{name}}" class="rounded-xl bg-white/5 hover:bg-white/10 p-3">
+                        <span class="text-[11px] uppercase tracking-wide text-white/60">E-mail</span>
+                        <p class="text-sm text-white truncate" title="{{email}}">{{email}}</p>
+                    </a>
+                    <a href="tel:{{phone}}" aria-label="Ligar para {{name}}" class="rounded-xl bg-white/5 hover:bg-white/10 p-3">
+                        <span class="text-[11px] uppercase tracking-wide text-white/60">Telefone</span>
+                        <p class="text-sm text-white">{{phone}}</p>
+                    </a>
+                    <div class="rounded-xl bg-white/5 p-3">
+                        <span class="text-[11px] uppercase tracking-wide text-white/60">Status</span>
+                        <div class="text-sm text-white">
+                            <span class="inline-flex mt-1 px-2.5 py-1 rounded-full text-xs font-medium bg-emerald-500/20 text-emerald-200">{{status}}</span>
+                        </div>
                     </div>
                 </div>
             </div>
-        </div>
+            <div class="mt-6 lg:hidden h-px w-full bg-white/10"></div>
+        </section>
     </div>
 
     <!-- Sticky Tabs -->


### PR DESCRIPTION
## Summary
- rework prospect header into responsive grid with avatar and truncated identity fields
- add metadata chips for owner, email, phone, and status with accessible links

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ada01655608322949f5dfd53b55175