### PR TITLE
Enable Empty State For Modal Searches And Enlarge Box Icon

### DIFF
--- a/src/html/clientes.html
+++ b/src/html/clientes.html
@@ -112,8 +112,8 @@
 
         <!-- Empty State -->
         <div id="clientesEmptyState" class="hidden py-12 flex flex-col items-center justify-center text-center px-4">
-          <div class="rounded-full bg-[var(--color-primary-opacity)] p-4 mb-4">
-            <i class="fas fa-users w-12 h-12 text-[var(--color-primary)]"></i>
+          <div class="rounded-full bg-[var(--color-primary-opacity)] p-6 mb-4">
+            <i class="fas fa-users text-6xl text-[var(--color-primary)]"></i>
           </div>
           <h3 class="text-lg font-medium text-white">Nenhum cliente encontrado</h3>
           <p class="mt-1 text-sm text-white/70">Cadastre o primeiro agora!</p>

--- a/src/html/produtos.html
+++ b/src/html/produtos.html
@@ -107,8 +107,8 @@
 
         <!-- Empty State -->
         <div id="produtosEmptyState" class="hidden py-12 flex flex-col items-center justify-center text-center px-4">
-          <div class="rounded-full bg-[var(--color-primary-opacity)] p-4 mb-4">
-            <i class="fas fa-box-open w-12 h-12 text-[var(--color-primary)]"></i>
+          <div class="rounded-full bg-[var(--color-primary-opacity)] p-6 mb-4">
+            <i class="fas fa-box-open text-6xl text-[var(--color-primary)]"></i>
           </div>
           <h3 class="text-lg font-medium text-white">Nenhum produto encontrado</h3>
           <p class="mt-1 text-sm text-white/70">Cadastre o primeiro agora!</p>

--- a/src/utils/modal.js
+++ b/src/utils/modal.js
@@ -6,6 +6,34 @@ const ModalManager = (() => {
   const modalConfigs = {
   };
 
+  function setupEmptyStates(wrapper) {
+    wrapper.querySelectorAll('table').forEach(table => {
+      const tbody = table.tBodies[0];
+      if (!tbody) return;
+      const empty = document.createElement('div');
+      empty.className = 'modal-empty-state hidden py-12 flex flex-col items-center justify-center text-center px-4';
+      empty.innerHTML = `
+        <div class="rounded-full bg-[var(--color-primary-opacity)] p-6 mb-4">
+          <i class="fas fa-box-open text-[var(--color-primary)] text-6xl"></i>
+        </div>
+        <h3 class="text-lg font-medium text-white">Nenhum resultado encontrado</h3>
+      `;
+      table.parentNode.insertBefore(empty, table.nextSibling);
+      const check = () => {
+        const visible = Array.from(tbody.querySelectorAll('tr')).filter(r => r.style.display !== 'none');
+        if (visible.length === 0) {
+          table.classList.add('hidden');
+          empty.classList.remove('hidden');
+        } else {
+          table.classList.remove('hidden');
+          empty.classList.add('hidden');
+        }
+      };
+      new MutationObserver(check).observe(tbody, { childList: true, subtree: true, attributes: true, attributeFilter: ['style', 'class'] });
+      check();
+    });
+  }
+
   async function open(htmlPath, scriptPath, overlayId, keepExisting = false) {
     if (arguments.length === 1) {
       const cfg = modalConfigs[htmlPath];
@@ -30,6 +58,7 @@ const ModalManager = (() => {
     if (token !== openToken) return;
     document.body.appendChild(wrapper);
     document.body.classList.add('overflow-hidden');
+    setupEmptyStates(wrapper);
 
     if (scriptPath) {
       const script = document.createElement('script');


### PR DESCRIPTION
## Summary
- Automatically add empty state handling to all modal tables
- Increase prominence of empty state box icons across screens

## Testing
- `npm test` (fails: test failed)

------
https://chatgpt.com/codex/tasks/task_e_68af3ab70ff48322b61aecd4f3e10519