### PR TITLE
Preencha Os Dados Do Cabeçalho Com O Exemplo No Mais Detalhes De Prospecções

### DIFF
--- a/src/html/modals/prospeccoes/detalhes.html
+++ b/src/html/modals/prospeccoes/detalhes.html
@@ -13,8 +13,8 @@
             <!-- Header Content -->
             <div class="flex items-center justify-between">
                 <div>
-                    <h1 class="text-2xl font-bold text-white">Jennifer Wilson</h1>
-                    <p class="text-gray-300">Acme Corporation</p>
+                    <h1 id="modalProspectNameHeader" class="text-2xl font-bold text-white"></h1>
+                    <p id="modalProspectCompanyHeader" class="text-gray-300"></p>
                 </div>
 
                 <div class="flex items-center gap-3">

--- a/src/html/prospeccoes-detalhes.html
+++ b/src/html/prospeccoes-detalhes.html
@@ -25,8 +25,8 @@
             <!-- Header Content -->
             <div class="flex items-center justify-between">
                 <div>
-                    <h1 class="text-2xl font-bold text-white">Jennifer Wilson</h1>
-                    <p class="text-gray-300">Acme Corporation</p>
+                    <h1 id="prospectNameHeader" class="text-2xl font-bold text-white"></h1>
+                    <p id="prospectCompanyHeader" class="text-gray-300"></p>
                 </div>
 
                 <div class="flex items-center gap-3">

--- a/src/js/modals/prospeccao-detalhes.js
+++ b/src/js/modals/prospeccao-detalhes.js
@@ -73,6 +73,8 @@
     cEl.textContent = data.company;
     cEl.title = data.company;
   }
+  get('modalProspectNameHeader')?.textContent = data.name;
+  get('modalProspectCompanyHeader')?.textContent = data.company;
   get('modalProspectOwner')?.textContent = data.ownerName;
   const emailLink = get('modalProspectEmailLink');
   const emailEl = get('modalProspectEmail');

--- a/src/js/prospeccoes-detalhes.js
+++ b/src/js/prospeccoes-detalhes.js
@@ -64,6 +64,8 @@ function initDetalhesProspeccao() {
     companyEl.textContent = prospect.company;
     companyEl.title = prospect.company;
   }
+  get('prospectNameHeader')?.textContent = prospect.name;
+  get('prospectCompanyHeader')?.textContent = prospect.company;
   get('prospectOwner')?.textContent = prospect.ownerName;
   const emailLink = get('prospectEmailLink');
   const emailEl = get('prospectEmail');


### PR DESCRIPTION
## Summary
- Atualiza cabeçalhos das páginas de detalhes de prospecções para receber dados dinamicamente
- Ajusta scripts de detalhes de prospecções para popular cabeçalhos com o objeto de exemplo

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ada580a490832282d62fab34f09c99