### PR TITLE
Improve Client Edit Flow

### DIFF
--- a/src/js/clientes.js
+++ b/src/js/clientes.js
@@ -3,14 +3,28 @@
 
 let todosClientes = [];
 
-async function carregarClientes() {
+async function carregarClientes(preserveFilters = false) {
     try {
         const resp = await fetch('http://localhost:3000/api/clientes/lista');
         const clientes = await resp.json();
         todosClientes = clientes;
-        popularFiltros(clientes);
-        renderClientes(clientes);
-        renderTotais(clientes);
+        if (preserveFilters) {
+            const buscaVal = document.getElementById('filtroBusca')?.value || '';
+            const donoVal = document.getElementById('filtroDono')?.value || '';
+            const statusVal = document.getElementById('filtroStatus')?.value || '';
+            popularFiltros(clientes);
+            const buscaEl = document.getElementById('filtroBusca');
+            const donoEl = document.getElementById('filtroDono');
+            const statusEl = document.getElementById('filtroStatus');
+            if (buscaEl) buscaEl.value = buscaVal;
+            if (donoEl) donoEl.value = donoVal;
+            if (statusEl) statusEl.value = statusVal;
+            aplicarFiltros();
+        } else {
+            popularFiltros(clientes);
+            renderClientes(clientes);
+            renderTotais(clientes);
+        }
     } catch (err) {
         console.error('Erro ao carregar clientes', err);
     }

--- a/src/js/modals/cliente-detalhes.js
+++ b/src/js/modals/cliente-detalhes.js
@@ -110,7 +110,10 @@
   const editar = document.getElementById('editarDetalhesCliente');
   if(editar){
     editar.addEventListener('click', () => {
-      if(cliente) abrirEditarCliente(cliente);
+      if(cliente){
+        Modal.close('detalhesCliente');
+        abrirEditarCliente(cliente);
+      }
     });
   }
 

--- a/src/js/modals/cliente-editar.js
+++ b/src/js/modals/cliente-editar.js
@@ -268,7 +268,7 @@
         if(!res.ok) throw new Error('Erro ao salvar');
         showToast('Cliente atualizado com sucesso');
         close();
-        if(typeof carregarClientes === 'function') carregarClientes();
+        if(typeof carregarClientes === 'function') await carregarClientes(true);
       }catch(err){
         console.error('Erro ao atualizar cliente', err);
         showToast('Erro ao salvar cliente', 'error');


### PR DESCRIPTION
## Summary
- Close client details modal before opening edit modal
- Preserve filter selections when reloading clients
- Refresh client table and filters after editing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af3bdf79148322b669ae5921eb0082