### PR TITLE
Clientes: Modal De Detalhes Com Botão Editar E Dados Fixos

### DIFF
--- a/src/html/modals/clientes/detalhes.html
+++ b/src/html/modals/clientes/detalhes.html
@@ -62,7 +62,6 @@
       <section id="panel-contatos" role="tabpanel" aria-labelledby="tab-contatos" class="px-8 py-6 hidden">
         <div class="flex justify-between items-center mb-6">
           <h3 class="text-lg font-semibold text-white">Contatos</h3>
-          <button class="btn-primary px-4 py-2 rounded-lg text-white font-medium">+ Novo Contato</button>
         </div>
         <div class="glass-surface rounded-xl border border-white/10 overflow-hidden">
           <div class="overflow-x-auto">
@@ -221,7 +220,6 @@
       <section id="panel-ordens" role="tabpanel" aria-labelledby="tab-ordens" class="px-8 py-6 hidden">
         <div class="flex justify-between items-center mb-6">
           <h3 class="text-lg font-semibold text-white">Ordens</h3>
-          <button class="btn-primary px-4 py-2 rounded-lg text-white font-medium">+ Nova Ordem</button>
         </div>
         <div class="glass-surface rounded-xl border border-white/10 overflow-hidden">
           <div class="overflow-x-auto">
@@ -255,8 +253,7 @@
     </div>
 
     <footer class="flex justify-end items-center gap-4 px-8 py-5 border-t border-white/10 flex-shrink-0">
-      <button class="btn-danger px-6 py-2 rounded-lg text-white font-medium min-w-[120px]">Cancelar</button>
-      <button class="btn-primary px-6 py-2 rounded-lg text-white font-medium min-w-[120px]">Salvar</button>
+      <button id="editarDetalhesCliente" class="btn-primary px-6 py-2 rounded-lg text-white font-medium min-w-[120px]">Editar</button>
     </footer>
   </div>
 </div>

--- a/src/js/modals/cliente-detalhes.js
+++ b/src/js/modals/cliente-detalhes.js
@@ -96,6 +96,25 @@
 
   activateTab(tabs[0], { setFocus: false });
 
+  const warn = e => {
+    if(['INPUT','SELECT','TEXTAREA'].includes(e.target.tagName)){
+      e.preventDefault();
+      e.target.blur();
+      showToast('Não é possível editar aqui. Use o botão Editar.');
+    }
+  };
+  overlay.addEventListener('mousedown', warn, true);
+  overlay.addEventListener('focusin', warn);
+  overlay.querySelectorAll('input, textarea').forEach(el => el.readOnly = true);
+
+  const editar = document.getElementById('editarDetalhesCliente');
+  if(editar){
+    editar.addEventListener('click', () => {
+      close();
+      if(cliente) abrirEditarCliente(cliente);
+    });
+  }
+
   function preencherDadosEmpresa(cli){
     const map = {
       empresaRazaoSocial: 'razao_social',


### PR DESCRIPTION
## Summary
- Substitui botões Cancelar/Salvar por botão Editar que abre modal de edição e fecha o de detalhes
- Remove opções de criar novo contato e nova ordem no modal de detalhes
- Bloqueia edição dos campos no modal de detalhes exibindo aviso ao tentar alterar

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae1889b7008322a6045d0f4723c4fe