### PR TITLE
Fix cancel button in client edit modal

### DIFF
--- a/src/html/modals/clientes/editar.html
+++ b/src/html/modals/clientes/editar.html
@@ -264,7 +264,7 @@
     </div>
 
     <footer class="flex justify-end items-center gap-4 px-8 py-5 border-t border-white/10 flex-shrink-0">
-      <button class="btn-danger px-6 py-2 rounded-lg text-white font-medium min-w-[120px]">Cancelar</button>
+      <button id="cancelarEditarCliente" class="btn-danger px-6 py-2 rounded-lg text-white font-medium min-w-[120px]">Cancelar</button>
       <button class="btn-primary px-6 py-2 rounded-lg text-white font-medium min-w-[120px]">Salvar</button>
     </footer>
   </div>

--- a/src/js/modals/cliente-editar.js
+++ b/src/js/modals/cliente-editar.js
@@ -5,6 +5,7 @@
   overlay.addEventListener('click', e => { if(e.target === overlay) close(); });
   const voltar = document.getElementById('voltarEditarCliente');
   if(voltar) voltar.addEventListener('click', close);
+  document.getElementById('cancelarEditarCliente')?.addEventListener('click', close);
   document.addEventListener('keydown', function esc(e){ if(e.key==='Escape'){ close(); document.removeEventListener('keydown', esc); }});
 
   const cliente = window.clienteEditar;
@@ -342,6 +343,7 @@
         if(!res.ok) throw new Error('Erro ao salvar');
         showToast('Cliente atualizado com sucesso');
         window.dispatchEvent(new Event('clienteEditado'));
+        close();
       }catch(err){
         console.error('Erro ao atualizar cliente', err);
         showToast('Erro ao salvar cliente', 'error');


### PR DESCRIPTION
## Summary
- wire up cancel button in client edit modal
- close edit modal after saving

## Testing
- `npm test` *(fails: Cannot find module '/workspace/App-Gestao/backend')*

------
https://chatgpt.com/codex/tasks/task_e_68af6629f1648322a8494a276c2a4be6