### PR TITLE
Remove slide-in effect from prospect details notes tables

### DIFF
--- a/src/html/modals/prospeccoes/detalhes.html
+++ b/src/html/modals/prospeccoes/detalhes.html
@@ -267,7 +267,7 @@
                         + Novo
                     </button>
                 </div>
-                <div class="glass-surface rounded-xl shadow-lg animate-fade-in-up table-scroll">
+                <div class="glass-surface rounded-xl shadow-lg table-scroll">
                     <table class="w-full">
                         <thead class="bg-gray-50 sticky top-0">
                             <tr>
@@ -308,7 +308,7 @@
                         + Novo
                     </button>
                 </div>
-                <div class="glass-surface rounded-xl shadow-lg animate-fade-in-up table-scroll">
+                <div class="glass-surface rounded-xl shadow-lg table-scroll">
                     <table class="w-full">
                         <thead class="bg-gray-50 sticky top-0">
                             <tr>
@@ -347,7 +347,7 @@
                         + Add
                     </button>
                 </div>
-                <div class="glass-surface rounded-xl shadow-lg animate-fade-in-up table-scroll">
+                <div class="glass-surface rounded-xl shadow-lg table-scroll">
                     <table class="w-full">
                         <thead class="bg-gray-50 sticky top-0">
                             <tr>


### PR DESCRIPTION
## Summary
- Remove fade-in-up animation from note tables in prospect details modal so tables load instantly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae211dacf48322b18b07d3d5297687