### PR TITLE
Populate Prospect Contact Fields in Modal

### DIFF
--- a/src/html/prospeccoes.html
+++ b/src/html/prospeccoes.html
@@ -190,7 +190,7 @@
                         </thead>
                         <tbody class="divide-y divide-white/10">
                             <!-- Lead 1 -->
-                            <tr class="transition-colors duration-150" style="cursor: pointer;" onmouseover="this.style.background='rgba(163, 148, 167, 0.05)'" onmouseout="this.style.background='transparent'">
+                            <tr class="transition-colors duration-150" style="cursor: pointer;" onmouseover="this.style.background='rgba(163, 148, 167, 0.05)'" onmouseout="this.style.background='transparent'" data-company="Empresa Alpha" data-phone="(11) 3333-4444" data-cell="(11) 98888-7777">
                                     <td class="px-6 py-4 whitespace-nowrap text-sm text-white">Ana Carolina Mendes</td>
                                     <td class="px-6 py-4 whitespace-nowrap text-sm" style="color: var(--color-violet)">ana.mendes@email.com</td>
                                     <td class="px-6 py-4 whitespace-nowrap">
@@ -206,7 +206,7 @@
                                 </tr>
 
                                 <!-- Lead 2 -->
-                                <tr class="transition-colors duration-150" style="cursor: pointer;" onmouseover="this.style.background='rgba(163, 148, 167, 0.05)'" onmouseout="this.style.background='transparent'">
+                                <tr class="transition-colors duration-150" style="cursor: pointer;" onmouseover="this.style.background='rgba(163, 148, 167, 0.05)'" onmouseout="this.style.background='transparent'" data-company="Empresa Beta" data-phone="(21) 4444-5555" data-cell="(21) 97777-6666">
                                     <td class="px-6 py-4 whitespace-nowrap text-sm text-white">Roberto Silva Santos</td>
                                     <td class="px-6 py-4 whitespace-nowrap text-sm" style="color: var(--color-violet)">roberto.santos@email.com</td>
                                     <td class="px-6 py-4 whitespace-nowrap">
@@ -222,7 +222,7 @@
                                 </tr>
 
                                 <!-- Lead 3 -->
-                                <tr class="transition-colors duration-150" style="cursor: pointer;" onmouseover="this.style.background='rgba(163, 148, 167, 0.05)'" onmouseout="this.style.background='transparent'">
+                                <tr class="transition-colors duration-150" style="cursor: pointer;" onmouseover="this.style.background='rgba(163, 148, 167, 0.05)'" onmouseout="this.style.background='transparent'" data-company="Empresa Gamma" data-phone="(31) 5555-6666" data-cell="(31) 96666-5555">
                                     <td class="px-6 py-4 whitespace-nowrap text-sm text-white">Mariana Costa Lima</td>
                                     <td class="px-6 py-4 whitespace-nowrap text-sm" style="color: var(--color-violet)">mariana.lima@email.com</td>
                                     <td class="px-6 py-4 whitespace-nowrap">
@@ -238,7 +238,7 @@
                                 </tr>
 
                                 <!-- Lead 4 -->
-                                <tr class="transition-colors duration-150" style="cursor: pointer;" onmouseover="this.style.background='rgba(163, 148, 167, 0.05)'" onmouseout="this.style.background='transparent'">
+                                <tr class="transition-colors duration-150" style="cursor: pointer;" onmouseover="this.style.background='rgba(163, 148, 167, 0.05)'" onmouseout="this.style.background='transparent'" data-company="Empresa Delta" data-phone="(41) 6666-7777" data-cell="(41) 95555-4444">
                                     <td class="px-6 py-4 whitespace-nowrap text-sm text-white">Carlos Eduardo Rocha</td>
                                     <td class="px-6 py-4 whitespace-nowrap text-sm" style="color: var(--color-violet)">carlos.rocha@email.com</td>
                                     <td class="px-6 py-4 whitespace-nowrap">

