### PR TITLE
Corrigir Formatação Do Modal De Prospecção

### DIFF
--- a/src/html/modals/prospeccoes/detalhes.html
+++ b/src/html/modals/prospeccoes/detalhes.html
@@ -1,30 +1,32 @@
 <div id="detalhesProspeccaoOverlay" class="hidden fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50">
   <div class="w-full max-w-6xl max-h-[90vh] glass-surface backdrop-blur-xl rounded-3xl border border-white/10 ring-1 ring-white/5 shadow-2xl/40 animate-modalFade slide-in overflow-hidden flex flex-col text-white">
-    <header class="relative px-8 py-5 border-b border-white/10 flex-shrink-0">
-        <h2 class="absolute left-1/2 -translate-x-1/2 text-lg font-semibold text-white">DETALHES PROSPECÇÃO</h2>
-        <div class="absolute left-1/2 top-14 -translate-x-1/2 text-center">
-            <h1 id="modalProspectNameHeader" class="text-2xl font-bold text-white">Jennifer Wilson</h1>
-            <p id="modalProspectCompanyHeader" class="text-gray-300">Acme Corporation</p>
-        </div>
-        <div class="flex items-center gap-3 justify-end">
-            <button class="btn-primary px-4 py-2 rounded-lg text-white font-medium">
-                Editar
-            </button>
-            <button id="prospectDelete" class="btn-danger px-4 py-2 rounded-lg text-white font-medium">
-                Deletar
-            </button>
-            <button class="btn-dark-blue px-4 py-2 rounded-lg text-white font-medium">
-                Alterar Responsável
-            </button>
-            <button id="toggleNotify" aria-pressed="false" class="btn-ghost px-4 py-2 rounded-lg text-white font-medium">
-                Notificações
-            </button>
-            <button class="btn-success px-6 py-2 rounded-lg font-medium text-black">
-                Converter
-            </button>
-            <button id="fecharDetalhesProspeccao" class="btn-danger p-2 rounded-lg text-white">
-                ✕
-            </button>
+    <header class="px-8 py-6 border-b border-white/10 flex flex-col gap-4 flex-shrink-0">
+        <h2 class="text-lg font-semibold text-center text-white">DETALHES PROSPECÇÃO</h2>
+        <div class="flex items-center">
+            <div class="flex-1 text-center">
+                <h1 id="modalProspectNameHeader" class="text-2xl font-bold text-white">Jennifer Wilson</h1>
+                <p id="modalProspectCompanyHeader" class="text-gray-300">Acme Corporation</p>
+            </div>
+            <div class="flex items-center gap-3 justify-end">
+                <button class="btn-primary px-4 py-2 rounded-lg text-white font-medium">
+                    Editar
+                </button>
+                <button id="prospectDelete" class="btn-danger px-4 py-2 rounded-lg text-white font-medium">
+                    Deletar
+                </button>
+                <button class="btn-dark-blue px-4 py-2 rounded-lg text-white font-medium">
+                    Alterar Responsável
+                </button>
+                <button id="toggleNotify" aria-pressed="false" class="btn-ghost px-4 py-2 rounded-lg text-white font-medium">
+                    Notificações
+                </button>
+                <button class="btn-success px-6 py-2 rounded-lg font-medium text-black">
+                    Converter
+                </button>
+                <button id="fecharDetalhesProspeccao" class="btn-danger p-2 rounded-lg text-white">
+                    ✕
+                </button>
+            </div>
         </div>
     </header>
 
@@ -48,7 +50,7 @@
                 <div class="hidden lg:block h-16 w-px bg-white/10 justify-self-center"></div>
 
                 <!-- Metadados -->
-                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
                     <div class="rounded-xl bg-white/5 p-3">
                         <span class="text-[11px] uppercase tracking-wide text-white/60">Responsável</span>
                         <p id="modalProspectOwner" class="text-sm text-white">João Silva</p>

--- a/src/js/modals/prospeccao-detalhes.js
+++ b/src/js/modals/prospeccao-detalhes.js
@@ -62,51 +62,73 @@
     cell: '(11) 99999-9999',
     status: 'Novo'
   };
