### PR TITLE
Ajustar Espaço Horizontal Dos Campos Do Lead Nos Detalhes De Prospecção

### DIFF
--- a/src/html/prospeccoes-detalhes.html
+++ b/src/html/prospeccoes-detalhes.html
@@ -48,7 +48,7 @@
     <!-- Summary Card -->
     <div class="px-6 py-6">
         <section class="w-full rounded-2xl bg-[--color-surface] backdrop-blur p-6 lg:p-8 shadow-lg">
-            <div class="grid gap-6 lg:grid-cols-[1.1fr_auto_0.9fr] items-center">
+            <div class="grid gap-4 lg:grid-cols-[1fr_auto_1.2fr] items-center">
                 <!-- Identidade -->
                 <div class="flex items-center gap-4">
                     <div class="h-16 w-16 rounded-full ring-2 ring-[--color-primary] grid place-items-center text-[--color-primary] font-semibold shrink-0">
@@ -64,7 +64,7 @@
                 <div class="hidden lg:block h-16 w-px bg-white/10 justify-self-center"></div>
 
                 <!-- Metadados -->
-                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-y-4 gap-x-6">
                     <div class="rounded-xl bg-white/5 p-3">
                         <span class="text-[11px] uppercase tracking-wide text-white/60">Responsável</span>
                         <p id="prospectOwner" class="text-sm text-white">João Silva</p>


### PR DESCRIPTION
## Summary
- expand the metadata column and reduce the gap from the identity section to prevent overlapping lead fields
- add horizontal spacing between lead metadata cards for clearer separation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68adf54b7500832287e58fb3489ca564