### PR TITLE
Clone modal mais detalhes para editar

### DIFF
--- a/src/html/modals/produtos/editar-detalhes.html
+++ b/src/html/modals/produtos/editar-detalhes.html
@@ -1,0 +1,56 @@
+<div id="editarDetalhesProdutoOverlay" class="hidden fixed inset-0 bg-black/50 flex items-center justify-center p-4">
+  <div class="w-full max-w-6xl max-h-[90vh] glass-surface backdrop-blur-xl rounded-3xl border border-white/10 ring-1 ring-white/5 shadow-2xl/40 animate-modalFade slide-in overflow-hidden flex flex-col">
+    <header class="px-8 py-5 border-b border-white/10 flex-shrink-0">
+      <div class="flex items-center justify-between mb-3">
+        <button id="voltarEditarDetalhesProduto" class="btn-neutral px-4 py-2 rounded-lg text-white font-medium flex items-center gap-2">← Voltar</button>
+        <h2 id="detalheTitulo" class="text-lg font-semibold text-white text-center flex-1 mx-4">DETALHE DE ESTOQUE – Produto</h2>
+        <button id="abrirInserirEstoque" class="btn-primary px-4 py-2 rounded-lg text-white font-medium flex items-center gap-2"><i class="fas fa-plus"></i>Inserir</button>
+      </div>
+      <!-- Subtítulo exibe código da peça -->
+      <p id="codigoPeca" class="text-sm text-gray-400 text-center"></p>
+    </header>
+
+    <div class="flex-1 overflow-y-auto modal-scroll">
+        <div class="px-8 py-6">
+              <div class="glass-surface rounded-xl border border-white/10 table-scroll">
+                  <table class="w-full">
+                      <thead class="bg-gray-50 sticky top-0">
+                          <tr class="border-b border-gray-200">
+                              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">PROCESSO ATUAL</th>
+                              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">ULTIMO ITEM</th>
+                              <th class="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">QUANTIDADE EM ESTOQUE</th>
+                              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">ÚLTIMA ALTERAÇÃO</th>
+                              <th class="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">AÇÕES</th>
+                          </tr>
+                      </thead>
+                      <tbody id="detalhesTableBody" class="divide-y divide-white/10 text-sm">
+                              </tbody>
+                  </table>
+              </div>
+              </div>
+       </div>
+
+      <div class="px-8 pb-8">
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
+            <div class="bg-surface/40 rounded-xl p-6 border border-white/10 text-center">
+              <p class="text-sm text-gray-400 mb-2">Total em Estoque</p>
+              <p id="totalEstoque" class="text-3xl font-bold text-white">0</p>
+              <p class="text-xs text-gray-500 mt-1">unidades</p>
+            </div>
+
+            <div class="bg-surface/40 rounded-xl p-6 border border-white/10 text-center">
+              <p class="text-sm text-gray-400 mb-2">Valor Estimado</p>
+              <p id="valorEstimado" class="text-3xl font-bold text-white">R$ 0,00</p>
+              <p class="text-xs text-gray-500 mt-1">valor total</p>
+            </div>
+
+            <div class="bg-surface/40 rounded-xl p-6 border border-white/10 text-center">
+              <p class="text-sm text-gray-400 mb-2">Lotes Ativos</p>
+              <p id="lotesAtivos" class="text-3xl font-bold text-white">0</p>
+              <p class="text-xs text-gray-500 mt-1">lotes</p>
+            </div>
+          </div>
+        </div>
+      </div>
+  </div>
+</div>

