### PR TITLE
Padronizar metadados do header do prospect

### DIFF
--- a/src/html/modals/prospeccoes/detalhes.html
+++ b/src/html/modals/prospeccoes/detalhes.html
@@ -34,9 +34,9 @@
       <!-- Summary Card -->
       <div class="px-8 py-6">
         <section class="w-full rounded-2xl bg-[--color-surface] backdrop-blur p-6 lg:p-8 shadow-lg">
-            <div class="grid gap-6 lg:grid-cols-[1.1fr_auto_0.9fr] items-center">
+            <div class="grid grid-cols-12 gap-6 items-center">
                 <!-- Identidade -->
-                <div class="flex items-center gap-4">
+                <div class="col-span-12 lg:col-span-6 flex items-center gap-4">
                     <div class="h-16 w-16 rounded-full ring-2 ring-[--color-primary] grid place-items-center text-[--color-primary] font-semibold shrink-0">
                         <span id="modalProspectInitials">JW</span>
                     </div>
@@ -46,37 +46,39 @@
                     </div>
                 </div>
 
-                <!-- Divisor Vertical -->
-                <div class="hidden lg:block h-16 w-px bg-white/10 justify-self-center"></div>
+                <!-- Metadados 3×2 -->
+                <div class="col-span-12 lg:col-span-6 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
 
-                <!-- Metadados -->
-                <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
-                    <div class="rounded-xl bg-white/5 p-3">
+                    <div class="rounded-lg border border-white/10 bg-white/5 backdrop-blur p-3 h-[76px] flex flex-col justify-center">
                         <span class="text-[11px] uppercase tracking-wide text-white/60">Responsável</span>
-                        <p id="modalProspectOwner" class="text-sm text-white">João Silva</p>
+                        <span id="modalProspectOwner" class="text-sm text-white truncate" title="João Silva">João Silva</span>
                     </div>
-                    <a id="modalProspectEmailLink" href="mailto:jennifer@acme.com" aria-label="Enviar e-mail" class="rounded-xl bg-white/5 hover:bg-white/10 p-3">
+
+                    <a id="modalProspectEmailLink" href="mailto:jennifer@acme.com" class="rounded-lg border border-white/10 bg-white/5 backdrop-blur p-3 h-[76px] flex flex-col justify-center hover:bg-white/10 transition-colors" aria-label="Enviar e-mail">
                         <span class="text-[11px] uppercase tracking-wide text-white/60">E-mail</span>
-                        <p id="modalProspectEmail" class="text-sm text-white" title="jennifer@acme.com">jennifer@acme.com</p>
+                        <span id="modalProspectEmail" class="text-sm text-white truncate" title="jennifer@acme.com">jennifer@acme.com</span>
                     </a>
-                    <a id="modalProspectPhoneLink" href="tel:(11)3333-4444" aria-label="Ligar" class="rounded-xl bg-white/5 hover:bg-white/10 p-3">
+
+                    <a id="modalProspectPhoneLink" href="tel:(11)3333-4444" class="rounded-lg border border-white/10 bg-white/5 backdrop-blur p-3 h-[76px] flex flex-col justify-center hover:bg-white/10 transition-colors" aria-label="Ligar">
                         <span class="text-[11px] uppercase tracking-wide text-white/60">Telefone</span>
-                        <p id="modalProspectPhone" class="text-sm text-white">(11) 3333-4444</p>
+                        <span id="modalProspectPhone" class="text-sm text-white truncate" title="(11) 3333-4444">(11) 3333-4444</span>
                     </a>
-                    <a id="modalProspectCellLink" href="tel:(11)99999-9999" aria-label="Ligar" class="rounded-xl bg-white/5 hover:bg-white/10 p-3">
+
+                    <a id="modalProspectCellLink" href="tel:(11)99999-9999" class="rounded-lg border border-white/10 bg-white/5 backdrop-blur p-3 h-[76px] flex flex-col justify-center hover:bg-white/10 transition-colors" aria-label="Ligar celular">
                         <span class="text-[11px] uppercase tracking-wide text-white/60">Celular</span>
-                        <p id="modalProspectCell" class="text-sm text-white">(11) 99999-9999</p>
+                        <span id="modalProspectCell" class="text-sm text-white truncate" title="(11) 99999-9999">(11) 99999-9999</span>
                     </a>
-                    <div class="rounded-xl bg-white/5 p-3">
+
+                    <div class="rounded-lg border border-white/10 bg-white/5 backdrop-blur p-3 h-[76px] flex flex-col justify-center">
                         <span class="text-[11px] uppercase tracking-wide text-white/60">Empresa</span>
-                        <p id="modalProspectCompanyMeta" class="text-sm text-white">Acme Corporation</p>
+                        <span id="modalProspectCompanyMeta" class="text-sm text-white truncate" title="Acme Corporation">Acme Corporation</span>
                     </div>
