### PR TITLE
Adicionar campos empresa e celular no cabecario

### DIFF
--- a/src/html/contatos.html
+++ b/src/html/contatos.html
@@ -100,6 +100,7 @@
                             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Nome</th>
                             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Tipo</th>
                             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Empresa</th>
+                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Celular</th>
                             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Telefone</th>
                             <th class="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">Ações</th>
                         </tr>
@@ -116,6 +117,7 @@
                             <td class="px-6 py-4 whitespace-nowrap"><span class="badge-info px-3 py-1 rounded-full text-xs font-medium">Fornecedor</span></td>
                             <td class="px-6 py-4 whitespace-nowrap text-sm" style="color: var(--color-violet)">Materiais Silva Ltda</td>
                             <td class="px-6 py-4 whitespace-nowrap text-sm" style="color: var(--color-violet)">(11) 99999-1234</td>
+                            <td class="px-6 py-4 whitespace-nowrap text-sm" style="color: var(--color-violet)">(11) 4000-1234</td>
                             <td class="px-6 py-4 whitespace-nowrap text-center">
                                 <i class="fas fa-edit w-5 h-5 cursor-pointer p-1 rounded transition-colors duration-150 hover:bg-white/10" style="color: var(--color-primary)" title="Editar"></i>
                             </td>
@@ -131,6 +133,7 @@
                             <td class="px-6 py-4 whitespace-nowrap"><span class="badge-success px-3 py-1 rounded-full text-xs font-medium">Parceiro</span></td>
                             <td class="px-6 py-4 whitespace-nowrap text-sm" style="color: var(--color-violet)">Design & Arquitetura</td>
                             <td class="px-6 py-4 whitespace-nowrap text-sm" style="color: var(--color-violet)">(11) 98888-5678</td>
+                            <td class="px-6 py-4 whitespace-nowrap text-sm" style="color: var(--color-violet)">(11) 3555-5678</td>
                             <td class="px-6 py-4 whitespace-nowrap text-center">
                                 <i class="fas fa-edit w-5 h-5 cursor-pointer p-1 rounded transition-colors duration-150 hover:bg-white/10" style="color: var(--color-primary)" title="Editar"></i>
                             </td>
@@ -146,6 +149,7 @@
                             <td class="px-6 py-4 whitespace-nowrap"><span class="badge-warning px-3 py-1 rounded-full text-xs font-medium">Arquiteto</span></td>
                             <td class="px-6 py-4 whitespace-nowrap text-sm" style="color: var(--color-violet)">Costa Arquitetura</td>
                             <td class="px-6 py-4 whitespace-nowrap text-sm" style="color: var(--color-violet)">(11) 97777-9012</td>
+                            <td class="px-6 py-4 whitespace-nowrap text-sm" style="color: var(--color-violet)">(11) 3444-9012</td>
                             <td class="px-6 py-4 whitespace-nowrap text-center">
                                 <i class="fas fa-edit w-5 h-5 cursor-pointer p-1 rounded transition-colors duration-150 hover:bg-white/10" style="color: var(--color-primary)" title="Editar"></i>
                             </td>
@@ -161,6 +165,7 @@
                             <td class="px-6 py-4 whitespace-nowrap"><span class="badge-neutral px-3 py-1 rounded-full text-xs font-medium">Representante</span></td>
                             <td class="px-6 py-4 whitespace-nowrap text-sm" style="color: var(--color-violet)">Representações Oliveira</td>
                             <td class="px-6 py-4 whitespace-nowrap text-sm" style="color: var(--color-violet)">(11) 96666-3456</td>
+                            <td class="px-6 py-4 whitespace-nowrap text-sm" style="color: var(--color-violet)">(11) 3333-3456</td>
                             <td class="px-6 py-4 whitespace-nowrap text-center">
                                 <i class="fas fa-edit w-5 h-5 cursor-pointer p-1 rounded transition-colors duration-150 hover:bg-white/10" style="color: var(--color-primary)" title="Editar"></i>
                             </td>
@@ -176,6 +181,7 @@
                             <td class="px-6 py-4 whitespace-nowrap"><span class="badge-info px-3 py-1 rounded-full text-xs font-medium">Fornecedor</span></td>
                             <td class="px-6 py-4 whitespace-nowrap text-sm" style="color: var(--color-violet)">Lima Decorações</td>
                             <td class="px-6 py-4 whitespace-nowrap text-sm" style="color: var(--color-violet)">(11) 95555-7890</td>
+                            <td class="px-6 py-4 whitespace-nowrap text-sm" style="color: var(--color-violet)">(11) 3222-7890</td>
                             <td class="px-6 py-4 whitespace-nowrap text-center">
                                 <i class="fas fa-edit w-5 h-5 cursor-pointer p-1 rounded transition-colors duration-150 hover:bg-white/10" style="color: var(--color-primary)" title="Editar"></i>
                             </td>
@@ -191,6 +197,7 @@
                             <td class="px-6 py-4 whitespace-nowrap"><span class="badge-success px-3 py-1 rounded-full text-xs font-medium">Parceiro</span></td>
                             <td class="px-6 py-4 whitespace-nowrap text-sm" style="color: var(--color-violet)">Rocha & Associados</td>
                             <td class="px-6 py-4 whitespace-nowrap text-sm" style="color: var(--color-violet)">(11) 94444-2468</td>
+                            <td class="px-6 py-4 whitespace-nowrap text-sm" style="color: var(--color-violet)">(11) 3111-2468</td>
                             <td class="px-6 py-4 whitespace-nowrap text-center">
                                 <i class="fas fa-edit w-5 h-5 cursor-pointer p-1 rounded transition-colors duration-150 hover:bg-white/10" style="color: var(--color-primary)" title="Editar"></i>
                             </td>


### PR DESCRIPTION
## Summary
- add Empresa and Celular columns to contact list header and populate sample data

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adaa7856d08322a63bcb76c10a495f