### PR TITLE
Add country column to client table and enable country search

### DIFF
--- a/backend/clientesController.js
+++ b/backend/clientesController.js
@@ -30,12 +30,13 @@ router.get('/lista', async (_req, res) => {
   try {
     // 'ent_uf' holds the two letter state for the delivery address
     const result = await pool.query(
-      'SELECT id, nome_fantasia, cnpj, ent_uf, status_cliente, dono_cliente FROM clientes ORDER BY nome_fantasia'
+      'SELECT id, nome_fantasia, cnpj, pais, ent_uf, status_cliente, dono_cliente FROM clientes ORDER BY nome_fantasia'
     );
     const clientes = result.rows.map(c => ({
       id: c.id,
       nome_fantasia: c.nome_fantasia,
       cnpj: c.cnpj,
+      pais: c.pais || '',
       estado: extractUF(c.ent_uf) || 'Unidentified State',
       status_cliente: c.status_cliente,
       dono_cliente: c.dono_cliente

--- a/src/html/clientes.html
+++ b/src/html/clientes.html
@@ -98,6 +98,7 @@
                         <tr>
                             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Nome</th>
                             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">CNPJ</th>
+                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">País</th>
                             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Estado</th>
                             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
                             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Dono</th>

--- a/src/js/clientes.js
+++ b/src/js/clientes.js
@@ -69,6 +69,7 @@ function aplicarFiltros() {
         const matchTermo = !termo ||
             c.nome_fantasia.toLowerCase().includes(termo) ||
             (c.cnpj || '').toLowerCase().includes(termo) ||
+            (c.pais || '').toLowerCase().includes(termo) ||
             (c.estado || '').toLowerCase().includes(termo);
         const matchDono = !dono || c.dono_cliente === dono;
         const matchStatus = !status || c.status_cliente === status;
@@ -118,6 +119,7 @@ function renderClientes(clientes) {
         tr.innerHTML = `
             <td class="px-6 py-4 whitespace-nowrap text-sm text-white">${c.nome_fantasia}</td>
             <td class="px-6 py-4 whitespace-nowrap text-sm" style="color: var(--color-violet)">${c.cnpj}</td>
+            <td class="px-6 py-4 whitespace-nowrap text-sm" style="color: var(--color-violet)">${c.pais || ''}</td>
             <td class="px-6 py-4 whitespace-nowrap text-sm" style="color: var(--color-violet)">${c.estado}</td>
             <td class="px-6 py-4 whitespace-nowrap">${badgeForStatus(c.status_cliente)}</td>
             <td class="px-6 py-4 whitespace-nowrap text-sm text-white">${c.dono_cliente || ''}</td>


### PR DESCRIPTION
## Summary
- show clients' country before state in listing
- include country in client search filter
- expose country field from backend

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af52c1f1848322883393964a996394