### PR TITLE
Corrigir cabeçario travado em prospectos

### DIFF
--- a/src/html/modals/prospeccoes/detalhes.html
+++ b/src/html/modals/prospeccoes/detalhes.html
@@ -48,11 +48,11 @@
                 <!-- Identidade -->
                 <div class="flex items-center gap-4">
                     <div class="h-16 w-16 rounded-full ring-2 ring-[--color-primary] grid place-items-center text-[--color-primary] font-semibold shrink-0">
-                        {{initials}}
+                        <span id="modalProspectInitials"></span>
                     </div>
                     <div class="min-w-0">
-                        <h2 class="text-xl lg:text-2xl font-semibold text-white truncate" title="{{name}}">{{name}}</h2>
-                        <p class="text-sm text-white/70 truncate" title="{{company}}">{{company}}</p>
+                        <h2 id="modalProspectName" class="text-xl lg:text-2xl font-semibold text-white truncate" title=""></h2>
+                        <p id="modalProspectCompany" class="text-sm text-white/70 truncate" title=""></p>
                     </div>
                 </div>
 
@@ -63,20 +63,20 @@
                 <div class="grid grid-cols-2 gap-4">
                     <div class="rounded-xl bg-white/5 p-3">
                         <span class="text-[11px] uppercase tracking-wide text-white/60">Responsável</span>
-                        <p class="text-sm text-white">{{ownerName}}</p>
+                        <p id="modalProspectOwner" class="text-sm text-white"></p>
                     </div>
-                    <a href="mailto:{{email}}" aria-label="Enviar e-mail para {{name}}" class="rounded-xl bg-white/5 hover:bg-white/10 p-3">
+                    <a id="modalProspectEmailLink" href="#" aria-label="" class="rounded-xl bg-white/5 hover:bg-white/10 p-3">
                         <span class="text-[11px] uppercase tracking-wide text-white/60">E-mail</span>
-                        <p class="text-sm text-white truncate" title="{{email}}">{{email}}</p>
+                        <p id="modalProspectEmail" class="text-sm text-white truncate" title=""></p>
                     </a>
-                    <a href="tel:{{phone}}" aria-label="Ligar para {{name}}" class="rounded-xl bg-white/5 hover:bg-white/10 p-3">
+                    <a id="modalProspectPhoneLink" href="#" aria-label="" class="rounded-xl bg-white/5 hover:bg-white/10 p-3">
                         <span class="text-[11px] uppercase tracking-wide text-white/60">Telefone</span>
-                        <p class="text-sm text-white">{{phone}}</p>
+                        <p id="modalProspectPhone" class="text-sm text-white"></p>
                     </a>
                     <div class="rounded-xl bg-white/5 p-3">
                         <span class="text-[11px] uppercase tracking-wide text-white/60">Status</span>
                         <div class="text-sm text-white">
-                            <span class="inline-flex mt-1 px-2.5 py-1 rounded-full text-xs font-medium bg-emerald-500/20 text-emerald-200">{{status}}</span>
+                            <span id="modalProspectStatus" class="inline-flex mt-1 px-2.5 py-1 rounded-full text-xs font-medium bg-emerald-500/20 text-emerald-200"></span>
                         </div>
                     </div>
                 </div>

--- a/src/html/prospeccoes-detalhes.html
+++ b/src/html/prospeccoes-detalhes.html
@@ -60,11 +60,11 @@
                 <!-- Identidade -->
                 <div class="flex items-center gap-4">
                     <div class="h-16 w-16 rounded-full ring-2 ring-[--color-primary] grid place-items-center text-[--color-primary] font-semibold shrink-0">
-                        {{initials}}
+                        <span id="prospectInitials"></span>
                     </div>
                     <div class="min-w-0">
-                        <h2 class="text-xl lg:text-2xl font-semibold text-white truncate" title="{{name}}">{{name}}</h2>
-                        <p class="text-sm text-white/70 truncate" title="{{company}}">{{company}}</p>
+                        <h2 id="prospectName" class="text-xl lg:text-2xl font-semibold text-white truncate" title=""></h2>
+                        <p id="prospectCompany" class="text-sm text-white/70 truncate" title=""></p>
                     </div>
                 </div>
 
@@ -75,20 +75,20 @@
                 <div class="grid grid-cols-2 gap-4">
                     <div class="rounded-xl bg-white/5 p-3">
                         <span class="text-[11px] uppercase tracking-wide text-white/60">Responsável</span>
-                        <p class="text-sm text-white">{{ownerName}}</p>
+                        <p id="prospectOwner" class="text-sm text-white"></p>
                     </div>
-                    <a href="mailto:{{email}}" aria-label="Enviar e-mail para {{name}}" class="rounded-xl bg-white/5 hover:bg-white/10 p-3">
+                    <a id="prospectEmailLink" href="#" aria-label="" class="rounded-xl bg-white/5 hover:bg-white/10 p-3">
                         <span class="text-[11px] uppercase tracking-wide text-white/60">E-mail</span>
-                        <p class="text-sm text-white truncate" title="{{email}}">{{email}}</p>
+                        <p id="prospectEmail" class="text-sm text-white truncate" title=""></p>
                     </a>