-                    <div class="rounded-xl bg-white/5 p-3">
+
+                    <div class="rounded-lg border border-white/10 bg-white/5 backdrop-blur p-3 h-[76px] flex flex-col justify-center">
                         <span class="text-[11px] uppercase tracking-wide text-white/60">Status</span>
-                        <div class="text-sm text-white">
-                            <span id="modalProspectStatus" class="inline-flex mt-1 px-2.5 py-1 rounded-full text-xs font-medium bg-emerald-500/20 text-emerald-200">Novo</span>
-                        </div>
+                        <span id="modalProspectStatus" class="mt-1 inline-flex max-w-max px-2.5 py-1 rounded-full text-xs font-medium bg-emerald-500/20 text-emerald-200 truncate" title="Novo">Novo</span>
                     </div>
+
                 </div>
             </div>
             <div class="mt-6 lg:hidden h-px w-full bg-white/10"></div>

--- a/src/js/modals/prospeccao-detalhes.js
+++ b/src/js/modals/prospeccao-detalhes.js
@@ -65,32 +65,36 @@
   const placeholder = 'Não informado';
   const val = v => (v && String(v).trim()) ? v : placeholder;
   const get = id => document.getElementById(id);
+  const setText = (el, text) => {
+    const isPlaceholder = text === placeholder;
+    el.textContent = text;
+    el.title = text;
+    el.classList.toggle('text-white/50', isPlaceholder);
+    el.classList.toggle('text-white', !isPlaceholder);
+  };
   const initialsEl = get('modalProspectInitials');
   if (initialsEl) initialsEl.textContent = data.initials;
   const nEl = get('modalProspectName');
   if (nEl) {
     const name = val(data.name);
-    nEl.textContent = name;
-    nEl.title = name;
+    setText(nEl, name);
   }
   const cEl = get('modalProspectCompany');
   if (cEl) {
     const company = val(data.company);
-    cEl.textContent = company;
-    cEl.title = company;
+    setText(cEl, company);
   }
   const headerNameEl = get('modalProspectNameHeader');
   if (headerNameEl) headerNameEl.textContent = val(data.name);
   const headerCompanyEl = get('modalProspectCompanyHeader');
   if (headerCompanyEl) headerCompanyEl.textContent = val(data.company);
   const ownerEl = get('modalProspectOwner');
-  if (ownerEl) ownerEl.textContent = val(data.ownerName);
+  if (ownerEl) setText(ownerEl, val(data.ownerName));
   const emailLink = get('modalProspectEmailLink');
   const emailEl = get('modalProspectEmail');
   if (emailLink && emailEl) {
     const email = val(data.email);
-    emailEl.textContent = email;
-    emailEl.title = email;
+    setText(emailEl, email);
     if(email !== placeholder){
       emailLink.href = `mailto:${data.email}`;
       emailLink.setAttribute('aria-label', `Enviar e-mail para ${data.name}`);
@@ -103,7 +107,7 @@
   const phoneEl = get('modalProspectPhone');
   if (phoneLink && phoneEl) {
     const phone = val(data.phone);
-    phoneEl.textContent = phone;
+    setText(phoneEl, phone);
     if(phone !== placeholder){
       phoneLink.href = `tel:${data.phone}`;
       phoneLink.setAttribute('aria-label', `Ligar para ${data.name}`);
@@ -116,7 +120,7 @@
   const cellEl = get('modalProspectCell');
   if (cellLink && cellEl) {
     const cell = val(data.cell);
-    cellEl.textContent = cell;
+    setText(cellEl, cell);
     if(cell !== placeholder){
       cellLink.href = `tel:${data.cell}`;
       cellLink.setAttribute('aria-label', `Ligar para ${data.name}`);
@@ -126,9 +130,15 @@
     }
   }
   const companyMetaEl = get('modalProspectCompanyMeta');
-  if (companyMetaEl) companyMetaEl.textContent = val(data.company);
+  if (companyMetaEl) setText(companyMetaEl, val(data.company));
   const statusEl = get('modalProspectStatus');
-  if (statusEl) statusEl.textContent = val(data.status);
+  if (statusEl) {
+    const status = val(data.status);
+    const isPlaceholder = status === placeholder;
+    statusEl.textContent = status;
+    statusEl.title = status;
+    statusEl.className = 'mt-1 inline-flex max-w-max px-2.5 py-1 rounded-full text-xs font-medium truncate ' + (isPlaceholder ? 'bg-white/5 text-white/50' : 'bg-emerald-500/20 text-emerald-200');
+  }
 
   const notifyBtn = document.getElementById('toggleNotify');
   if(notifyBtn){


### PR DESCRIPTION
## Summary
- reorganize metadata tiles into a responsive 3×2 grid with uniform glass cards
- add placeholder handling for missing fields and dynamic status badge styling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae0383154083228a353d9b4b7ffa3d