### PR TITLE
Fix Email Overflow in Prospecting Details Modal

### DIFF
--- a/src/html/modals/prospeccoes/detalhes.html
+++ b/src/html/modals/prospeccoes/detalhes.html
@@ -51,27 +51,27 @@
 
                     <div class="rounded-lg border border-white/10 bg-white/5 backdrop-blur p-3 h-[76px] flex flex-col justify-center">
                         <span class="text-[11px] uppercase tracking-wide text-white/60">Responsável</span>
-                        <span id="modalProspectOwner" class="text-sm text-white truncate" title="João Silva">João Silva</span>
+                        <span id="modalProspectOwner" class="block text-sm text-white truncate" title="João Silva">João Silva</span>
                     </div>
 
                     <button id="modalProspectEmailLink" type="button" class="rounded-lg border border-white/10 bg-white/5 backdrop-blur p-3 h-[76px] flex flex-col justify-center hover:bg-white/10 transition-colors" aria-label="Copiar e-mail">
                         <span class="text-[11px] uppercase tracking-wide text-white/60">E-mail</span>
-                        <span id="modalProspectEmail" class="text-sm text-white truncate" title="jennifer@acme.com">jennifer@acme.com</span>
+                        <span id="modalProspectEmail" class="block text-sm text-white truncate" title="jennifer@acme.com">jennifer@acme.com</span>
                     </button>
 
                     <button id="modalProspectPhoneLink" type="button" class="rounded-lg border border-white/10 bg-white/5 backdrop-blur p-3 h-[76px] flex flex-col justify-center hover:bg-white/10 transition-colors" aria-label="Copiar telefone">
                         <span class="text-[11px] uppercase tracking-wide text-white/60">Telefone</span>
-                        <span id="modalProspectPhone" class="text-sm text-white truncate" title="(11) 3333-4444">(11) 3333-4444</span>
+                        <span id="modalProspectPhone" class="block text-sm text-white truncate" title="(11) 3333-4444">(11) 3333-4444</span>
                     </button>
 
                     <button id="modalProspectCellLink" type="button" class="rounded-lg border border-white/10 bg-white/5 backdrop-blur p-3 h-[76px] flex flex-col justify-center hover:bg-white/10 transition-colors" aria-label="Copiar celular">
                         <span class="text-[11px] uppercase tracking-wide text-white/60">Celular</span>
-                        <span id="modalProspectCell" class="text-sm text-white truncate" title="(11) 99999-9999">(11) 99999-9999</span>
+                        <span id="modalProspectCell" class="block text-sm text-white truncate" title="(11) 99999-9999">(11) 99999-9999</span>
                     </button>
 
                     <div class="rounded-lg border border-white/10 bg-white/5 backdrop-blur p-3 h-[76px] flex flex-col justify-center">
                         <span class="text-[11px] uppercase tracking-wide text-white/60">Empresa</span>
-                        <span id="modalProspectCompanyMeta" class="text-sm text-white truncate" title="Acme Corporation">Acme Corporation</span>
+                        <span id="modalProspectCompanyMeta" class="block text-sm text-white truncate" title="Acme Corporation">Acme Corporation</span>
                     </div>
 
                     <div class="rounded-lg border border-white/10 bg-white/5 backdrop-blur p-3 h-[76px] flex flex-col justify-center">


### PR DESCRIPTION
## Summary
- ensure long prospect emails (and other contact info) truncate instead of overflowing their containers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae1b6f835083228c74b73a588cdc17