### PR TITLE
Remover efeito de subir nas tabelas de notas

### DIFF
--- a/src/styles/scroll.css
+++ b/src/styles/scroll.css
@@ -105,9 +105,16 @@ select option {
 
 /* Module entry animation */
 .module-enter {
-  animation: moduleFadeInUp 0.6s ease-out forwards;
-  opacity: 0;
-  transform: translateY(20px);
+  opacity: 1;
+  transform: none;
+  animation: none;
+}
+
+/* Disable fade-in-up animations */
+.animate-fade-in-up {
+  opacity: 1 !important;
+  transform: none !important;
+  animation: none !important;
 }
 
 @keyframes moduleFadeInUp {


### PR DESCRIPTION
## Summary
- disable module entry and fade-in-up animations so note tables load without rising

## Testing
- `npm test` *(fails: test failed)*

------
https://chatgpt.com/codex/tasks/task_e_68ae1f3bc58c8322aea1651df4d1d631