-                    <a href="tel:{{phone}}" aria-label="Ligar para {{name}}" class="rounded-xl bg-white/5 hover:bg-white/10 p-3">
+                    <a id="prospectPhoneLink" href="#" aria-label="" class="rounded-xl bg-white/5 hover:bg-white/10 p-3">
                         <span class="text-[11px] uppercase tracking-wide text-white/60">Telefone</span>
-                        <p class="text-sm text-white">{{phone}}</p>
+                        <p id="prospectPhone" class="text-sm text-white"></p>
                     </a>
                     <div class="rounded-xl bg-white/5 p-3">
                         <span class="text-[11px] uppercase tracking-wide text-white/60">Status</span>
                         <div class="text-sm text-white">
-                            <span class="inline-flex mt-1 px-2.5 py-1 rounded-full text-xs font-medium bg-emerald-500/20 text-emerald-200">{{status}}</span>
+                            <span id="prospectStatus" class="inline-flex mt-1 px-2.5 py-1 rounded-full text-xs font-medium bg-emerald-500/20 text-emerald-200"></span>
                         </div>
                     </div>
                 </div>

--- a/src/js/modals/prospeccao-detalhes.js
+++ b/src/js/modals/prospeccao-detalhes.js
@@ -51,6 +51,46 @@
 
   setTab('overview');
 
+  // Preenche os dados do prospecto no modal
+  const data = window.prospectDetails || {
+    initials: 'JW',
+    name: 'Jennifer Wilson',
+    company: 'Acme Corporation',
+    ownerName: 'João Silva',
+    email: 'jennifer@acme.com',
+    phone: '(11) 99999-9999',
+    status: 'Novo'
+  };
+  const get = id => document.getElementById(id);
+  get('modalProspectInitials')?.textContent = data.initials;
+  const nEl = get('modalProspectName');
+  if (nEl) {
+    nEl.textContent = data.name;
+    nEl.title = data.name;
+  }
+  const cEl = get('modalProspectCompany');
+  if (cEl) {
+    cEl.textContent = data.company;
+    cEl.title = data.company;
+  }
+  get('modalProspectOwner')?.textContent = data.ownerName;
+  const emailLink = get('modalProspectEmailLink');
+  const emailEl = get('modalProspectEmail');
+  if (emailLink && emailEl) {
+    emailLink.href = `mailto:${data.email}`;
+    emailLink.setAttribute('aria-label', `Enviar e-mail para ${data.name}`);
+    emailEl.textContent = data.email;
+    emailEl.title = data.email;
+  }
+  const phoneLink = get('modalProspectPhoneLink');
+  const phoneEl = get('modalProspectPhone');
+  if (phoneLink && phoneEl) {
+    phoneLink.href = `tel:${data.phone}`;
+    phoneLink.setAttribute('aria-label', `Ligar para ${data.name}`);
+    phoneEl.textContent = data.phone;
+  }
+  get('modalProspectStatus')?.textContent = data.status;
+
   const notifyBtn = document.getElementById('toggleNotify');
   if(notifyBtn){
     notifyBtn.addEventListener('click', function(){

--- a/src/js/prospeccoes-detalhes.js
+++ b/src/js/prospeccoes-detalhes.js
@@ -42,6 +42,46 @@ function initDetalhesProspeccao() {
 
   setTab('overview');
 
+  // Preenche os dados do prospecto no cabeçalho
+  const prospect = window.prospectDetails || {
+    initials: 'JW',
+    name: 'Jennifer Wilson',
+    company: 'Acme Corporation',
+    ownerName: 'João Silva',
+    email: 'jennifer@acme.com',
+    phone: '(11) 99999-9999',
+    status: 'Novo'
+  };
+  const get = id => document.getElementById(id);
+  get('prospectInitials')?.textContent = prospect.initials;
+  const nameEl = get('prospectName');
+  if (nameEl) {
+    nameEl.textContent = prospect.name;
+    nameEl.title = prospect.name;
+  }
+  const companyEl = get('prospectCompany');
+  if (companyEl) {
+    companyEl.textContent = prospect.company;
+    companyEl.title = prospect.company;
+  }
+  get('prospectOwner')?.textContent = prospect.ownerName;
+  const emailLink = get('prospectEmailLink');
+  const emailEl = get('prospectEmail');
+  if (emailLink && emailEl) {
+    emailLink.href = `mailto:${prospect.email}`;
+    emailLink.setAttribute('aria-label', `Enviar e-mail para ${prospect.name}`);
+    emailEl.textContent = prospect.email;
+    emailEl.title = prospect.email;
+  }
+  const phoneLink = get('prospectPhoneLink');
+  const phoneEl = get('prospectPhone');
+  if (phoneLink && phoneEl) {
+    phoneLink.href = `tel:${prospect.phone}`;
+    phoneLink.setAttribute('aria-label', `Ligar para ${prospect.name}`);
+    phoneEl.textContent = prospect.phone;
+  }
+  get('prospectStatus')?.textContent = prospect.status;
+
   const notifyBtn = document.getElementById('toggleNotify');
   if (notifyBtn) {
     notifyBtn.addEventListener('click', function () {


### PR DESCRIPTION
## Summary
- replace template placeholders in prospect detail views with DOM elements
- populate prospect data programmatically to avoid showing raw template code

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ada28753608322a3c2b724be569e25