### PR TITLE
Restrict Cliente CNPJ And Inscricao Estadual Length And Check Duplicates

### DIFF
--- a/backend/clientesController.js
+++ b/backend/clientesController.js
@@ -219,6 +219,10 @@ router.post('/', async (req, res) => {
     cli.anotacoes
   ];
   try {
+    const dupCheck = await pool.query('SELECT id FROM clientes WHERE cnpj = $1', [cli.cnpj]);
+    if (dupCheck.rows.length) {
+      return res.status(409).json({ error: 'Cliente já registrado' });
+    }
     const insertRes = await pool.query(
       `INSERT INTO clientes (
         razao_social, nome_fantasia, cnpj, inscricao_estadual, site,

--- a/src/html/modals/clientes/novo.html
+++ b/src/html/modals/clientes/novo.html
@@ -34,7 +34,7 @@
               </div>
               <div>
                 <label class="block text-sm font-medium text-gray-300 mb-2">CNPJ</label>
-                <input id="empresaCnpj" type="text" placeholder="00.000.000/0001-00" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+                <input id="empresaCnpj" type="text" placeholder="00.000.000/0001-00" maxlength="18" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
               </div>
               <div>
                 <label class="block text-sm font-medium text-gray-300 mb-2">Segmento</label>
@@ -48,7 +48,7 @@
               </div>
               <div>
                 <label class="block text-sm font-medium text-gray-300 mb-2">Inscrição Estadual</label>
-                <input id="empresaInscricaoEstadual" type="text" placeholder="000.000.000.000" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+                <input id="empresaInscricaoEstadual" type="text" placeholder="000.000.000.000" maxlength="15" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
               </div>
               <div>
                 <label class="block text-sm font-medium text-gray-300 mb-2">Site</label>

--- a/src/js/modals/cliente-novo.js
+++ b/src/js/modals/cliente-novo.js
@@ -10,6 +10,19 @@
   // signal spinner loaded immediately
   window.dispatchEvent(new CustomEvent('modalSpinnerLoaded', { detail: 'novoCliente' }));
 
+  const cnpjInput = document.getElementById('empresaCnpj');
+  if (cnpjInput) {
+    cnpjInput.addEventListener('input', () => {
+      cnpjInput.value = cnpjInput.value.replace(/\D/g, '').slice(0, 14);
+    });
+  }
+  const ieInput = document.getElementById('empresaInscricaoEstadual');
+  if (ieInput) {
+    ieInput.addEventListener('input', () => {
+      ieInput.value = ieInput.value.replace(/\D/g, '').slice(0, 15);
+    });
+  }
+
   const tablist = overlay.querySelector('[role="tablist"]');
   const tabs = Array.from(overlay.querySelectorAll('[role="tab"]'));
   const panels = Array.from(overlay.querySelectorAll('[role="tabpanel"]'));
@@ -216,6 +229,10 @@
         headers:{'Content-Type':'application/json'},
         body: JSON.stringify(dados)
       });
+      if (res.status === 409) {
+        showToast('Cliente já registrado', 'error');
+        return;
+      }
       if(!res.ok) throw new Error('Erro ao registrar');
       showToast('Cliente registrado com sucesso');
       close();


### PR DESCRIPTION
## Summary
- limit CNPJ and inscrição estadual inputs to expected character counts
- sanitize numeric input and prevent duplicate client registration
- inform users when a client already exists during registration

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af459260948322a0d9c3c0d63bb9e3