### PR TITLE
Add copy buttons for client address sections

### DIFF
--- a/src/html/modals/clientes/detalhes.html
+++ b/src/html/modals/clientes/detalhes.html
@@ -88,7 +88,10 @@
 
       <section id="panel-enderecos" role="tabpanel" aria-labelledby="tab-enderecos" class="px-8 py-6 hidden">
         <div class="mb-8">
-          <h3 class="text-lg font-semibold text-white mb-4">Endereço de Registro</h3>
+          <h3 class="text-lg font-semibold text-white mb-4 flex items-center gap-2">
+            <button id="copyRegEndereco" type="button" class="text-gray-400 hover:text-white"><i class="fas fa-copy"></i></button>
+            Endereço de Registro
+          </h3>
           <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div class="md:col-span-2">
               <label class="block text-sm font-medium text-gray-300 mb-2">Rua</label>
@@ -131,7 +134,10 @@
 
         <div class="mb-8">
           <div class="flex items-center justify-between mb-4">
-            <h3 class="text-lg font-semibold text-white">Endereço de Cobrança</h3>
+            <h3 class="text-lg font-semibold text-white flex items-center gap-2">
+              <button id="copyCobEndereco" type="button" class="text-gray-400 hover:text-white"><i class="fas fa-copy"></i></button>
+              Endereço de Cobrança
+            </h3>
             <label class="flex items-center gap-3">
               <input id="cobrancaIgual" type="checkbox" class="component-toggle" />
               <span class="text-sm text-gray-300">Igual ao de Registro</span>
@@ -179,7 +185,10 @@
 
         <div>
           <div class="flex items-center justify-between mb-4">
-            <h3 class="text-lg font-semibold text-white">Endereço de Entrega</h3>
+            <h3 class="text-lg font-semibold text-white flex items-center gap-2">
+              <button id="copyEntEndereco" type="button" class="text-gray-400 hover:text-white"><i class="fas fa-copy"></i></button>
+              Endereço de Entrega
+            </h3>
             <label class="flex items-center gap-3">
               <input id="entregaIgual" type="checkbox" class="component-toggle" />
               <span class="text-sm text-gray-300">Igual ao de Registro</span>

--- a/src/js/modals/cliente-detalhes.js
+++ b/src/js/modals/cliente-detalhes.js
@@ -116,6 +116,7 @@
   overlay.addEventListener('focusin', warn);
   overlay.querySelectorAll('input, textarea').forEach(el => el.readOnly = true);
   addCopyButtons();
+  setupAddressCopyButtons();
 
   const editar = document.getElementById('editarDetalhesCliente');
   if(editar){
@@ -251,6 +252,39 @@
         }
       });
       wrapper.appendChild(btn);
+    });
+  }
+
+  function setupAddressCopyButtons(){
+    const formatAddress = prefix => {
+      const rua = document.getElementById(prefix + 'Rua')?.value.trim() || '';
+      const numero = document.getElementById(prefix + 'Numero')?.value.trim() || '';
+      const complemento = document.getElementById(prefix + 'Complemento')?.value.trim() || '';
+      const bairro = document.getElementById(prefix + 'Bairro')?.value.trim() || '';
+      const cidade = document.getElementById(prefix + 'Cidade')?.value.trim() || '';
+      const estado = document.getElementById(prefix + 'Estado')?.value.trim() || '';
+      const pais = document.getElementById(prefix + 'Pais')?.value.trim() || '';
+      const cep = document.getElementById(prefix + 'Cep')?.value.trim() || '';
+      return `${rua} ${numero}${complemento ? ', ' + complemento : ''}, ${bairro}, ${cidade}/${estado}, ${pais} - ${cep}`;
+    };
+    const buttons = {
+      reg: 'copyRegEndereco',
+      cob: 'copyCobEndereco',
+      ent: 'copyEntEndereco'
+    };
+    Object.entries(buttons).forEach(([prefix, id]) => {
+      const btn = document.getElementById(id);
+      if(btn){
+        btn.addEventListener('click', async () => {
+          const text = formatAddress(prefix);
+          try{
+            await navigator.clipboard.writeText(text);
+            showToast('Endereço copiado!', 'success');
+          }catch{
+            showToast('Erro ao copiar', 'error');
+          }
+        });
+      }
     });
   }
 


### PR DESCRIPTION
## Summary
- add copy icons to client address headers in details modal
- enable copying formatted address fields to clipboard

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af66e4272883229db25b0a23082dff