### PR TITLE
Corrigir estado em novo e editar cliente

### DIFF
--- a/src/js/geo-service.js
+++ b/src/js/geo-service.js
@@ -7,6 +7,40 @@ const ENDPOINT_COUNTRIES =
 const ENDPOINT_STATES =
   'https://raw.githubusercontent.com/dr5hn/countries-states-cities-database/master/states.json'; // carregado sob demanda
 
+// Fallbacks offline mínimos para evitar falhas quando não há internet
+const FALLBACK_COUNTRIES = [{ name: 'Brasil', code: 'BR' }];
+const FALLBACK_STATES = {
+  BR: [
+    { name: 'Acre', code: 'AC' },
+    { name: 'Alagoas', code: 'AL' },
+    { name: 'Amapá', code: 'AP' },
+    { name: 'Amazonas', code: 'AM' },
+    { name: 'Bahia', code: 'BA' },
+    { name: 'Ceará', code: 'CE' },
+    { name: 'Distrito Federal', code: 'DF' },
+    { name: 'Espírito Santo', code: 'ES' },
+    { name: 'Goiás', code: 'GO' },
+    { name: 'Maranhão', code: 'MA' },
+    { name: 'Mato Grosso', code: 'MT' },
+    { name: 'Mato Grosso do Sul', code: 'MS' },
+    { name: 'Minas Gerais', code: 'MG' },
+    { name: 'Pará', code: 'PA' },
+    { name: 'Paraíba', code: 'PB' },
+    { name: 'Paraná', code: 'PR' },
+    { name: 'Pernambuco', code: 'PE' },
+    { name: 'Piauí', code: 'PI' },
+    { name: 'Rio de Janeiro', code: 'RJ' },
+    { name: 'Rio Grande do Norte', code: 'RN' },
+    { name: 'Rio Grande do Sul', code: 'RS' },
+    { name: 'Rondônia', code: 'RO' },
+    { name: 'Roraima', code: 'RR' },
+    { name: 'Santa Catarina', code: 'SC' },
+    { name: 'São Paulo', code: 'SP' },
+    { name: 'Sergipe', code: 'SE' },
+    { name: 'Tocantins', code: 'TO' }
+  ]
+};
+
 /* Caches */
 let _countriesCache = null;            // Array<{ name, code }>
 let _statesIndexByCountry = null;      // Map<string, Array<{ name, code }>>
@@ -21,16 +55,18 @@ const byName = (a, b) =>
  */
 async function getCountries() {
   if (_countriesCache) return _countriesCache;
-
-  const res = await fetch(ENDPOINT_COUNTRIES, { cache: 'force-cache' });
-  if (!res.ok) throw new Error('Falha ao baixar lista de países');
-
-  const data = await res.json();
-  _countriesCache = data
-    .map(c => ({ name: c?.name?.common ?? '', code: c?.cca2 ?? '' }))
-    .filter(c => c.name && c.code)
-    .sort(byName);
-
+  try {
+    const res = await fetch(ENDPOINT_COUNTRIES, { cache: 'force-cache' });
+    if (!res.ok) throw new Error('Falha ao baixar lista de países');
+    const data = await res.json();
+    _countriesCache = data
+      .map(c => ({ name: c?.name?.common ?? '', code: c?.cca2 ?? '' }))
+      .filter(c => c.name && c.code)
+      .sort(byName);
+  } catch (err) {
+    console.warn('getCountries fallback usado:', err);
+    _countriesCache = FALLBACK_COUNTRIES.slice();
+  }
   return _countriesCache;
 }
 
@@ -38,21 +74,24 @@ async function getCountries() {
 async function ensureStatesIndex() {
   if (_statesIndexByCountry) return _statesIndexByCountry;
 
-  const res = await fetch(ENDPOINT_STATES, { cache: 'force-cache' });
-  if (!res.ok) throw new Error('Falha ao baixar lista de estados');
-
-  const states = await res.json(); // [{ country_code, name, state_code, ... }]
   const idx = new Map();
-
-  for (const s of states) {
-    const cc = s.country_code; // ISO-2 (ex.: "BR", "US")
-    if (!cc) continue;
-    if (!idx.has(cc)) idx.set(cc, []);
-    idx.get(cc).push({ name: s.name, code: s.state_code || s.name });
+  try {
+    const res = await fetch(ENDPOINT_STATES, { cache: 'force-cache' });
+    if (!res.ok) throw new Error('Falha ao baixar lista de estados');
+    const states = await res.json(); // [{ country_code, name, state_code, ... }]
+    for (const s of states) {
+      const cc = s.country_code;
+      if (!cc) continue;
+      if (!idx.has(cc)) idx.set(cc, []);
+      idx.get(cc).push({ name: s.name, code: s.state_code || s.name });
+    }
+  } catch (err) {
+    console.warn('ensureStatesIndex fallback usado:', err);
+    for (const cc in FALLBACK_STATES) {
+      idx.set(cc, FALLBACK_STATES[cc].slice());
+    }
   }
-  // Ordena cada lista
   for (const [cc, list] of idx) list.sort(byName);
-
   _statesIndexByCountry = idx;
   return _statesIndexByCountry;
 }


### PR DESCRIPTION
## Summary
- add offline fallback lists for countries and Brazilian states
- safeguard geo service calls with try/catch to use fallback when network fails

## Testing
- `node - <<'NODE'
global.window = {};
require('./src/js/geo-service.js');
(async () => {
  const countries = await window.geoService.getCountries();
  console.log('countries', countries);
  const states = await window.geoService.getStatesByCountry('BR');
  console.log('states count', states.length);
})();
NODE`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af53d159688322958dde4786a8ff60