+  const placeholder = 'Não informado';
+  const val = v => (v && String(v).trim()) ? v : placeholder;
   const get = id => document.getElementById(id);
   const initialsEl = get('modalProspectInitials');
   if (initialsEl) initialsEl.textContent = data.initials;
   const nEl = get('modalProspectName');
   if (nEl) {
-    nEl.textContent = data.name;
-    nEl.title = data.name;
+    const name = val(data.name);
+    nEl.textContent = name;
+    nEl.title = name;
   }
   const cEl = get('modalProspectCompany');
   if (cEl) {
-    cEl.textContent = data.company;
-    cEl.title = data.company;
+    const company = val(data.company);
+    cEl.textContent = company;
+    cEl.title = company;
   }
   const headerNameEl = get('modalProspectNameHeader');
-  if (headerNameEl) headerNameEl.textContent = data.name;
+  if (headerNameEl) headerNameEl.textContent = val(data.name);
   const headerCompanyEl = get('modalProspectCompanyHeader');
-  if (headerCompanyEl) headerCompanyEl.textContent = data.company;
+  if (headerCompanyEl) headerCompanyEl.textContent = val(data.company);
   const ownerEl = get('modalProspectOwner');
-  if (ownerEl) ownerEl.textContent = data.ownerName;
+  if (ownerEl) ownerEl.textContent = val(data.ownerName);
   const emailLink = get('modalProspectEmailLink');
   const emailEl = get('modalProspectEmail');
   if (emailLink && emailEl) {
-    emailLink.href = `mailto:${data.email}`;
-    emailLink.setAttribute('aria-label', `Enviar e-mail para ${data.name}`);
-    emailEl.textContent = data.email;
-    emailEl.title = data.email;
+    const email = val(data.email);
+    emailEl.textContent = email;
+    emailEl.title = email;
+    if(email !== placeholder){
+      emailLink.href = `mailto:${data.email}`;
+      emailLink.setAttribute('aria-label', `Enviar e-mail para ${data.name}`);
+    } else {
+      emailLink.removeAttribute('href');
+      emailLink.setAttribute('aria-label', 'E-mail não informado');
+    }
   }
   const phoneLink = get('modalProspectPhoneLink');
   const phoneEl = get('modalProspectPhone');
   if (phoneLink && phoneEl) {
-    phoneLink.href = `tel:${data.phone}`;
-    phoneLink.setAttribute('aria-label', `Ligar para ${data.name}`);
-    phoneEl.textContent = data.phone;
+    const phone = val(data.phone);
+    phoneEl.textContent = phone;
+    if(phone !== placeholder){
+      phoneLink.href = `tel:${data.phone}`;
+      phoneLink.setAttribute('aria-label', `Ligar para ${data.name}`);
+    } else {
+      phoneLink.removeAttribute('href');
+      phoneLink.setAttribute('aria-label', 'Telefone não informado');
+    }
   }
   const cellLink = get('modalProspectCellLink');
   const cellEl = get('modalProspectCell');
   if (cellLink && cellEl) {
-    cellLink.href = `tel:${data.cell}`;
-    cellLink.setAttribute('aria-label', `Ligar para ${data.name}`);
-    cellEl.textContent = data.cell;
+    const cell = val(data.cell);
+    cellEl.textContent = cell;
+    if(cell !== placeholder){
+      cellLink.href = `tel:${data.cell}`;
+      cellLink.setAttribute('aria-label', `Ligar para ${data.name}`);
+    } else {
+      cellLink.removeAttribute('href');
+      cellLink.setAttribute('aria-label', 'Celular não informado');
+    }
   }
   const companyMetaEl = get('modalProspectCompanyMeta');
-  if (companyMetaEl) companyMetaEl.textContent = data.company;
+  if (companyMetaEl) companyMetaEl.textContent = val(data.company);
   const statusEl = get('modalProspectStatus');
-  if (statusEl) statusEl.textContent = data.status;
+  if (statusEl) statusEl.textContent = val(data.status);
 
   const notifyBtn = document.getElementById('toggleNotify');
   if(notifyBtn){


### PR DESCRIPTION
## Summary
- Rearrange modal header to properly position title, lead name, and action buttons
- Ensure prospect metadata fields use defaults when missing
- Display metadata in three columns to better use vertical space

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adf42acdf88322b34d4334d5615e47