### PR TITLE
Add Celular And Empresa Fields To Prospect Header

### DIFF
--- a/src/html/prospeccoes-detalhes.html
+++ b/src/html/prospeccoes-detalhes.html
@@ -72,7 +72,7 @@
                 <div class="hidden lg:block h-16 w-px bg-white/10 justify-self-center"></div>
 
                 <!-- Metadados -->
-                <div class="grid grid-cols-2 gap-4">
+                <div class="grid grid-cols-2 md:grid-cols-3 gap-4">
                     <div class="rounded-xl bg-white/5 p-3">
                         <span class="text-[11px] uppercase tracking-wide text-white/60">Responsável</span>
                         <p id="prospectOwner" class="text-sm text-white"></p>
@@ -85,6 +85,14 @@
                         <span class="text-[11px] uppercase tracking-wide text-white/60">Telefone</span>
                         <p id="prospectPhone" class="text-sm text-white"></p>
                     </a>
+                    <a id="prospectCellLink" href="#" aria-label="" class="rounded-xl bg-white/5 hover:bg-white/10 p-3">
+                        <span class="text-[11px] uppercase tracking-wide text-white/60">Celular</span>
+                        <p id="prospectCell" class="text-sm text-white"></p>
+                    </a>
+                    <div class="rounded-xl bg-white/5 p-3">
+                        <span class="text-[11px] uppercase tracking-wide text-white/60">Empresa</span>
+                        <p id="prospectCompanyMeta" class="text-sm text-white"></p>
+                    </div>
                     <div class="rounded-xl bg-white/5 p-3">
                         <span class="text-[11px] uppercase tracking-wide text-white/60">Status</span>
                         <div class="text-sm text-white">

--- a/src/js/prospeccoes-detalhes.js
+++ b/src/js/prospeccoes-detalhes.js
@@ -50,6 +50,7 @@ function initDetalhesProspeccao() {
     ownerName: 'João Silva',
     email: 'jennifer@acme.com',
     phone: '(11) 99999-9999',
+    mobile: '(11) 98888-7777',
     status: 'Novo'
   };
   const get = id => document.getElementById(id);
@@ -86,6 +87,15 @@ function initDetalhesProspeccao() {
     phoneLink.setAttribute('aria-label', `Ligar para ${prospect.name}`);
     phoneEl.textContent = prospect.phone;
   }
+  const cellLink = get('prospectCellLink');
+  const cellEl = get('prospectCell');
+  if (cellLink && cellEl) {
+    cellLink.href = `tel:${prospect.mobile}`;
+    cellLink.setAttribute('aria-label', `Ligar para ${prospect.name} (celular)`);
+    cellEl.textContent = prospect.mobile;
+  }
+  const companyMetaEl = get('prospectCompanyMeta');
+  if (companyMetaEl) companyMetaEl.textContent = prospect.company;
   const statusEl = get('prospectStatus');
   if (statusEl) statusEl.textContent = prospect.status;
 


### PR DESCRIPTION
## Summary
- display additional Celular and Empresa fields in prospect header metadata
- populate new fields with example prospect data

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68adacd64cd88322b0e0b7c09e7d1797