### PR TITLE
Improve Client Edit Flow

### DIFF
--- a/src/js/clientes.js
+++ b/src/js/clientes.js
@@ -3,14 +3,28 @@
 
 let todosClientes = [];
 
-async function carregarClientes() {
+async function carregarClientes(preserveFilters = false) {
     try {
         const resp = await fetch('http://localhost:3000/api/clientes/lista');
         const clientes = await resp.json();
         todosClientes = clientes;
-        popularFiltros(clientes);
-        renderClientes(clientes);
-        renderTotais(clientes);
+        if (preserveFilters) {
+            const buscaVal = document.getElementById('filtroBusca')?.value || '';
+            const donoVal = document.getElementById('filtroDono')?.value || '';
+            const statusVal = document.getElementById('filtroStatus')?.value || '';
+            popularFiltros(clientes);
+            const buscaEl = document.getElementById('filtroBusca');
+            const donoEl = document.getElementById('filtroDono');
+            const statusEl = document.getElementById('filtroStatus');
+            if (buscaEl) buscaEl.value = buscaVal;
+            if (donoEl) donoEl.value = donoVal;
+            if (statusEl) statusEl.value = statusVal;
+            aplicarFiltros();
+        } else {
+            popularFiltros(clientes);
+            renderClientes(clientes);
+            renderTotais(clientes);
+        }
     } catch (err) {
         console.error('Erro ao carregar clientes', err);
     }
@@ -165,6 +179,8 @@ function abrirEditarCliente(cliente) {
     window.clienteEditar = cliente;
     openModalWithSpinner('modals/clientes/editar.html', '../js/modals/cliente-editar.js', 'editarCliente');
 }
+
+window.addEventListener('clienteEditado', () => carregarClientes(true));
 
 function renderTotais(clientes) {
     const container = document.getElementById('totaisBadges');

--- a/src/js/modals/cliente-detalhes.js
+++ b/src/js/modals/cliente-detalhes.js
@@ -110,7 +110,10 @@
   const editar = document.getElementById('editarDetalhesCliente');
   if(editar){
     editar.addEventListener('click', () => {
-      if(cliente) abrirEditarCliente(cliente);
+      if(cliente){
+        Modal.close('detalhesCliente');
+        setTimeout(() => abrirEditarCliente(cliente), 0);
+      }
     });
   }
 

--- a/src/js/modals/cliente-editar.js
+++ b/src/js/modals/cliente-editar.js
@@ -267,8 +267,8 @@
         });
         if(!res.ok) throw new Error('Erro ao salvar');
         showToast('Cliente atualizado com sucesso');
+        window.dispatchEvent(new Event('clienteEditado'));
         close();
-        if(typeof carregarClientes === 'function') carregarClientes();
       }catch(err){
         console.error('Erro ao atualizar cliente', err);
         showToast('Erro ao salvar cliente', 'error');


### PR DESCRIPTION
## Summary
- Ensure edit button closes details modal and then opens edit modal with spinner
- Refresh client list and filters after saving edits via global event

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af3bdf79148322b669ae5921eb0082