### PR TITLE
Fix Tab Bar Overlay In Prospecção Details

### DIFF
--- a/src/html/modals/prospeccoes/detalhes.html
+++ b/src/html/modals/prospeccoes/detalhes.html
@@ -83,7 +83,7 @@
         </section>
       </div>
 
-        <nav class="sticky top-0 z-20 bg-surface/80 backdrop-blur-xl border-b border-white/10" role="tablist">
+        <nav class="sticky top-0 z-20 bg-[--color-bg-deep] backdrop-blur-xl border-b border-white/10" role="tablist">
         <div class="px-8">
             <div class="flex gap-8 overflow-x-auto">
                 <button role="tab" data-tab="overview" aria-selected="true"

--- a/src/html/prospeccoes-detalhes.html
+++ b/src/html/prospeccoes-detalhes.html
@@ -98,7 +98,7 @@
     </div>
 
     <!-- Sticky Tabs -->
-      <nav class="sticky top-[120px] z-20 bg-surface/80 backdrop-blur-xl border-b border-white/10" role="tablist">
+      <nav class="sticky top-[120px] z-20 bg-[--color-bg-deep] backdrop-blur-xl border-b border-white/10" role="tablist">
         <div class="px-6">
             <div class="flex gap-8 overflow-x-auto">
                 <button role="tab" data-tab="overview" aria-selected="true"


### PR DESCRIPTION
## Summary
- prevent content from showing through sticky tab bars

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae0021915483229257ef8b7840f12a