### PR TITLE
Prevent closing parent modals when adding client contact

### DIFF
--- a/src/html/modals/clientes/contato.html
+++ b/src/html/modals/clientes/contato.html
@@ -1,8 +1,9 @@
 <div id="novoContatoClienteOverlay" class="fixed inset-0 bg-black/50 flex items-center justify-center p-4">
   <div class="max-w-md w-full glass-surface backdrop-blur-xl rounded-2xl border border-white/10 ring-1 ring-white/5 shadow-2xl/40 animate-modalFade">
-    <header class="relative px-6 py-4 border-b border-white/10">
-      <h2 class="text-lg font-semibold text-center text-white">NOVO CONTATO</h2>
-      <button id="fecharNovoContatoCliente" class="btn-danger icon-only absolute right-4 top-4 text-white">✕</button>
+    <header class="grid grid-cols-3 items-center px-6 py-4 border-b border-white/10">
+      <button id="voltarNovoContatoCliente" class="btn-neutral px-4 py-2 rounded-lg text-white font-medium flex items-center gap-2 justify-self-start">← Voltar</button>
+      <h2 class="text-lg font-semibold text-white text-center">Novo Contato</h2>
+      <span></span>
     </header>
     <form id="novoContatoClienteForm" class="p-6 space-y-4">
       <div class="relative">

--- a/src/js/modals/cliente-contato.js
+++ b/src/js/modals/cliente-contato.js
@@ -3,7 +3,7 @@
   if(!overlay) return;
   const close = () => Modal.close('novoContatoCliente');
   overlay.addEventListener('click', e => { if(e.target === overlay) close(); });
-  document.getElementById('fecharNovoContatoCliente')?.addEventListener('click', close);
+  document.getElementById('voltarNovoContatoCliente')?.addEventListener('click', close);
   document.addEventListener('keydown', function esc(e){ if(e.key==='Escape'){ close(); document.removeEventListener('keydown', esc); }});
 
   const form = document.getElementById('novoContatoClienteForm');

--- a/src/js/modals/cliente-editar.js
+++ b/src/js/modals/cliente-editar.js
@@ -164,7 +164,7 @@
   }
 
   document.getElementById('addContatoBtn')?.addEventListener('click', () => {
-    Modal.open('modals/clientes/contato.html', '../js/modals/cliente-contato.js', 'novoContatoCliente');
+    Modal.open('modals/clientes/contato.html', '../js/modals/cliente-contato.js', 'novoContatoCliente', true);
   });
 
   window.addEventListener('clienteContatoAdicionado', e => {

--- a/src/js/modals/cliente-novo.js
+++ b/src/js/modals/cliente-novo.js
@@ -138,7 +138,7 @@
   renderContatos();
 
   document.getElementById('addContatoBtn')?.addEventListener('click', () => {
-    Modal.open('modals/clientes/contato.html', '../js/modals/cliente-contato.js', 'novoContatoCliente');
+    Modal.open('modals/clientes/contato.html', '../js/modals/cliente-contato.js', 'novoContatoCliente', true);
   });
 
   window.addEventListener('clienteContatoAdicionado', e => {


### PR DESCRIPTION
## Summary
- Preserve existing modals when opening the new client contact modal from create or edit client flows
- Replace close icon with back button in new client contact modal and wire up handler

## Testing
- `npm test` *(fails: Cannot find module '/workspace/App-Gestao/backend')*

------
https://chatgpt.com/codex/tasks/task_e_68af51fcdfd48322a5e98daa3a433fc9