### PR TITLE
Implement contact modal for client creation and editing

### DIFF
--- a/backend/clientesController.js
+++ b/backend/clientesController.js
@@ -317,6 +317,13 @@ router.put('/:id', async (req, res) => {
        WHERE id = $28`,
       values
     );
+    const contatos = Array.isArray(cli.contatos) ? cli.contatos : [];
+    for(const ct of contatos){
+      await pool.query(
+        'INSERT INTO contatos_cliente (id_cliente, nome, cargo, telefone_celular, telefone_fixo, email) VALUES ($1,$2,$3,$4,$5,$6)',
+        [id, ct.nome, ct.cargo, ct.telefone_celular, ct.telefone_fixo, ct.email]
+      );
+    }
     res.json({ success: true });
   } catch (err) {
     console.error('Erro ao atualizar cliente:', err);

--- a/src/html/modals/clientes/contato.html
+++ b/src/html/modals/clientes/contato.html
@@ -1,0 +1,33 @@
+<div id="novoContatoClienteOverlay" class="fixed inset-0 bg-black/50 flex items-center justify-center p-4">
+  <div class="max-w-md w-full glass-surface backdrop-blur-xl rounded-2xl border border-white/10 ring-1 ring-white/5 shadow-2xl/40 animate-modalFade">
+    <header class="relative px-6 py-4 border-b border-white/10">
+      <h2 class="text-lg font-semibold text-center text-white">NOVO CONTATO</h2>
+      <button id="fecharNovoContatoCliente" class="btn-danger icon-only absolute right-4 top-4 text-white">✕</button>
+    </header>
+    <form id="novoContatoClienteForm" class="p-6 space-y-4">
+      <div class="relative">
+        <input id="contatoNome" name="nome" type="text" placeholder=" " class="peer w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-transparent focus:border-primary focus:ring-2 focus:ring-primary/50 transition" required />
+        <label for="contatoNome" class="absolute left-4 top-1/2 -translate-y-1/2 text-base text-gray-300 pointer-events-none transition-all duration-150 peer-placeholder-shown:top-1/2 peer-placeholder-shown:-translate-y-1/2 peer-placeholder-shown:text-base peer-focus:top-0 peer-focus:-translate-y-full peer-focus:text-xs peer-focus:text-primary peer-valid:top-0 peer-valid:-translate-y-full peer-valid:text-xs">Nome</label>
+      </div>
+      <div class="relative">
+        <input id="contatoCargo" name="cargo" type="text" placeholder=" " class="peer w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-transparent focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+        <label for="contatoCargo" class="absolute left-4 top-1/2 -translate-y-1/2 text-base text-gray-300 pointer-events-none transition-all duration-150 peer-placeholder-shown:top-1/2 peer-placeholder-shown:-translate-y-1/2 peer-placeholder-shown:text-base peer-focus:top-0 peer-focus:-translate-y-full peer-focus:text-xs peer-focus:text-primary peer-valid:top-0 peer-valid:-translate-y-full peer-valid:text-xs">Cargo</label>
+      </div>
+      <div class="relative">
+        <input id="contatoEmail" name="email" type="email" placeholder=" " class="peer w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-transparent focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+        <label for="contatoEmail" class="absolute left-4 top-1/2 -translate-y-1/2 text-base text-gray-300 pointer-events-none transition-all duration-150 peer-placeholder-shown:top-1/2 peer-placeholder-shown:-translate-y-1/2 peer-placeholder-shown:text-base peer-focus:top-0 peer-focus:-translate-y-full peer-focus:text-xs peer-focus:text-primary peer-valid:top-0 peer-valid:-translate-y-full peer-valid:text-xs">E-mail</label>
+      </div>
+      <div class="relative">
+        <input id="contatoCelular" name="telefone_celular" type="text" placeholder=" " class="peer w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-transparent focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+        <label for="contatoCelular" class="absolute left-4 top-1/2 -translate-y-1/2 text-base text-gray-300 pointer-events-none transition-all duration-150 peer-placeholder-shown:top-1/2 peer-placeholder-shown:-translate-y-1/2 peer-placeholder-shown:text-base peer-focus:top-0 peer-focus:-translate-y-full peer-focus:text-xs peer-focus:text-primary peer-valid:top-0 peer-valid:-translate-y-full peer-valid:text-xs">Telefone Celular</label>
+      </div>
+      <div class="relative">
+        <input id="contatoFixo" name="telefone_fixo" type="text" placeholder=" " class="peer w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-transparent focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+        <label for="contatoFixo" class="absolute left-4 top-1/2 -translate-y-1/2 text-base text-gray-300 pointer-events-none transition-all duration-150 peer-placeholder-shown:top-1/2 peer-placeholder-shown:-translate-y-1/2 peer-placeholder-shown:text-base peer-focus:top-0 peer-focus:-translate-y-full peer-focus:text-xs peer-focus:text-primary peer-valid:top-0 peer-valid:-translate-y-full peer-valid:text-xs">Telefone Fixo</label>
+      </div>
+    </form>
+    <footer class="flex justify-end px-6 py-4 border-t border-white/10">
+      <button type="submit" form="novoContatoClienteForm" class="btn-primary px-6 py-2 rounded-lg text-white font-medium">Registrar</button>
+    </footer>
+  </div>
+</div>

--- a/src/html/modals/clientes/editar.html
+++ b/src/html/modals/clientes/editar.html
@@ -62,7 +62,7 @@
       <section id="panel-contatos" role="tabpanel" aria-labelledby="tab-contatos" class="px-8 py-6 hidden">
         <div class="flex justify-between items-center mb-6">
           <h3 class="text-lg font-semibold text-white">Contatos</h3>
-          <button class="btn-primary px-4 py-2 rounded-lg text-white font-medium">+ Novo Contato</button>
+          <button id="addContatoBtn" class="btn-primary px-4 py-2 rounded-lg text-white font-medium">+ Novo Contato</button>
         </div>
         <div class="glass-surface rounded-xl border border-white/10 overflow-hidden">
           <div class="overflow-x-auto">

--- a/src/js/modals/cliente-contato.js
+++ b/src/js/modals/cliente-contato.js
@@ -1,0 +1,22 @@
+(function(){
+  const overlay = document.getElementById('novoContatoClienteOverlay');
+  if(!overlay) return;
+  const close = () => Modal.close('novoContatoCliente');
+  overlay.addEventListener('click', e => { if(e.target === overlay) close(); });
+  document.getElementById('fecharNovoContatoCliente')?.addEventListener('click', close);
+  document.addEventListener('keydown', function esc(e){ if(e.key==='Escape'){ close(); document.removeEventListener('keydown', esc); }});
+
+  const form = document.getElementById('novoContatoClienteForm');
+  form.addEventListener('submit', e => {
+    e.preventDefault();
+    const data = {
+      nome: form.nome.value.trim(),
+      cargo: form.cargo.value.trim(),
+      email: form.email.value.trim(),
+      telefone_celular: form.telefone_celular.value.trim(),
+      telefone_fixo: form.telefone_fixo.value.trim()
+    };
+    window.dispatchEvent(new CustomEvent('clienteContatoAdicionado', { detail: data }));
+    close();
+  });
+})();

--- a/src/js/modals/cliente-novo.js
+++ b/src/js/modals/cliente-novo.js
@@ -138,13 +138,11 @@
   renderContatos();
 
   document.getElementById('addContatoBtn')?.addEventListener('click', () => {
-    const nome = prompt('Nome do contato:')?.trim();
-    if(!nome) return;
-    const cargo = prompt('Cargo:')?.trim() || '';
-    const email = prompt('E-mail:')?.trim() || '';
-    const telCel = prompt('Telefone Celular:')?.trim() || '';
-    const telFixo = prompt('Telefone Fixo:')?.trim() || '';
-    contatos.push({ nome, cargo, email, telefone_celular: telCel, telefone_fixo: telFixo });
+    Modal.open('modals/clientes/contato.html', '../js/modals/cliente-contato.js', 'novoContatoCliente');
+  });
+
+  window.addEventListener('clienteContatoAdicionado', e => {
+    contatos.push(e.detail);
     renderContatos();
   });
 


### PR DESCRIPTION
## Summary
- add modal to capture client contact details
- wire contact modal into new and edit client flows
- persist new contacts when updating clients

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af4f5b7db0832283ff380ee740f530