### PR TITLE
Enable copy-to-clipboard for prospect contact fields

### DIFF
--- a/src/html/prospeccoes-detalhes.html
+++ b/src/html/prospeccoes-detalhes.html
@@ -69,18 +69,18 @@
                         <span class="text-[11px] uppercase tracking-wide text-white/60">Responsável</span>
                         <p id="prospectOwner" class="text-sm text-white">João Silva</p>
                     </div>
-                    <a id="prospectEmailLink" href="mailto:jennifer@acme.com" aria-label="Enviar e-mail para Jennifer Wilson" class="rounded-xl bg-white/5 hover:bg-white/10 p-3">
+                    <button id="prospectEmailLink" type="button" aria-label="Copiar e-mail" class="rounded-xl bg-white/5 hover:bg-white/10 p-3 w-full text-left">
                         <span class="text-[11px] uppercase tracking-wide text-white/60">E-mail</span>
                         <p id="prospectEmail" class="text-sm text-white" title="jennifer@acme.com">jennifer@acme.com</p>
-                    </a>
-                    <a id="prospectPhoneLink" href="tel:(11)3333-4444" aria-label="Ligar para Jennifer Wilson" class="rounded-xl bg-white/5 hover:bg-white/10 p-3">
+                    </button>
+                    <button id="prospectPhoneLink" type="button" aria-label="Copiar telefone" class="rounded-xl bg-white/5 hover:bg-white/10 p-3 w-full text-left">
                         <span class="text-[11px] uppercase tracking-wide text-white/60">Telefone</span>
                         <p id="prospectPhone" class="text-sm text-white">(11) 3333-4444</p>
-                    </a>
-                    <a id="prospectCellLink" href="tel:(11)99999-9999" aria-label="Ligar para Jennifer Wilson" class="rounded-xl bg-white/5 hover:bg-white/10 p-3">
+                    </button>
+                    <button id="prospectCellLink" type="button" aria-label="Copiar celular" class="rounded-xl bg-white/5 hover:bg-white/10 p-3 w-full text-left">
                         <span class="text-[11px] uppercase tracking-wide text-white/60">Celular</span>
                         <p id="prospectCell" class="text-sm text-white">(11) 99999-9999</p>
-                    </a>
+                    </button>
                     <div class="rounded-xl bg-white/5 p-3">
                         <span class="text-[11px] uppercase tracking-wide text-white/60">Empresa</span>
                         <p id="prospectCompanyMeta" class="text-sm text-white">Acme Corporation</p>
@@ -479,5 +479,7 @@
         </section>
     </div>
   </div>
+  <script src="../js/utils/notifications.js"></script>
+  <script src="../js/prospeccoes-detalhes.js"></script>
 </body>
 </html>

--- a/src/js/prospeccoes-detalhes.js
+++ b/src/js/prospeccoes-detalhes.js
@@ -75,24 +75,41 @@ function initDetalhesProspeccao() {
   const emailLink = get('prospectEmailLink');
   const emailEl = get('prospectEmail');
   if (emailLink && emailEl) {
-    emailLink.href = `mailto:${prospect.email}`;
-    emailLink.setAttribute('aria-label', `Enviar e-mail para ${prospect.name}`);
+    emailLink.setAttribute('aria-label', `Copiar e-mail de ${prospect.name}`);
     emailEl.textContent = prospect.email;
     emailEl.title = prospect.email;
+    emailLink.addEventListener('click', e => {
+      e.preventDefault();
+      navigator.clipboard
+        .writeText(prospect.email)
+        .then(() => window.showToast?.('E-mail copiado!', 'success'));
+    });
   }
   const phoneLink = get('prospectPhoneLink');
   const phoneEl = get('prospectPhone');
   if (phoneLink && phoneEl) {
-    phoneLink.href = `tel:${prospect.phone}`;
-    phoneLink.setAttribute('aria-label', `Ligar para ${prospect.name}`);
+    phoneLink.setAttribute('aria-label', `Copiar telefone de ${prospect.name}`);
     phoneEl.textContent = prospect.phone;
+    phoneEl.title = prospect.phone;
+    phoneLink.addEventListener('click', e => {
+      e.preventDefault();
+      navigator.clipboard
+        .writeText(prospect.phone)
+        .then(() => window.showToast?.('Telefone copiado!', 'success'));
+    });
   }
   const cellLink = get('prospectCellLink');
   const cellEl = get('prospectCell');
   if (cellLink && cellEl) {
-    cellLink.href = `tel:${prospect.mobile}`;
-    cellLink.setAttribute('aria-label', `Ligar para ${prospect.name} (celular)`);
+    cellLink.setAttribute('aria-label', `Copiar celular de ${prospect.name}`);
     cellEl.textContent = prospect.mobile;
+    cellEl.title = prospect.mobile;
+    cellLink.addEventListener('click', e => {
+      e.preventDefault();
+      navigator.clipboard
+        .writeText(prospect.mobile)
+        .then(() => window.showToast?.('Celular copiado!', 'success'));
+    });
   }
   const companyMetaEl = get('prospectCompanyMeta');
   if (companyMetaEl) companyMetaEl.textContent = prospect.company;


### PR DESCRIPTION
## Summary
- Replace prospect contact links with buttons to avoid default mailto/tel behavior
- Simplify copy-to-clipboard handlers to show success toasts for email, phone, and cell

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae09964ec88322ba7bbcab8b2b4644