### PR TITLE
Restrict phone numbers to digits in contact modal

### DIFF
--- a/src/html/modals/clientes/contato.html
+++ b/src/html/modals/clientes/contato.html
@@ -19,11 +19,11 @@
         <label for="contatoEmail" class="absolute left-4 top-1/2 -translate-y-1/2 text-base text-gray-300 pointer-events-none transition-all duration-150 peer-placeholder-shown:top-1/2 peer-placeholder-shown:-translate-y-1/2 peer-placeholder-shown:text-base peer-focus:top-0 peer-focus:-translate-y-full peer-focus:text-xs peer-focus:text-primary peer-valid:top-0 peer-valid:-translate-y-full peer-valid:text-xs">E-mail</label>
       </div>
       <div class="relative">
-        <input id="contatoCelular" name="telefone_celular" type="text" placeholder=" " class="peer w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-transparent focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+        <input id="contatoCelular" name="telefone_celular" type="text" inputmode="numeric" pattern="[0-9]*" placeholder=" " class="peer w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-transparent focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
         <label for="contatoCelular" class="absolute left-4 top-1/2 -translate-y-1/2 text-base text-gray-300 pointer-events-none transition-all duration-150 peer-placeholder-shown:top-1/2 peer-placeholder-shown:-translate-y-1/2 peer-placeholder-shown:text-base peer-focus:top-0 peer-focus:-translate-y-full peer-focus:text-xs peer-focus:text-primary peer-valid:top-0 peer-valid:-translate-y-full peer-valid:text-xs">Telefone Celular</label>
       </div>
       <div class="relative">
-        <input id="contatoFixo" name="telefone_fixo" type="text" placeholder=" " class="peer w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-transparent focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+        <input id="contatoFixo" name="telefone_fixo" type="text" inputmode="numeric" pattern="[0-9]*" placeholder=" " class="peer w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-transparent focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
         <label for="contatoFixo" class="absolute left-4 top-1/2 -translate-y-1/2 text-base text-gray-300 pointer-events-none transition-all duration-150 peer-placeholder-shown:top-1/2 peer-placeholder-shown:-translate-y-1/2 peer-placeholder-shown:text-base peer-focus:top-0 peer-focus:-translate-y-full peer-focus:text-xs peer-focus:text-primary peer-valid:top-0 peer-valid:-translate-y-full peer-valid:text-xs">Telefone Fixo</label>
       </div>
     </form>

--- a/src/js/modals/cliente-contato.js
+++ b/src/js/modals/cliente-contato.js
@@ -7,6 +7,9 @@
   document.addEventListener('keydown', function esc(e){ if(e.key==='Escape'){ close(); document.removeEventListener('keydown', esc); }});
 
   const form = document.getElementById('novoContatoClienteForm');
+  const onlyDigits = e => { e.target.value = e.target.value.replace(/\D/g, ''); };
+  form.telefone_celular.addEventListener('input', onlyDigits);
+  form.telefone_fixo.addEventListener('input', onlyDigits);
   form.addEventListener('submit', e => {
     e.preventDefault();
     const data = {


### PR DESCRIPTION
## Summary
- enforce digit-only input for contact phone fields
- strip non-numeric characters during typing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af53b60fec8322aaecf27d6867495f