### PR TITLE
Enable Edit Modal From Cliente Details

### DIFF
--- a/src/js/clientes.js
+++ b/src/js/clientes.js
@@ -180,6 +180,10 @@ function abrirEditarCliente(cliente) {
     openModalWithSpinner('modals/clientes/editar.html', '../js/modals/cliente-editar.js', 'editarCliente');
 }
 
+// Expose the edit modal opener globally so other scripts (like the
+// detalhes modal) can trigger it after closing.
+window.abrirEditarCliente = abrirEditarCliente;
+
 window.addEventListener('clienteEditado', () => carregarClientes(true));
 
 function renderTotais(clientes) {

--- a/src/js/modals/cliente-detalhes.js
+++ b/src/js/modals/cliente-detalhes.js
@@ -112,7 +112,9 @@
     editar.addEventListener('click', () => {
       if(cliente){
         Modal.close('detalhesCliente');
-        setTimeout(() => abrirEditarCliente(cliente), 0);
+        setTimeout(() => {
+          if(window.abrirEditarCliente) window.abrirEditarCliente(cliente);
+        }, 0);
       }
     });
   }


### PR DESCRIPTION
## Summary
- expose abrirEditarCliente globally so details modal can trigger edit
- trigger edit modal opener from client details once view closes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af44eecf588322b493db2e4c41f0bd