### PR TITLE
Add Country And State Selection For Addresses

### DIFF
--- a/backend/clientesController.js
+++ b/backend/clientesController.js
@@ -75,6 +75,7 @@ router.get('/:id', async (req, res) => {
         complemento: row.reg_complemento,
         bairro: row.reg_bairro,
         cidade: row.reg_cidade,
+        pais: row.reg_pais,
         estado: row.reg_uf,
         cep: row.reg_cep
       },
@@ -84,6 +85,7 @@ router.get('/:id', async (req, res) => {
         complemento: row.cob_complemento,
         bairro: row.cob_bairro,
         cidade: row.cob_cidade,
+        pais: row.cob_pais,
         estado: row.cob_uf,
         cep: row.cob_cep
       },
@@ -93,6 +95,7 @@ router.get('/:id', async (req, res) => {
         complemento: row.ent_complemento,
         bairro: row.ent_bairro,
         cidade: row.ent_cidade,
+        pais: row.ent_pais,
         estado: row.ent_uf,
         cep: row.ent_cep
       },
@@ -149,16 +152,17 @@ router.get('/:id/resumo', async (req, res) => {
       const cidade = row[`${prefix}_cidade`] || '';
       const uf = row[`${prefix}_uf`] || '';
       const cep = row[`${prefix}_cep`] || '';
+      const pais = row[`${prefix}_pais`] || '';
 
       return (
         `${logradouro}, ${numero}` +
         (complemento ? ` - ${complemento}` : '') +
-        `, ${bairro} - ${cidade}/${uf} - ${cep}`
+        `, ${bairro} - ${cidade}/${uf} - ${cep}` + (pais ? ` - ${pais}` : '')
       );
     }
 
     function enderecoIgual(aPrefix, bPrefix) {
-      const fields = ['logradouro', 'numero', 'complemento', 'bairro', 'cidade', 'uf', 'cep'];
+      const fields = ['logradouro', 'numero', 'complemento', 'bairro', 'cidade', 'uf', 'cep', 'pais'];
       return fields.every((f) => row[`${aPrefix}_${f}`] === row[`${bPrefix}_${f}`]);
     }
 
@@ -195,6 +199,7 @@ router.post('/', async (req, res) => {
     cli.cnpj,
     cli.inscricao_estadual,
     cli.site,
+    cli.endereco_registro?.pais,
     cli.endereco_registro?.rua,
     cli.endereco_registro?.numero,
     cli.endereco_registro?.complemento,
@@ -202,6 +207,7 @@ router.post('/', async (req, res) => {
     cli.endereco_registro?.cidade,
     cli.endereco_registro?.estado,
     cli.endereco_registro?.cep,
+    cli.endereco_cobranca?.pais,
     cli.endereco_cobranca?.rua,
     cli.endereco_cobranca?.numero,
     cli.endereco_cobranca?.complemento,
@@ -209,6 +215,7 @@ router.post('/', async (req, res) => {
     cli.endereco_cobranca?.cidade,
     cli.endereco_cobranca?.estado,
     cli.endereco_cobranca?.cep,
+    cli.endereco_entrega?.pais,
     cli.endereco_entrega?.rua,
     cli.endereco_entrega?.numero,
     cli.endereco_entrega?.complemento,
@@ -226,12 +233,12 @@ router.post('/', async (req, res) => {
     const insertRes = await pool.query(
       `INSERT INTO clientes (
         razao_social, nome_fantasia, cnpj, inscricao_estadual, site,
-        reg_logradouro, reg_numero, reg_complemento, reg_bairro, reg_cidade, reg_uf, reg_cep,
-        cob_logradouro, cob_numero, cob_complemento, cob_bairro, cob_cidade, cob_uf, cob_cep,
-        ent_logradouro, ent_numero, ent_complemento, ent_bairro, ent_cidade, ent_uf, ent_cep,
+        reg_pais, reg_logradouro, reg_numero, reg_complemento, reg_bairro, reg_cidade, reg_uf, reg_cep,
+        cob_pais, cob_logradouro, cob_numero, cob_complemento, cob_bairro, cob_cidade, cob_uf, cob_cep,
+        ent_pais, ent_logradouro, ent_numero, ent_complemento, ent_bairro, ent_cidade, ent_uf, ent_cep,
         anotacoes
       ) VALUES (
-        $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27
+        $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27,$28,$29,$30
       ) RETURNING id`,
       values
     );
@@ -260,6 +267,7 @@ router.put('/:id', async (req, res) => {
     cli.cnpj,
     cli.inscricao_estadual,
     cli.site,
+    cli.endereco_registro?.pais,
     cli.endereco_registro?.rua,
     cli.endereco_registro?.numero,
     cli.endereco_registro?.complemento,
@@ -267,6 +275,7 @@ router.put('/:id', async (req, res) => {
     cli.endereco_registro?.cidade,
     cli.endereco_registro?.estado,
     cli.endereco_registro?.cep,
+    cli.endereco_cobranca?.pais,
     cli.endereco_cobranca?.rua,
     cli.endereco_cobranca?.numero,
     cli.endereco_cobranca?.complemento,
@@ -274,6 +283,7 @@ router.put('/:id', async (req, res) => {
     cli.endereco_cobranca?.cidade,
     cli.endereco_cobranca?.estado,
     cli.endereco_cobranca?.cep,
+    cli.endereco_entrega?.pais,
     cli.endereco_entrega?.rua,
     cli.endereco_entrega?.numero,
     cli.endereco_entrega?.complemento,
@@ -292,29 +302,32 @@ router.put('/:id', async (req, res) => {
         cnpj = $3,
         inscricao_estadual = $4,
         site = $5,
-        reg_logradouro = $6,
-        reg_numero = $7,
-        reg_complemento = $8,
-        reg_bairro = $9,
-        reg_cidade = $10,
-        reg_uf = $11,
-        reg_cep = $12,
-        cob_logradouro = $13,
-        cob_numero = $14,
-        cob_complemento = $15,
-        cob_bairro = $16,
-        cob_cidade = $17,
-        cob_uf = $18,
-        cob_cep = $19,
-        ent_logradouro = $20,
-        ent_numero = $21,
-        ent_complemento = $22,
-        ent_bairro = $23,
-        ent_cidade = $24,
-        ent_uf = $25,
-        ent_cep = $26,
-        anotacoes = $27
-       WHERE id = $28`,
+        reg_pais = $6,
+        reg_logradouro = $7,
+        reg_numero = $8,
+        reg_complemento = $9,
+        reg_bairro = $10,
+        reg_cidade = $11,
+        reg_uf = $12,
+        reg_cep = $13,
+        cob_pais = $14,
+        cob_logradouro = $15,
+        cob_numero = $16,
+        cob_complemento = $17,
+        cob_bairro = $18,
+        cob_cidade = $19,
+        cob_uf = $20,
+        cob_cep = $21,
+        ent_pais = $22,
+        ent_logradouro = $23,
+        ent_numero = $24,
+        ent_complemento = $25,
+        ent_bairro = $26,
+        ent_cidade = $27,
+        ent_uf = $28,
+        ent_cep = $29,
+        anotacoes = $30
+       WHERE id = $31`,
       values
     );
     res.json({ success: true });

--- a/backend/clientesResumo.test.js
+++ b/backend/clientesResumo.test.js
@@ -19,6 +19,7 @@ function setupDb() {
       ent_cidade text,
       ent_uf text,
       ent_cep text,
+      ent_pais text,
       cob_logradouro text,
       cob_numero text,
       cob_complemento text,
@@ -26,13 +27,15 @@ function setupDb() {
       cob_cidade text,
       cob_uf text,
       cob_cep text,
+      cob_pais text,
       reg_logradouro text,
       reg_numero text,
       reg_complemento text,
       reg_bairro text,
       reg_cidade text,
       reg_uf text,
-      reg_cep text
+      reg_cep text,
+      reg_pais text
     );
   `);
   db.public.none(`
@@ -55,14 +58,14 @@ test('GET /api/clientes/:id/resumo formata endereços e contatos', async () => {
 
   await pool.query(`INSERT INTO clientes (
     id, nome_fantasia, razao_social, cnpj, inscricao_estadual,
-    ent_logradouro, ent_numero, ent_complemento, ent_bairro, ent_cidade, ent_uf, ent_cep,
-    cob_logradouro, cob_numero, cob_complemento, cob_bairro, cob_cidade, cob_uf, cob_cep,
-    reg_logradouro, reg_numero, reg_complemento, reg_bairro, reg_cidade, reg_uf, reg_cep
+    ent_logradouro, ent_numero, ent_complemento, ent_bairro, ent_cidade, ent_uf, ent_cep, ent_pais,
+    cob_logradouro, cob_numero, cob_complemento, cob_bairro, cob_cidade, cob_uf, cob_cep, cob_pais,
+    reg_logradouro, reg_numero, reg_complemento, reg_bairro, reg_cidade, reg_uf, reg_cep, reg_pais
   ) VALUES (
     1, 'Cliente A', 'Cliente A SA', '123', '321',
-    'Rua X', '10', '', 'Bairro X', 'Cidade X', 'SP', '12345-678',
-    'Rua X', '10', '', 'Bairro X', 'Cidade X', 'SP', '12345-678',
-    'Rua Y', '20', 'Sala 5', 'Bairro Y', 'Cidade Y', 'RJ', '98765-432'
+    'Rua X', '10', '', 'Bairro X', 'Cidade X', 'SP', '12345-678', 'BR',
+    'Rua X', '10', '', 'Bairro X', 'Cidade X', 'SP', '12345-678', 'BR',
+    'Rua Y', '20', 'Sala 5', 'Bairro Y', 'Cidade Y', 'RJ', '98765-432', 'BR'
   );`);
 
   await pool.query(`INSERT INTO contatos_cliente (id_cliente, nome, telefone_fixo, telefone_celular, email)
@@ -88,9 +91,9 @@ test('GET /api/clientes/:id/resumo formata endereços e contatos', async () => {
   assert.strictEqual(res.status, 200);
   const body = await res.json();
 
-  assert.strictEqual(body.endereco_entrega, 'Rua X, 10, Bairro X - Cidade X/SP - 12345-678');
+  assert.strictEqual(body.endereco_entrega, 'Rua X, 10, Bairro X - Cidade X/SP - 12345-678 - BR');
   assert.strictEqual(body.endereco_faturamento, 'Igual Entrega');
-  assert.strictEqual(body.endereco_registro, 'Rua Y, 20 - Sala 5, Bairro Y - Cidade Y/RJ - 98765-432');
+  assert.strictEqual(body.endereco_registro, 'Rua Y, 20 - Sala 5, Bairro Y - Cidade Y/RJ - 98765-432 - BR');
   assert.deepStrictEqual(body.contatos, [
     {
       id_cliente: 1,

--- a/src/html/modals/clientes/detalhes.html
+++ b/src/html/modals/clientes/detalhes.html
@@ -111,12 +111,15 @@
               <input id="regCidade" type="text" placeholder="São Paulo" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-300 mb-2">Estado</label>
-              <select id="regEstado" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition select-arrow appearance-none">
+              <label class="block text-sm font-medium text-gray-300 mb-2">País</label>
+              <select id="regPais" disabled class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition select-arrow appearance-none">
                 <option value="">Selecione</option>
-                <option value="SP">São Paulo</option>
-                <option value="RJ">Rio de Janeiro</option>
-                <option value="MG">Minas Gerais</option>
+              </select>
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-300 mb-2">Estado</label>
+              <select id="regEstado" disabled class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition select-arrow appearance-none">
+                <option value="">Selecione o país</option>
               </select>
             </div>
             <div>
@@ -156,12 +159,15 @@
               <input id="cobCidade" type="text" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-300 mb-2">Estado</label>
-              <select id="cobEstado" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition select-arrow appearance-none">
+              <label class="block text-sm font-medium text-gray-300 mb-2">País</label>
+              <select id="cobPais" disabled class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition select-arrow appearance-none">
                 <option value="">Selecione</option>
-                <option value="SP">São Paulo</option>
-                <option value="RJ">Rio de Janeiro</option>
-                <option value="MG">Minas Gerais</option>
+              </select>
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-300 mb-2">Estado</label>
+              <select id="cobEstado" disabled class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition select-arrow appearance-none">
+                <option value="">Selecione o país</option>
               </select>
             </div>
             <div>
@@ -201,12 +207,15 @@
               <input id="entCidade" type="text" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-300 mb-2">Estado</label>
-              <select id="entEstado" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition select-arrow appearance-none">
+              <label class="block text-sm font-medium text-gray-300 mb-2">País</label>
+              <select id="entPais" disabled class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition select-arrow appearance-none">
                 <option value="">Selecione</option>
-                <option value="SP">São Paulo</option>
-                <option value="RJ">Rio de Janeiro</option>
-                <option value="MG">Minas Gerais</option>
+              </select>
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-300 mb-2">Estado</label>
+              <select id="entEstado" disabled class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition select-arrow appearance-none">
+                <option value="">Selecione o país</option>
               </select>
             </div>
             <div>

--- a/src/html/modals/clientes/editar.html
+++ b/src/html/modals/clientes/editar.html
@@ -112,12 +112,15 @@
               <input id="regCidade" type="text" placeholder="São Paulo" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-300 mb-2">Estado</label>
-              <select id="regEstado" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition select-arrow appearance-none">
+              <label class="block text-sm font-medium text-gray-300 mb-2">País</label>
+              <select id="regPais" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition select-arrow appearance-none">
                 <option value="">Selecione</option>
-                <option value="SP">São Paulo</option>
-                <option value="RJ">Rio de Janeiro</option>
-                <option value="MG">Minas Gerais</option>
+              </select>
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-300 mb-2">Estado</label>
+              <select id="regEstado" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition select-arrow appearance-none" disabled>
+                <option value="">Selecione o país</option>
               </select>
             </div>
             <div>
@@ -157,12 +160,15 @@
               <input id="cobCidade" type="text" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-300 mb-2">Estado</label>
-              <select id="cobEstado" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition select-arrow appearance-none">
+              <label class="block text-sm font-medium text-gray-300 mb-2">País</label>
+              <select id="cobPais" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition select-arrow appearance-none">
                 <option value="">Selecione</option>
-                <option value="SP">São Paulo</option>
-                <option value="RJ">Rio de Janeiro</option>
-                <option value="MG">Minas Gerais</option>
+              </select>
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-300 mb-2">Estado</label>
+              <select id="cobEstado" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition select-arrow appearance-none" disabled>
+                <option value="">Selecione o país</option>
               </select>
             </div>
             <div>
@@ -202,12 +208,15 @@
               <input id="entCidade" type="text" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-300 mb-2">Estado</label>
-              <select id="entEstado" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition select-arrow appearance-none">
+              <label class="block text-sm font-medium text-gray-300 mb-2">País</label>
+              <select id="entPais" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition select-arrow appearance-none">
                 <option value="">Selecione</option>
-                <option value="SP">São Paulo</option>
-                <option value="RJ">Rio de Janeiro</option>
-                <option value="MG">Minas Gerais</option>
+              </select>
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-300 mb-2">Estado</label>
+              <select id="entEstado" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition select-arrow appearance-none" disabled>
+                <option value="">Selecione o país</option>
               </select>
             </div>
             <div>

--- a/src/html/modals/clientes/novo.html
+++ b/src/html/modals/clientes/novo.html
@@ -112,12 +112,15 @@
               <input id="regCidade" type="text" placeholder="São Paulo" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-300 mb-2">Estado</label>
-              <select id="regEstado" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition select-arrow appearance-none">
+              <label class="block text-sm font-medium text-gray-300 mb-2">País</label>
+              <select id="regPais" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition select-arrow appearance-none">
                 <option value="">Selecione</option>
-                <option value="SP">São Paulo</option>
-                <option value="RJ">Rio de Janeiro</option>
-                <option value="MG">Minas Gerais</option>
+              </select>
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-300 mb-2">Estado</label>
+              <select id="regEstado" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition select-arrow appearance-none" disabled>
+                <option value="">Selecione o país</option>
               </select>
             </div>
             <div>
@@ -157,12 +160,15 @@
               <input id="cobCidade" type="text" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-300 mb-2">Estado</label>
-              <select id="cobEstado" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition select-arrow appearance-none">
+              <label class="block text-sm font-medium text-gray-300 mb-2">País</label>
+              <select id="cobPais" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition select-arrow appearance-none">
                 <option value="">Selecione</option>
-                <option value="SP">São Paulo</option>
-                <option value="RJ">Rio de Janeiro</option>
-                <option value="MG">Minas Gerais</option>
+              </select>
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-300 mb-2">Estado</label>
+              <select id="cobEstado" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition select-arrow appearance-none" disabled>
+                <option value="">Selecione o país</option>
               </select>
             </div>
             <div>
@@ -202,12 +208,15 @@
               <input id="entCidade" type="text" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-300 mb-2">Estado</label>
-              <select id="entEstado" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition select-arrow appearance-none">
+              <label class="block text-sm font-medium text-gray-300 mb-2">País</label>
+              <select id="entPais" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition select-arrow appearance-none">
                 <option value="">Selecione</option>
-                <option value="SP">São Paulo</option>
-                <option value="RJ">Rio de Janeiro</option>
-                <option value="MG">Minas Gerais</option>
+              </select>
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-300 mb-2">Estado</label>
+              <select id="entEstado" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition select-arrow appearance-none" disabled>
+                <option value="">Selecione o país</option>
               </select>
             </div>
             <div>

--- a/src/js/geo-service.js
+++ b/src/js/geo-service.js
@@ -1,0 +1,77 @@
+// geo-service.js
+// Busca países (nome + ISO-2) e estados por país, com cache e lazy-load.
+
+/* Endpoints públicos */
+const ENDPOINT_COUNTRIES =
+  'https://restcountries.com/v3.1/all?fields=name,cca2'; // leve (nome + ISO-2)
+const ENDPOINT_STATES =
+  'https://raw.githubusercontent.com/dr5hn/countries-states-cities-database/master/states.json'; // carregado sob demanda
+
+/* Caches */
+let _countriesCache = null;            // Array<{ name, code }>
+let _statesIndexByCountry = null;      // Map<string, Array<{ name, code }>>
+
+/* Util: sort por nome (case-insensitive) */
+const byName = (a, b) =>
+  a.name.localeCompare(b.name, undefined, { sensitivity: 'base' });
+
+/**
+ * Retorna todos os países (nome + ISO-2), ordenados por nome.
+ * Cacheado após a primeira chamada.
+ */
+async function getCountries() {
+  if (_countriesCache) return _countriesCache;
+
+  const res = await fetch(ENDPOINT_COUNTRIES, { cache: 'force-cache' });
+  if (!res.ok) throw new Error('Falha ao baixar lista de países');
+
+  const data = await res.json();
+  _countriesCache = data
+    .map(c => ({ name: c?.name?.common ?? '', code: c?.cca2 ?? '' }))
+    .filter(c => c.name && c.code)
+    .sort(byName);
+
+  return _countriesCache;
+}
+
+/* Garante o índice de estados por país (carrega uma vez e mantém em memória) */
+async function ensureStatesIndex() {
+  if (_statesIndexByCountry) return _statesIndexByCountry;
+
+  const res = await fetch(ENDPOINT_STATES, { cache: 'force-cache' });
+  if (!res.ok) throw new Error('Falha ao baixar lista de estados');
+
+  const states = await res.json(); // [{ country_code, name, state_code, ... }]
+  const idx = new Map();
+
+  for (const s of states) {
+    const cc = s.country_code; // ISO-2 (ex.: "BR", "US")
+    if (!cc) continue;
+    if (!idx.has(cc)) idx.set(cc, []);
+    idx.get(cc).push({ name: s.name, code: s.state_code || s.name });
+  }
+  // Ordena cada lista
+  for (const [cc, list] of idx) list.sort(byName);
+
+  _statesIndexByCountry = idx;
+  return _statesIndexByCountry;
+}
+
+/**
+ * Retorna os estados/províncias de um país (ISO-2), ex.: "BR", "US".
+ * Lazy-load: baixa o dataset na primeira chamada e guarda em cache.
+ */
+async function getStatesByCountry(iso2) {
+  if (!iso2) return [];
+  const idx = await ensureStatesIndex();
+  return idx.get(iso2) ?? [];
+}
+
+/* Opcional: helpers */
+function clearGeoCache() {
+  _countriesCache = null;
+  _statesIndexByCountry = null;
+}
+
+// Expondo funções no escopo global
+window.geoService = { getCountries, getStatesByCountry, clearGeoCache };

--- a/src/js/modals/cliente-editar.js
+++ b/src/js/modals/cliente-editar.js
@@ -8,6 +8,15 @@
   document.addEventListener('keydown', function esc(e){ if(e.key==='Escape'){ close(); document.removeEventListener('keydown', esc); }});
 
   const cliente = window.clienteEditar;
+  if(!window.geoService){
+    await new Promise((resolve, reject) => {
+      const s = document.createElement('script');
+      s.src = '../js/geo-service.js';
+      s.onload = resolve;
+      s.onerror = reject;
+      document.head.appendChild(s);
+    });
+  }
   if(cliente){
     const titulo = document.getElementById('clienteEditarTitulo');
     if(titulo) titulo.textContent = `Editar – ${cliente.nome_fantasia || ''}`;
@@ -16,7 +25,7 @@
       const data = await res.json();
       if(data && data.cliente){
         preencherDadosEmpresa(data.cliente);
-        preencherEnderecos(data.cliente);
+        await preencherEnderecos(data.cliente);
         renderContatos(data.contatos || []);
         inicializarToggles(data.cliente);
         const notas = document.getElementById('clienteNotas');
@@ -116,18 +125,55 @@
       avatar.textContent = initials;
     }
   }
-
-  function preencherEnderecos(cli){
-    const fill = (prefix, data) => {
-      if(!data) return;
-      for(const key of ['rua','numero','complemento','bairro','cidade','estado','cep']){
+  async function setupEndereco(prefix, data){
+    const paisSel = document.getElementById(prefix + 'Pais');
+    const estadoSel = document.getElementById(prefix + 'Estado');
+    if(paisSel && estadoSel){
+      const countries = await geoService.getCountries();
+      paisSel.innerHTML = '<option value="">Selecione</option>' +
+        countries.map(c => `<option value="${c.code}">${c.name}</option>`).join('');
+      if(data?.pais){
+        paisSel.value = data.pais;
+        const states = await geoService.getStatesByCountry(data.pais);
+        estadoSel.innerHTML = '<option value="">Selecione</option>' +
+          states.map(s => `<option value="${s.code}">${s.name}</option>`).join('');
+        estadoSel.disabled = false;
+        estadoSel.value = data.estado || '';
+      } else {
+        estadoSel.disabled = true;
+        estadoSel.innerHTML = '<option value="">Selecione o país</option>';
+      }
+      paisSel.addEventListener('change', async () => {
+        const code = paisSel.value;
+        if(!code){
+          estadoSel.disabled = true;
+          estadoSel.innerHTML = '<option value="">Selecione o país</option>';
+          return;
+        }
+        const states = await geoService.getStatesByCountry(code);
+        estadoSel.disabled = false;
+        estadoSel.innerHTML = '<option value="">Selecione</option>' +
+          states.map(s => `<option value="${s.code}">${s.name}</option>`).join('');
+      });
+      estadoSel.addEventListener('mousedown', e => {
+        if(!paisSel.value){
+          e.preventDefault();
+          alert('Por favor, selecione o país primeiro');
+        }
+      });
+    }
+    if(data){
+      for(const key of ['rua','numero','complemento','bairro','cidade','cep']){
         const el = document.getElementById(`${prefix}${key.charAt(0).toUpperCase()+key.slice(1)}`);
         if(el) el.value = data[key] || '';
       }
-    };
-    fill('reg', cli.endereco_registro);
-    fill('cob', cli.endereco_cobranca);
-    fill('ent', cli.endereco_entrega);
+    }
+  }
+
+  async function preencherEnderecos(cli){
+    await setupEndereco('reg', cli.endereco_registro);
+    await setupEndereco('cob', cli.endereco_cobranca);
+    await setupEndereco('ent', cli.endereco_entrega);
   }
 
   function renderContatos(contatos){
@@ -236,6 +282,7 @@
       complemento: getVal(prefix+'Complemento'),
       bairro: getVal(prefix+'Bairro'),
       cidade: getVal(prefix+'Cidade'),
+      pais: getVal(prefix+'Pais'),
       estado: getVal(prefix+'Estado'),
       cep: getVal(prefix+'Cep')
     });


### PR DESCRIPTION
## Summary
- add geo-service to fetch countries and states lazily
- require country selection before loading states in client address forms
- persist country fields for all client addresses in the database

## Testing
- `npm test` (fails: Cannot find module '/workspace/App-Gestao/backend')
- `node --test backend/*.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68af508e5564832286b359486231afc5