### PR TITLE
Enable copy-on-click for prospect modal contact info

### DIFF
--- a/src/html/modals/prospeccoes/detalhes.html
+++ b/src/html/modals/prospeccoes/detalhes.html
@@ -54,20 +54,20 @@
                         <span id="modalProspectOwner" class="text-sm text-white truncate" title="João Silva">João Silva</span>
                     </div>
 
-                    <a id="modalProspectEmailLink" href="mailto:jennifer@acme.com" class="rounded-lg border border-white/10 bg-white/5 backdrop-blur p-3 h-[76px] flex flex-col justify-center hover:bg-white/10 transition-colors" aria-label="Enviar e-mail">
+                    <button id="modalProspectEmailLink" type="button" class="rounded-lg border border-white/10 bg-white/5 backdrop-blur p-3 h-[76px] flex flex-col justify-center hover:bg-white/10 transition-colors" aria-label="Copiar e-mail">
                         <span class="text-[11px] uppercase tracking-wide text-white/60">E-mail</span>
                         <span id="modalProspectEmail" class="text-sm text-white truncate" title="jennifer@acme.com">jennifer@acme.com</span>
-                    </a>
+                    </button>
 
-                    <a id="modalProspectPhoneLink" href="tel:(11)3333-4444" class="rounded-lg border border-white/10 bg-white/5 backdrop-blur p-3 h-[76px] flex flex-col justify-center hover:bg-white/10 transition-colors" aria-label="Ligar">
+                    <button id="modalProspectPhoneLink" type="button" class="rounded-lg border border-white/10 bg-white/5 backdrop-blur p-3 h-[76px] flex flex-col justify-center hover:bg-white/10 transition-colors" aria-label="Copiar telefone">
                         <span class="text-[11px] uppercase tracking-wide text-white/60">Telefone</span>
                         <span id="modalProspectPhone" class="text-sm text-white truncate" title="(11) 3333-4444">(11) 3333-4444</span>
-                    </a>
+                    </button>
 
-                    <a id="modalProspectCellLink" href="tel:(11)99999-9999" class="rounded-lg border border-white/10 bg-white/5 backdrop-blur p-3 h-[76px] flex flex-col justify-center hover:bg-white/10 transition-colors" aria-label="Ligar celular">
+                    <button id="modalProspectCellLink" type="button" class="rounded-lg border border-white/10 bg-white/5 backdrop-blur p-3 h-[76px] flex flex-col justify-center hover:bg-white/10 transition-colors" aria-label="Copiar celular">
                         <span class="text-[11px] uppercase tracking-wide text-white/60">Celular</span>
                         <span id="modalProspectCell" class="text-sm text-white truncate" title="(11) 99999-9999">(11) 99999-9999</span>
-                    </a>
+                    </button>
 
                     <div class="rounded-lg border border-white/10 bg-white/5 backdrop-blur p-3 h-[76px] flex flex-col justify-center">
                         <span class="text-[11px] uppercase tracking-wide text-white/60">Empresa</span>

--- a/src/js/modals/prospeccao-detalhes.js
+++ b/src/js/modals/prospeccao-detalhes.js
@@ -95,12 +95,14 @@
   if (emailLink && emailEl) {
     const email = val(data.email);
     setText(emailEl, email);
-    if(email !== placeholder){
-      emailLink.href = `mailto:${data.email}`;
-      emailLink.setAttribute('aria-label', `Enviar e-mail para ${data.name}`);
-    } else {
-      emailLink.removeAttribute('href');
-      emailLink.setAttribute('aria-label', 'E-mail não informado');
+    emailLink.setAttribute('aria-label', email !== placeholder ? `Copiar e-mail de ${data.name}` : 'E-mail não informado');
+    if (email !== placeholder) {
+      emailLink.addEventListener('click', e => {
+        e.preventDefault();
+        navigator.clipboard
+          .writeText(data.email)
+          .then(() => window.showToast?.('E-mail copiado!', 'success'));
+      });
     }
   }
   const phoneLink = get('modalProspectPhoneLink');
@@ -108,12 +110,14 @@
   if (phoneLink && phoneEl) {
     const phone = val(data.phone);
     setText(phoneEl, phone);
-    if(phone !== placeholder){
-      phoneLink.href = `tel:${data.phone}`;
-      phoneLink.setAttribute('aria-label', `Ligar para ${data.name}`);
-    } else {
-      phoneLink.removeAttribute('href');
-      phoneLink.setAttribute('aria-label', 'Telefone não informado');
+    phoneLink.setAttribute('aria-label', phone !== placeholder ? `Copiar telefone de ${data.name}` : 'Telefone não informado');
+    if (phone !== placeholder) {
+      phoneLink.addEventListener('click', e => {
+        e.preventDefault();
+        navigator.clipboard
+          .writeText(data.phone)
+          .then(() => window.showToast?.('Telefone copiado!', 'success'));
+      });
     }
   }
   const cellLink = get('modalProspectCellLink');
@@ -121,12 +125,14 @@
   if (cellLink && cellEl) {
     const cell = val(data.cell);
     setText(cellEl, cell);
-    if(cell !== placeholder){
-      cellLink.href = `tel:${data.cell}`;
-      cellLink.setAttribute('aria-label', `Ligar para ${data.name}`);
-    } else {
-      cellLink.removeAttribute('href');
-      cellLink.setAttribute('aria-label', 'Celular não informado');
+    cellLink.setAttribute('aria-label', cell !== placeholder ? `Copiar celular de ${data.name}` : 'Celular não informado');
+    if (cell !== placeholder) {
+      cellLink.addEventListener('click', e => {
+        e.preventDefault();
+        navigator.clipboard
+          .writeText(data.cell)
+          .then(() => window.showToast?.('Celular copiado!', 'success'));
+      });
     }
   }
   const companyMetaEl = get('modalProspectCompanyMeta');


### PR DESCRIPTION
## Summary
- allow copying e-mail, phone and cell from prospect details modal
- show success toast after copying contact fields

## Testing
- `npm test` *(fails: Cannot find module '/workspace/App-Gestao/backend')*


------
https://chatgpt.com/codex/tasks/task_e_68ae1356301883229927096c848c9b58