### PR TITLE
Ajusta Modal de Detalhes do Cliente

### DIFF
--- a/src/css/clientes.css
+++ b/src/css/clientes.css
@@ -193,3 +193,21 @@ body {
     transform: translateX(24px);
 }
 
+.toast {
+    color: white;
+    padding: 0.5rem 1rem;
+    border-radius: 0.25rem;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    transition: opacity 0.5s ease-in-out;
+    background-color: #374151;
+}
+
+.toast-success { background-color: #16a34a; }
+.toast-error { background-color: #dc2626; }
+.toast-info { background-color: #2563eb; }
+
+.component-toggle:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+

--- a/src/js/modals/cliente-detalhes.js
+++ b/src/js/modals/cliente-detalhes.js
@@ -100,7 +100,7 @@
     if(['INPUT','SELECT','TEXTAREA'].includes(e.target.tagName)){
       e.preventDefault();
       e.target.blur();
-      showToast('Não é possível editar aqui. Use o botão Editar.');
+      showToast('Não é possível editar aqui. Use o botão Editar.', 'error');
     }
   };
   overlay.addEventListener('mousedown', warn, true);
@@ -182,14 +182,14 @@
     const entToggle = document.getElementById('entregaIgual');
     const entFields = document.getElementById('entregaFields');
     if(cobToggle && cobFields){
-      const update = () => cobFields.classList.toggle('hidden', cobToggle.checked);
-      cobToggle.addEventListener('change', update);
-      if(same(cli.endereco_cobranca, cli.endereco_registro)){ cobToggle.checked = true; update(); }
+      if(same(cli.endereco_cobranca, cli.endereco_registro)) cobToggle.checked = true;
+      cobFields.classList.toggle('hidden', cobToggle.checked);
+      cobToggle.disabled = true;
     }
     if(entToggle && entFields){
-      const update = () => entFields.classList.toggle('hidden', entToggle.checked);
-      entToggle.addEventListener('change', update);
-      if(same(cli.endereco_entrega, cli.endereco_registro)){ entToggle.checked = true; update(); }
+      if(same(cli.endereco_entrega, cli.endereco_registro)) entToggle.checked = true;
+      entFields.classList.toggle('hidden', entToggle.checked);
+      entToggle.disabled = true;
     }
   }
 


### PR DESCRIPTION
## Summary
- destaca avisos de erro em vermelho e bloqueia toggles no modal de detalhes
- impede interação em botões on/off e mantém navegação para edição

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae1d021c108322840773fe40cc2029