--- a/src/js/modals/produto-detalhes-editar.js
+++ b/src/js/modals/produto-detalhes-editar.js
@@ -1,0 +1,114 @@
+(function(){
+  const overlay = document.getElementById('editarDetalhesProdutoOverlay');
+  const close = () => Modal.close('editarDetalhesProduto');
+  overlay.addEventListener('click', e => { if(e.target === overlay) close(); });
+  const voltar = document.getElementById('voltarEditarDetalhesProduto');
+  if (voltar) voltar.addEventListener('click', close);
+  document.addEventListener('keydown', function esc(e){ if(e.key==='Escape'){ close(); document.removeEventListener('keydown', esc); } });
+
+  const inserirBtn = document.getElementById('abrirInserirEstoque');
+  if (inserirBtn) inserirBtn.addEventListener('click', () => {
+    overlay.classList.add('pointer-events-none', 'blur-sm');
+    Modal.open('modals/produtos/estoque-inserir.html', '../js/modals/produto-estoque-inserir.js', 'inserirEstoque', true);
+  });
+
+  const item = window.produtoDetalhesEditar;
+  if(item){
+    const titulo = document.getElementById('detalheTitulo');
+    if(titulo) titulo.textContent = `DETALHE DE ESTOQUE – ${item.nome || ''}`;
+    const codigoEl = document.getElementById('codigoPeca');
+    if(codigoEl) codigoEl.textContent = `Código da Peça: ${item.codigo || ''}`; // subtítulo mostra código da peça
+    carregarDetalhes(item.codigo, item.id).finally(() => {
+      window.dispatchEvent(new CustomEvent('modalSpinnerLoaded', { detail: 'editarDetalhesProduto' }));
+    });
+    window.reloadEditarDetalhesProduto = () => carregarDetalhes(item.codigo, item.id);
+  } else {
+    window.dispatchEvent(new CustomEvent('modalSpinnerLoaded', { detail: 'editarDetalhesProduto' }));
+  }
+
+  async function carregarDetalhes(codigo, id){
+    try {
+      // Ajuste: envia produtoCodigo (string) e produtoId (int)
+      const { lotes: dados } = await window.electronAPI.listarDetalhesProduto({ produtoCodigo: codigo, produtoId: id });
+      item.lotes = dados;
+      const tbody = document.getElementById('detalhesTableBody');
+      if(!tbody) return;
+      tbody.innerHTML = '';
+      let total = 0;
+      dados.forEach(d => {
+        total += Number(d.quantidade || 0);
+        const tr = document.createElement('tr');
+        tr.className = 'border-b border-white/5 hover:bg-white/5 transition';
+        tr.innerHTML = `
+          <td class="py-4 px-4 text-gray-300">${d.etapa || ''}</td>
+          <td class="py-4 px-4 text-white font-medium">${d.ultimo_item || ''}</td>
+          <td class="py-4 px-4 text-center text-white font-medium">${d.quantidade ?? ''}</td>
+          <td class="py-4 px-4 text-gray-300">${formatDateTime(d.data_hora_completa)}</td>
+          <td class="py-4 px-4 text-center">
+            <div class="flex items-center justify-center space-x-2">
+              <i class="fas fa-edit w-5 h-5 cursor-pointer p-1 rounded transition-colors duration-150 hover:bg-white/10" style="color: var(--color-primary)" title="Editar"></i>
+              <i class="fas fa-trash w-5 h-5 cursor-pointer p-1 rounded transition-colors duration-150 hover:bg-white/10 hover:text-white" style="color: var(--color-red)" title="Excluir"></i>
+            </div>
+          </td>
+        `;
+        const editBtn = tr.querySelector('.fa-edit');
+        const delBtn = tr.querySelector('.fa-trash');
+        if (editBtn) editBtn.addEventListener('click', () => editarLinha(tr, d));
+        if (delBtn) delBtn.addEventListener('click', () => excluirLote(d.id));
+        tbody.appendChild(tr);
+      });
+      const totalEl = document.getElementById('totalEstoque');
+      if (totalEl) totalEl.textContent = total;
+      const lotesEl = document.getElementById('lotesAtivos');
+      if (lotesEl) lotesEl.textContent = dados.length;
+      const valorEl = document.getElementById('valorEstimado');
+      const preco = Number(item?.preco_venda || 0);
+      if (valorEl) valorEl.textContent = (total * preco).toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
+    } catch(err) {
+      console.error('Erro ao carregar detalhes do produto', err);
+    }
+  }
+
+  function editarLinha(tr, dados) {
+    const qtdCell = tr.children[2];
+    const actionsCell = tr.children[4];
+    const original = dados.quantidade;
+    qtdCell.innerHTML = `<input type="number" class="w-20 bg-transparent border-b border-white/20 text-center text-white focus:outline-none" value="${original}">`;
+    actionsCell.innerHTML = `
+      <div class="flex items-center justify-center space-x-2">
+        <i class="fas fa-check w-5 h-5 cursor-pointer p-1 rounded transition-colors duration-150 hover:bg-white/10" style="color: var(--color-green)" title="Confirmar"></i>
+        <i class="fas fa-times w-5 h-5 cursor-pointer p-1 rounded transition-colors duration-150 hover:bg-white/10 hover:text-white" style="color: var(--color-red)" title="Cancelar"></i>
+      </div>`;
+    const input = qtdCell.querySelector('input');
+    const [confirmBtn, cancelBtn] = actionsCell.querySelectorAll('i');
+    confirmBtn.addEventListener('click', async () => {
+      const novaQtd = Number(input.value);
+      try {
+        await window.electronAPI.atualizarLoteProduto({ id: dados.id, quantidade: novaQtd });
+        showToast('Quantidade atualizada', 'success');
+        carregarDetalhes(item.codigo, item.id);
+        if (typeof carregarProdutos === 'function') carregarProdutos();
+      } catch (err) {
+        console.error(err);
+        showToast('Erro ao atualizar quantidade', 'error');
+      }
+    });
+    cancelBtn.addEventListener('click', () => carregarDetalhes(item.codigo, item.id));
+  }
+
+  function excluirLote(id) {
+    window.loteExcluir = {
+      id,
+      reload: () => {
+        carregarDetalhes(item.codigo, item.id);
+        if (typeof carregarProdutos === 'function') carregarProdutos();
+      }
+    };
+    Modal.open('modals/produtos/excluir-lote.html', '../js/modals/produto-lote-excluir.js', 'excluirLote', true);
+  }
+
+  function formatDateTime(value){
+    if(!value) return '';
+    return new Date(value).toLocaleString('pt-BR');
+  }
+})();

--- a/src/js/produtos.js
+++ b/src/js/produtos.js
@@ -418,8 +418,8 @@ function abrirEditarProduto(prod) {
         showToast('Produto inválido', 'error');
         return;
     }
-    window.produtoSelecionado = prod;
-    openModalWithSpinner('modals/produtos/editar.html', '../js/modals/produto-editar.js', 'editarProduto');
+    window.produtoDetalhesEditar = prod;
+    openModalWithSpinner('modals/produtos/editar-detalhes.html', '../js/modals/produto-detalhes-editar.js', 'editarDetalhesProduto');
 }
 
 function abrirExcluirProduto(prod) {


### PR DESCRIPTION
## Summary
- clone 'mais detalhes' modal to reuse it when editing products
- add matching script to handle cloned modal interactions
- update edit action to open the cloned details modal

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae1656adb083229a654f48dc68756c