### PR TITLE
Add loading spinner to client details modal

### DIFF
--- a/src/js/clientes.js
+++ b/src/js/clientes.js
@@ -115,9 +115,36 @@ function renderClientes(clientes) {
     });
 }
 
+function openModalWithSpinner(htmlPath, scriptPath, overlayId) {
+    Modal.closeAll();
+    const spinner = document.createElement('div');
+    spinner.id = 'modalLoading';
+    spinner.className = 'fixed inset-0 z-[2000] bg-black/50 flex items-center justify-center';
+    spinner.innerHTML = '<div class="w-16 h-16 border-4 border-[#b6a03e] border-t-transparent rounded-full animate-spin"></div>';
+    document.body.appendChild(spinner);
+    const start = Date.now();
+    function handleLoaded(e) {
+        if (e.detail !== overlayId) return;
+        const overlay = document.getElementById(`${overlayId}Overlay`);
+        const elapsed = Date.now() - start;
+        const show = () => {
+            spinner.remove();
+            overlay.classList.remove('hidden');
+        };
+        if (elapsed < 3000) {
+            setTimeout(show, Math.max(0, 2000 - elapsed));
+        } else {
+            show();
+        }
+        window.removeEventListener('modalSpinnerLoaded', handleLoaded);
+    }
+    window.addEventListener('modalSpinnerLoaded', handleLoaded);
+    Modal.open(htmlPath, scriptPath, overlayId, true);
+}
+
 function abrirDetalhesCliente(cliente) {
     window.clienteDetalhes = cliente;
-    Modal.open('modals/clientes/detalhes.html', '../js/modals/cliente-detalhes.js', 'detalhesCliente');
+    openModalWithSpinner('modals/clientes/detalhes.html', '../js/modals/cliente-detalhes.js', 'detalhesCliente');
 }
 
 function renderTotais(clientes) {

--- a/src/js/modals/cliente-detalhes.js
+++ b/src/js/modals/cliente-detalhes.js
@@ -1,7 +1,6 @@
 (async function(){
   const overlay = document.getElementById('detalhesClienteOverlay');
   if(!overlay) return;
-  overlay.classList.remove('hidden');
   const close = () => Modal.close('detalhesCliente');
   overlay.addEventListener('click', e => { if(e.target === overlay) close(); });
   const voltar = document.getElementById('voltarDetalhesCliente');
@@ -23,10 +22,14 @@
         const notas = document.getElementById('clienteNotas');
         if(notas) notas.value = data.cliente.anotacoes || '';
       }
-      carregarOrdens(cliente.id);
+      await carregarOrdens(cliente.id);
     } catch(err){
       console.error('Erro ao carregar detalhes do cliente', err);
+    } finally {
+      window.dispatchEvent(new CustomEvent('modalSpinnerLoaded', { detail: 'detalhesCliente' }));
     }
+  } else {
+    window.dispatchEvent(new CustomEvent('modalSpinnerLoaded', { detail: 'detalhesCliente' }));
   }
 
   const tablist = overlay.querySelector('[role="tablist"]');


### PR DESCRIPTION
## Summary
- show a spinner while client details modal loads data
- dispatch spinner completion event after fetching client details and orders

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae156607bc8322a60363d9a86f15a9