### PR TITLE
Ensure empty state in all modal tables and enlarge box icon

### DIFF
--- a/src/html/clientes.html
+++ b/src/html/clientes.html
@@ -113,7 +113,7 @@
         <!-- Empty State -->
         <div id="clientesEmptyState" class="hidden py-12 flex flex-col items-center justify-center text-center px-4">
           <div class="rounded-full bg-[var(--color-primary-opacity)] p-4 mb-4">
-            <i class="fas fa-users w-12 h-12 text-[var(--color-primary)]"></i>
+            <i class="fas fa-users text-[var(--color-primary)] text-6xl"></i>
           </div>
           <h3 class="text-lg font-medium text-white">Nenhum cliente encontrado</h3>
           <p class="mt-1 text-sm text-white/70">Cadastre o primeiro agora!</p>

--- a/src/html/menu.html
+++ b/src/html/menu.html
@@ -371,6 +371,7 @@
     <script src="../utils/modal.js"></script>
     <script src="../utils/colorParser.js"></script>
     <script src="../utils/colors.js"></script>
+    <script src="../js/utils/empty-state.js"></script>
     <script src="../js/utils/notifications.js"></script>
     <script src="../js/notifications.js"></script>
     <script src="../js/menu.js"></script>

--- a/src/html/produtos.html
+++ b/src/html/produtos.html
@@ -108,7 +108,7 @@
         <!-- Empty State -->
         <div id="produtosEmptyState" class="hidden py-12 flex flex-col items-center justify-center text-center px-4">
           <div class="rounded-full bg-[var(--color-primary-opacity)] p-4 mb-4">
-            <i class="fas fa-box-open w-12 h-12 text-[var(--color-primary)]"></i>
+            <i class="fas fa-box-open text-[var(--color-primary)] text-6xl"></i>
           </div>
           <h3 class="text-lg font-medium text-white">Nenhum produto encontrado</h3>
           <p class="mt-1 text-sm text-white/70">Cadastre o primeiro agora!</p>

--- a/src/js/utils/empty-state.js
+++ b/src/js/utils/empty-state.js
@@ -1,0 +1,58 @@
+(function() {
+  function visibleRows(tbody) {
+    return Array.from(tbody.querySelectorAll('tr')).filter(tr => {
+      return tr.offsetParent !== null && !tr.classList.contains('hidden');
+    });
+  }
+
+  function updateTableEmptyState(table) {
+    const tbody = table.tBodies[0];
+    if (!tbody) return;
+    const rows = visibleRows(tbody);
+    let emptyRow = tbody.querySelector('.empty-state-row');
+    if (rows.length === 0) {
+      if (!emptyRow) {
+        emptyRow = document.createElement('tr');
+        emptyRow.className = 'empty-state-row';
+        const td = document.createElement('td');
+        td.colSpan = table.tHead ? table.tHead.rows[0].cells.length : 1;
+        td.innerHTML = `
+          <div class="py-12 flex flex-col items-center justify-center text-center text-white/70">
+            <i class="fas fa-box-open text-[var(--color-primary)]" style="font-size:4rem;"></i>
+            <p class="mt-2">Nenhum registro encontrado</p>
+          </div>
+        `;
+        emptyRow.appendChild(td);
+        tbody.appendChild(emptyRow);
+      }
+    } else if (emptyRow) {
+      emptyRow.remove();
+    }
+  }
+
+  function observeTable(table) {
+    const tbody = table.tBodies[0];
+    if (!tbody) return;
+    const observer = new MutationObserver(() => updateTableEmptyState(table));
+    observer.observe(tbody, { childList: true });
+    updateTableEmptyState(table);
+  }
+
+  function scan(node) {
+    if (!node.querySelectorAll) return;
+    node.querySelectorAll('table').forEach(table => {
+      if (!table._emptyStateObserved) {
+        table._emptyStateObserved = true;
+        observeTable(table);
+      }
+    });
+  }
+
+  document.addEventListener('DOMContentLoaded', () => {
+    scan(document);
+    const bodyObserver = new MutationObserver(mutations => {
+      mutations.forEach(m => m.addedNodes.forEach(scan));
+    });
+    bodyObserver.observe(document.body, { childList: true, subtree: true });
+  });
+})();


### PR DESCRIPTION
## Summary
- Add universal empty-state handler that observes table content and displays a prominent box icon when no rows remain
- Include empty-state utility across the main menu so modals inherit the behavior
- Increase empty-state icon size for clientes and produtos to improve visibility

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae227f0ce883228c1acba4cb2ea707