### PR TITLE
Prevent Email Text Overflow

### DIFF
--- a/src/html/modals/prospeccoes/detalhes.html
+++ b/src/html/modals/prospeccoes/detalhes.html
@@ -49,32 +49,32 @@
                 <!-- Metadados 3×2 -->
                 <div class="col-span-12 lg:col-span-7 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
 
-                    <div class="rounded-lg border border-white/10 bg-white/5 backdrop-blur p-3 h-[76px] flex flex-col justify-center">
+                    <div class="rounded-lg border border-white/10 bg-white/5 backdrop-blur p-3 h-[76px] flex flex-col justify-center overflow-hidden">
                         <span class="text-[11px] uppercase tracking-wide text-white/60">Responsável</span>
                         <span id="modalProspectOwner" class="block text-sm text-white truncate" title="João Silva">João Silva</span>
                     </div>
 
-                    <button id="modalProspectEmailLink" type="button" class="rounded-lg border border-white/10 bg-white/5 backdrop-blur p-3 h-[76px] flex flex-col justify-center hover:bg-white/10 transition-colors" aria-label="Copiar e-mail">
+                    <button id="modalProspectEmailLink" type="button" class="rounded-lg border border-white/10 bg-white/5 backdrop-blur p-3 h-[76px] flex flex-col justify-center hover:bg-white/10 transition-colors overflow-hidden" aria-label="Copiar e-mail">
                         <span class="text-[11px] uppercase tracking-wide text-white/60">E-mail</span>
                         <span id="modalProspectEmail" class="block text-sm text-white truncate" title="jennifer@acme.com">jennifer@acme.com</span>
                     </button>
 
-                    <button id="modalProspectPhoneLink" type="button" class="rounded-lg border border-white/10 bg-white/5 backdrop-blur p-3 h-[76px] flex flex-col justify-center hover:bg-white/10 transition-colors" aria-label="Copiar telefone">
+                    <button id="modalProspectPhoneLink" type="button" class="rounded-lg border border-white/10 bg-white/5 backdrop-blur p-3 h-[76px] flex flex-col justify-center hover:bg-white/10 transition-colors overflow-hidden" aria-label="Copiar telefone">
                         <span class="text-[11px] uppercase tracking-wide text-white/60">Telefone</span>
                         <span id="modalProspectPhone" class="block text-sm text-white truncate" title="(11) 3333-4444">(11) 3333-4444</span>
                     </button>
 
-                    <button id="modalProspectCellLink" type="button" class="rounded-lg border border-white/10 bg-white/5 backdrop-blur p-3 h-[76px] flex flex-col justify-center hover:bg-white/10 transition-colors" aria-label="Copiar celular">
+                    <button id="modalProspectCellLink" type="button" class="rounded-lg border border-white/10 bg-white/5 backdrop-blur p-3 h-[76px] flex flex-col justify-center hover:bg-white/10 transition-colors overflow-hidden" aria-label="Copiar celular">
                         <span class="text-[11px] uppercase tracking-wide text-white/60">Celular</span>
                         <span id="modalProspectCell" class="block text-sm text-white truncate" title="(11) 99999-9999">(11) 99999-9999</span>
                     </button>
 
-                    <div class="rounded-lg border border-white/10 bg-white/5 backdrop-blur p-3 h-[76px] flex flex-col justify-center">
+                    <div class="rounded-lg border border-white/10 bg-white/5 backdrop-blur p-3 h-[76px] flex flex-col justify-center overflow-hidden">
                         <span class="text-[11px] uppercase tracking-wide text-white/60">Empresa</span>
                         <span id="modalProspectCompanyMeta" class="block text-sm text-white truncate" title="Acme Corporation">Acme Corporation</span>
                     </div>
 
-                    <div class="rounded-lg border border-white/10 bg-white/5 backdrop-blur p-3 h-[76px] flex flex-col justify-center">
+                    <div class="rounded-lg border border-white/10 bg-white/5 backdrop-blur p-3 h-[76px] flex flex-col justify-center overflow-hidden">
                         <span class="text-[11px] uppercase tracking-wide text-white/60">Status</span>
                         <span id="modalProspectStatus" class="mt-1 inline-flex max-w-max px-2.5 py-1 rounded-full text-xs font-medium bg-emerald-500/20 text-emerald-200 truncate" title="Novo">Novo</span>
                     </div>


### PR DESCRIPTION
## Summary
- ensure prospect metadata boxes hide overflow so long text like emails and phones don't exceed their containers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae1e9a8a5c832293943cdd66eaec6b