--- a/src/js/modals/prospeccao-detalhes.js
+++ b/src/js/modals/prospeccao-detalhes.js
@@ -65,9 +65,11 @@
   const placeholder = 'Não informado';
   const val = v => (v && String(v).trim()) ? v : placeholder;
   const get = id => document.getElementById(id);
-  const setText = (el, text) => {
+  const truncate = (str, max) => str.length > max ? str.slice(0, max - 1) + '…' : str;
+  const setText = (el, text, max) => {
     const isPlaceholder = text === placeholder;
-    el.textContent = text;
+    const display = (!isPlaceholder && max) ? truncate(text, max) : text;
+    el.textContent = display;
     el.title = text;
     el.classList.toggle('text-white/50', isPlaceholder);
     el.classList.toggle('text-white', !isPlaceholder);
@@ -82,12 +84,12 @@
   const cEl = get('modalProspectCompany');
   if (cEl) {
     const company = val(data.company);
-    setText(cEl, company);
+    setText(cEl, company, 40);
   }
   const headerNameEl = get('modalProspectNameHeader');
   if (headerNameEl) headerNameEl.textContent = val(data.name);
   const headerCompanyEl = get('modalProspectCompanyHeader');
-  if (headerCompanyEl) headerCompanyEl.textContent = val(data.company);
+  if (headerCompanyEl) setText(headerCompanyEl, val(data.company), 40);
   const ownerEl = get('modalProspectOwner');
   if (ownerEl) setText(ownerEl, val(data.ownerName));
   const emailLink = get('modalProspectEmailLink');
@@ -109,7 +111,7 @@
   const phoneEl = get('modalProspectPhone');
   if (phoneLink && phoneEl) {
     const phone = val(data.phone);
-    setText(phoneEl, phone);
+    setText(phoneEl, phone, 20);
     phoneLink.setAttribute('aria-label', phone !== placeholder ? `Copiar telefone de ${data.name}` : 'Telefone não informado');
     if (phone !== placeholder) {
       phoneLink.addEventListener('click', e => {
@@ -124,7 +126,7 @@
   const cellEl = get('modalProspectCell');
   if (cellLink && cellEl) {
     const cell = val(data.cell);
-    setText(cellEl, cell);
+    setText(cellEl, cell, 20);
     cellLink.setAttribute('aria-label', cell !== placeholder ? `Copiar celular de ${data.name}` : 'Celular não informado');
     if (cell !== placeholder) {
       cellLink.addEventListener('click', e => {
@@ -136,7 +138,7 @@
     }
   }
   const companyMetaEl = get('modalProspectCompanyMeta');
-  if (companyMetaEl) setText(companyMetaEl, val(data.company));
+  if (companyMetaEl) setText(companyMetaEl, val(data.company), 40);
   const statusEl = get('modalProspectStatus');
   if (statusEl) {
     const status = val(data.status);

--- a/src/js/prospeccoes.js
+++ b/src/js/prospeccoes.js
@@ -45,14 +45,19 @@ function initProspeccoes() {
                 const email = emailCell?.textContent.trim() || '';
                 const status = statusCell?.textContent.trim() || '';
                 const ownerName = ownerCell?.textContent.trim() || '';
+                const limit = (str, max) => str && str.length > max ? str.slice(0, max) : str;
+                const company = limit(row.dataset.company?.trim() || '', 60);
+                const phone = limit(row.dataset.phone?.trim() || '', 20);
+                const cell = limit(row.dataset.cell?.trim() || '', 20);
                 const initials = name.split(' ').map(n => n[0]).join('').slice(0, 2).toUpperCase();
                 window.prospectDetails = {
                     initials,
                     name,
-                    company: '',
+                    company,
                     ownerName,
                     email,
-                    phone: '',
+                    phone,
+                    cell,
                     status
                 };
             }


### PR DESCRIPTION
## Summary
- include company, phone, and cell data attributes on prospect table rows
- pass these fields to the details modal with length limits
- truncate long values in the modal to keep content within its boxes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae16a333548322af8e834c73eac624