### PR TITLE
Padronizar tabelas de notas com estilo de orçamentos

### DIFF
--- a/src/html/modals/clientes/detalhes.html
+++ b/src/html/modals/clientes/detalhes.html
@@ -225,18 +225,18 @@
         </div>
         <div class="glass-surface rounded-xl border border-white/10 overflow-hidden">
           <div class="overflow-x-auto">
-            <table class="w-full text-sm table-fixed">
-              <thead class="glass-surface">
-                <tr class="border-b border-white/10">
-                  <th class="w-1/6 text-left py-4 px-4 text-gray-300 font-medium">Nº ORDEM</th>
-                  <th class="w-1/6 text-left py-4 px-4 text-gray-300 font-medium">TIPO</th>
-                  <th class="w-1/6 text-left py-4 px-4 text-gray-300 font-medium">INÍCIO</th>
-                  <th class="w-1/6 text-left py-4 px-4 text-gray-300 font-medium">COND. PAGAMENTO</th>
-                  <th class="w-1/6 text-left py-4 px-4 text-gray-300 font-medium">VALOR</th>
-                  <th class="w-1/6 text-left py-4 px-4 text-gray-300 font-medium">STATUS</th>
+            <table class="w-full">
+              <thead class="bg-gray-50 sticky top-0">
+                <tr>
+                  <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Nº Ordem</th>
+                  <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Tipo</th>
+                  <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Início</th>
+                  <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Cond. Pagamento</th>
+                  <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Valor</th>
+                  <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
                 </tr>
               </thead>
-              <tbody id="ordensTabela">
+              <tbody id="ordensTabela" class="divide-y divide-white/10">
                 <tr>
                   <td colspan="6" class="py-12 text-center text-gray-400">Criar no banco de dados</td>
                 </tr>

--- a/src/js/modals/cliente-detalhes.js
+++ b/src/js/modals/cliente-detalhes.js
@@ -215,12 +215,12 @@
     ordens.forEach(o => {
       const tr = document.createElement('tr');
       tr.innerHTML = `
-        <td class="w-1/6 py-4 px-4 text-left text-white">${o.numero}</td>
-        <td class="w-1/6 py-4 px-4 text-left text-white">${o.tipo}</td>
-        <td class="w-1/6 py-4 px-4 text-left text-white">${o.inicio || ''}</td>
-        <td class="w-1/6 py-4 px-4 text-left text-white">${o.condicao || ''}</td>
-        <td class="w-1/6 py-4 px-4 text-left text-white">${formatCurrency(o.valor)}</td>
-        <td class="w-1/6 py-4 px-4 text-left text-white">${o.status || ''}</td>`;
+        <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-white">${o.numero}</td>
+        <td class="px-6 py-4 whitespace-nowrap text-sm text-white">${o.tipo}</td>
+        <td class="px-6 py-4 whitespace-nowrap text-sm" style="color: var(--color-violet)">${o.inicio || ''}</td>
+        <td class="px-6 py-4 whitespace-nowrap text-sm" style="color: var(--color-violet)">${o.condicao || ''}</td>
+        <td class="px-6 py-4 whitespace-nowrap text-sm text-right text-white">${formatCurrency(o.valor)}</td>
+        <td class="px-6 py-4 whitespace-nowrap text-sm text-white">${o.status || ''}</td>`;
       tbody.appendChild(tr);
     });
   }


### PR DESCRIPTION
## Summary
- Harmonize orders table styling to match budget tables
- Update client details script to render order rows with consistent classes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ada945032883229e73dfb5b2bb7546