### PR TITLE
Corrigir seleção de país e estado na tabela de clientes

### DIFF
--- a/backend/clientesController.js
+++ b/backend/clientesController.js
@@ -4,40 +4,17 @@ const pool = require('./db');
 const router = express.Router();
 
 // GET /api/clientes/lista
-// The database now stores address fields in individual columns (ent_uf, reg_uf,
-// etc.).  Keep the utility for backwards compatibility but simply return the
-// value when it's already a 2-letter state.
-function extractUF(endereco) {
-  if (!endereco) return '';
-  if (typeof endereco === 'string' && endereco.length === 2) return endereco.toUpperCase();
-  const regex = /,\s*([A-Za-z]{2})\s*,\s*CEP/i;
-  const match = endereco.match(regex);
-  const validUF = [
-    'AC','AL','AP','AM','BA','CE','DF','ES','GO','MA','MT','MS','MG','PA',
-    'PB','PR','PE','PI','RJ','RN','RS','RO','RR','SC','SP','SE','TO'
-  ];
-  if (match) {
-    const uf = match[1].toUpperCase();
-    return validUF.includes(uf) ? uf : '';
-  }
-  const beforeCep = endereco.split(/CEP/i)[0];
-  const parts = beforeCep.split(',').map(p => p.trim()).filter(Boolean);
-  const ufCandidate = parts[parts.length - 1]?.toUpperCase();
-  return validUF.includes(ufCandidate) ? ufCandidate : '';
-}
-
 router.get('/lista', async (_req, res) => {
   try {
-    // 'ent_pais' and 'ent_uf' hold the country and state for the delivery address
     const result = await pool.query(
-      'SELECT id, nome_fantasia, cnpj, ent_pais AS pais, ent_uf, status_cliente, dono_cliente FROM clientes ORDER BY nome_fantasia'
+      'SELECT id, nome_fantasia, cnpj, ent_pais AS pais, ent_uf AS estado, status_cliente, dono_cliente FROM clientes ORDER BY nome_fantasia'
     );
     const clientes = result.rows.map(c => ({
       id: c.id,
       nome_fantasia: c.nome_fantasia,
       cnpj: c.cnpj,
-      pais: c.reg_pais || '',
-      estado: extractUF(c.ent_uf) || 'Unidentified State',
+      pais: c.pais || '',
+      estado: c.estado || '',
       status_cliente: c.status_cliente,
       dono_cliente: c.dono_cliente
     }));
@@ -200,7 +177,7 @@ router.post('/', async (req, res) => {
     cli.cnpj,
     cli.inscricao_estadual,
     cli.site,
-    cli.endereco_registro?.reg_pais,
+    cli.endereco_registro?.pais,
     cli.endereco_registro?.rua,
     cli.endereco_registro?.numero,
     cli.endereco_registro?.complemento,
@@ -208,7 +185,7 @@ router.post('/', async (req, res) => {
     cli.endereco_registro?.cidade,
     cli.endereco_registro?.estado,
     cli.endereco_registro?.cep,
-    cli.endereco_cobranca?.cob_pais,
+    cli.endereco_cobranca?.pais,
     cli.endereco_cobranca?.rua,
     cli.endereco_cobranca?.numero,
     cli.endereco_cobranca?.complemento,
@@ -216,7 +193,7 @@ router.post('/', async (req, res) => {
     cli.endereco_cobranca?.cidade,
     cli.endereco_cobranca?.estado,
     cli.endereco_cobranca?.cep,
-    cli.endereco_entrega?.ent_pais,
+    cli.endereco_entrega?.pais,
     cli.endereco_entrega?.rua,
     cli.endereco_entrega?.numero,
     cli.endereco_entrega?.complemento,
@@ -268,7 +245,7 @@ router.put('/:id', async (req, res) => {
     cli.cnpj,
     cli.inscricao_estadual,
     cli.site,
-    cli.endereco_registro?.reg_pais,
+    cli.endereco_registro?.pais,
     cli.endereco_registro?.rua,
     cli.endereco_registro?.numero,
     cli.endereco_registro?.complemento,
@@ -276,7 +253,7 @@ router.put('/:id', async (req, res) => {
     cli.endereco_registro?.cidade,
     cli.endereco_registro?.estado,
     cli.endereco_registro?.cep,
-    cli.endereco_cobranca?.cob_pais,
+    cli.endereco_cobranca?.pais,
     cli.endereco_cobranca?.rua,
     cli.endereco_cobranca?.numero,
     cli.endereco_cobranca?.complemento,
@@ -284,7 +261,7 @@ router.put('/:id', async (req, res) => {
     cli.endereco_cobranca?.cidade,
     cli.endereco_cobranca?.estado,
     cli.endereco_cobranca?.cep,
-    cli.endereco_entrega?.ent_pais,
+    cli.endereco_entrega?.pais,
     cli.endereco_entrega?.rua,
     cli.endereco_entrega?.numero,
     cli.endereco_entrega?.complemento,

--- a/backend/clientesResumo.test.js
+++ b/backend/clientesResumo.test.js
@@ -65,9 +65,9 @@ test('GET /api/clientes/:id/resumo formata endereços e contatos', async () => {
     reg_logradouro, reg_numero, reg_complemento, reg_bairro, reg_cidade, reg_uf, reg_cep, reg_pais
   ) VALUES (
     1, 'Cliente A', 'Cliente A SA', '123', '321',
-    'Rua X', '10', '', 'Bairro X', 'Cidade X', 'SP', '12345-678', 'BR',
-    'Rua X', '10', '', 'Bairro X', 'Cidade X', 'SP', '12345-678', 'BR',
-    'Rua Y', '20', 'Sala 5', 'Bairro Y', 'Cidade Y', 'RJ', '98765-432', 'BR'
+    'Rua X', '10', '', 'Bairro X', 'Cidade X', 'São Paulo', '12345-678', 'Brasil',
+    'Rua X', '10', '', 'Bairro X', 'Cidade X', 'São Paulo', '12345-678', 'Brasil',
+    'Rua Y', '20', 'Sala 5', 'Bairro Y', 'Cidade Y', 'Rio de Janeiro', '98765-432', 'Brasil'
   );`);
 
   await pool.query(`INSERT INTO contatos_cliente (id_cliente, nome, telefone_fixo, telefone_celular, email)
@@ -93,9 +93,9 @@ test('GET /api/clientes/:id/resumo formata endereços e contatos', async () => {
   assert.strictEqual(res.status, 200);
   const body = await res.json();
 
-  assert.strictEqual(body.endereco_entrega, 'Rua X, 10, Bairro X - Cidade X/SP - 12345-678 - BR');
+  assert.strictEqual(body.endereco_entrega, 'Rua X, 10, Bairro X - Cidade X/São Paulo - 12345-678 - Brasil');
   assert.strictEqual(body.endereco_faturamento, 'Igual Entrega');
-  assert.strictEqual(body.endereco_registro, 'Rua Y, 20 - Sala 5, Bairro Y - Cidade Y/RJ - 98765-432 - BR');
+  assert.strictEqual(body.endereco_registro, 'Rua Y, 20 - Sala 5, Bairro Y - Cidade Y/Rio de Janeiro - 98765-432 - Brasil');
   assert.deepStrictEqual(body.contatos, [
     {
       id_cliente: 1,
@@ -115,7 +115,7 @@ test('GET /api/clientes/lista inclui pais', async () => {
   const pool = new Pool();
 
   await pool.query(`INSERT INTO clientes (id, nome_fantasia, cnpj, ent_uf, ent_pais, status_cliente, dono_cliente)
-                    VALUES (1, 'Cliente A', '123', 'SP', 'BR', 'Ativo', 'Joao')`);
+                    VALUES (1, 'Cliente A', '123', 'São Paulo', 'Brasil', 'Ativo', 'Joao')`);
 
   const dbModulePath = require.resolve('./db');
   require.cache[dbModulePath] = {
@@ -140,8 +140,8 @@ test('GET /api/clientes/lista inclui pais', async () => {
     id: 1,
     nome_fantasia: 'Cliente A',
     cnpj: '123',
-    pais: 'BR',
-    estado: 'SP',
+    pais: 'Brasil',
+    estado: 'São Paulo',
     status_cliente: 'Ativo',
     dono_cliente: 'Joao'
   }]);

--- a/src/js/modals/cliente-detalhes.js
+++ b/src/js/modals/cliente-detalhes.js
@@ -162,13 +162,18 @@
       if(paisSel && estadoSel){
         const countries = await geoService.getCountries();
         paisSel.innerHTML = '<option value="">Selecione</option>' +
-          countries.map(c => `<option value="${c.code}">${c.name}</option>`).join('');
+          countries.map(c => `<option value="${c.name}" data-code="${c.code}">${c.name}</option>`).join('');
         paisSel.value = data.pais || '';
         if(data.pais){
-          const states = await geoService.getStatesByCountry(data.pais);
-          estadoSel.innerHTML = '<option value="">Selecione</option>' +
-            states.map(s => `<option value="${s.code}">${s.name}</option>`).join('');
-          estadoSel.value = data.estado || '';
+          const code = countries.find(c => c.name === data.pais)?.code;
+          if(code){
+            const states = await geoService.getStatesByCountry(code);
+            estadoSel.innerHTML = '<option value="">Selecione</option>' +
+              states.map(s => `<option value="${s.name}">${s.name}</option>`).join('');
+            estadoSel.value = data.estado || '';
+          } else {
+            estadoSel.innerHTML = '<option value="">Selecione o país</option>';
+          }
         } else {
           estadoSel.innerHTML = '<option value="">Selecione o país</option>';
         }

--- a/src/js/modals/cliente-editar.js
+++ b/src/js/modals/cliente-editar.js
@@ -136,20 +136,26 @@
     if(paisSel && estadoSel){
       const countries = await geoService.getCountries();
       paisSel.innerHTML = '<option value="">Selecione</option>' +
-        countries.map(c => `<option value="${c.code}">${c.name}</option>`).join('');
+        countries.map(c => `<option value="${c.name}" data-code="${c.code}">${c.name}</option>`).join('');
       if(data?.pais){
         paisSel.value = data.pais;
-        const states = await geoService.getStatesByCountry(data.pais);
-        estadoSel.innerHTML = '<option value="">Selecione</option>' +
-          states.map(s => `<option value="${s.code}">${s.name}</option>`).join('');
-        estadoSel.disabled = false;
-        estadoSel.value = data.estado || '';
+        const code = countries.find(c => c.name === data.pais)?.code;
+        if(code){
+          const states = await geoService.getStatesByCountry(code);
+          estadoSel.innerHTML = '<option value="">Selecione</option>' +
+            states.map(s => `<option value="${s.name}">${s.name}</option>`).join('');
+          estadoSel.disabled = false;
+          estadoSel.value = data.estado || '';
+        } else {
+          estadoSel.disabled = true;
+          estadoSel.innerHTML = '<option value="">Selecione o país</option>';
+        }
       } else {
         estadoSel.disabled = true;
         estadoSel.innerHTML = '<option value="">Selecione o país</option>';
       }
       paisSel.addEventListener('change', async () => {
-        const code = paisSel.value;
+        const code = paisSel.selectedOptions[0]?.dataset.code;
         if(!code){
           estadoSel.disabled = true;
           estadoSel.innerHTML = '<option value="">Selecione o país</option>';
@@ -158,7 +164,7 @@
         const states = await geoService.getStatesByCountry(code);
         estadoSel.disabled = false;
         estadoSel.innerHTML = '<option value="">Selecione</option>' +
-          states.map(s => `<option value="${s.code}">${s.name}</option>`).join('');
+          states.map(s => `<option value="${s.name}">${s.name}</option>`).join('');
       });
       estadoSel.addEventListener('mousedown', e => {
         if(!paisSel.value){

--- a/src/js/modals/cliente-novo.js
+++ b/src/js/modals/cliente-novo.js
@@ -123,11 +123,11 @@
     if(!paisSel || !estadoSel) return;
     const countries = await geoService.getCountries();
     paisSel.innerHTML = '<option value="">Selecione</option>' +
-      countries.map(c => `<option value="${c.code}">${c.name}</option>`).join('');
+      countries.map(c => `<option value="${c.name}" data-code="${c.code}">${c.name}</option>`).join('');
     estadoSel.disabled = true;
     estadoSel.innerHTML = '<option value="">Selecione o país</option>';
     paisSel.addEventListener('change', async () => {
-      const code = paisSel.value;
+      const code = paisSel.selectedOptions[0]?.dataset.code;
       if(!code){
         estadoSel.disabled = true;
         estadoSel.innerHTML = '<option value="">Selecione o país</option>';
@@ -136,7 +136,7 @@
       const states = await geoService.getStatesByCountry(code);
       estadoSel.disabled = false;
       estadoSel.innerHTML = '<option value="">Selecione</option>' +
-        states.map(s => `<option value="${s.code}">${s.name}</option>`).join('');
+        states.map(s => `<option value="${s.name}">${s.name}</option>`).join('');
     });
     estadoSel.addEventListener('mousedown', e => {
       if(!paisSel.value){


### PR DESCRIPTION
## Summary
- corrigida consulta de clientes para retornar país e estado pelo nome
- atualizados modais para enviar e exibir nomes completos de país e estado
- ajustados testes de clientes para refletir dados completos

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af615ec5608322b3b1b026da845c19