### PR TITLE
Add owner, status and origin fields to client modals

### DIFF
--- a/backend/clientesController.js
+++ b/backend/clientesController.js
@@ -201,7 +201,10 @@ router.post('/', async (req, res) => {
     cli.endereco_entrega?.cidade,
     cli.endereco_entrega?.estado,
     cli.endereco_entrega?.cep,
-    cli.anotacoes
+    cli.anotacoes,
+    cli.status_cliente,
+    cli.dono_cliente,
+    cli.origem_captacao
   ];
   try {
     const dupCheck = await pool.query('SELECT id FROM clientes WHERE cnpj = $1', [cli.cnpj]);
@@ -214,9 +217,9 @@ router.post('/', async (req, res) => {
         reg_pais, reg_logradouro, reg_numero, reg_complemento, reg_bairro, reg_cidade, reg_uf, reg_cep,
         cob_pais, cob_logradouro, cob_numero, cob_complemento, cob_bairro, cob_cidade, cob_uf, cob_cep,
         ent_pais, ent_logradouro, ent_numero, ent_complemento, ent_bairro, ent_cidade, ent_uf, ent_cep,
-        anotacoes
+        anotacoes, status_cliente, dono_cliente, origem_captacao
       ) VALUES (
-        $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27,$28,$29,$30
+        $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27,$28,$29,$30,$31,$32,$33
       ) RETURNING id`,
       values
     );
@@ -270,6 +273,9 @@ router.put('/:id', async (req, res) => {
     cli.endereco_entrega?.estado,
     cli.endereco_entrega?.cep,
     cli.anotacoes,
+    cli.status_cliente,
+    cli.dono_cliente,
+    cli.origem_captacao,
     id
   ];
   try {
@@ -304,8 +310,11 @@ router.put('/:id', async (req, res) => {
         ent_cidade = $27,
         ent_uf = $28,
         ent_cep = $29,
-        anotacoes = $30
-       WHERE id = $31`,
+        anotacoes = $30,
+        status_cliente = $31,
+        dono_cliente = $32,
+        origem_captacao = $33
+       WHERE id = $34`,
       values
     );
     const contatos = Array.isArray(cli.contatos) ? cli.contatos : [];

--- a/backend/clientesResumo.test.js
+++ b/backend/clientesResumo.test.js
@@ -37,7 +37,8 @@ function setupDb() {
       reg_cep text,
       reg_pais text,
       status_cliente text,
-      dono_cliente text
+      dono_cliente text,
+      origem_captacao text
     );
   `);
   db.public.none(`

--- a/src/html/modals/clientes/detalhes.html
+++ b/src/html/modals/clientes/detalhes.html
@@ -37,14 +37,8 @@
                 <input id="empresaCnpj" type="text" placeholder="00.000.000/0001-00" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
               </div>
               <div>
-                <label class="block text-sm font-medium text-gray-300 mb-2">Segmento</label>
-                <select id="empresaSegmento" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition select-arrow appearance-none">
-                  <option value="">Selecione o segmento</option>
-                  <option value="varejo">Varejo</option>
-                  <option value="atacado">Atacado</option>
-                  <option value="servicos">Serviços</option>
-                  <option value="industria">Indústria</option>
-                </select>
+                <label class="block text-sm font-medium text-gray-300 mb-2">Dono</label>
+                <input id="empresaDono" type="text" placeholder="Nome do dono" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
               </div>
               <div>
                 <label class="block text-sm font-medium text-gray-300 mb-2">Inscrição Estadual</label>
@@ -53,6 +47,14 @@
               <div>
                 <label class="block text-sm font-medium text-gray-300 mb-2">Site</label>
                 <input id="empresaSite" type="url" placeholder="https://www.exemplo.com.br" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+              </div>
+              <div>
+                <label class="block text-sm font-medium text-gray-300 mb-2">Status</label>
+                <input id="empresaStatus" type="text" placeholder="Status" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+              </div>
+              <div>
+                <label class="block text-sm font-medium text-gray-300 mb-2">Origem Captação</label>
+                <input id="empresaOrigemCaptacao" type="text" placeholder="Origem do contato" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
               </div>
             </div>
           </div>

--- a/src/html/modals/clientes/editar.html
+++ b/src/html/modals/clientes/editar.html
@@ -37,13 +37,9 @@
                 <input id="empresaCnpj" type="text" placeholder="00.000.000/0001-00" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
               </div>
               <div>
-                <label class="block text-sm font-medium text-gray-300 mb-2">Segmento</label>
-                <select id="empresaSegmento" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition select-arrow appearance-none">
-                  <option value="">Selecione o segmento</option>
-                  <option value="varejo">Varejo</option>
-                  <option value="atacado">Atacado</option>
-                  <option value="servicos">Serviços</option>
-                  <option value="industria">Indústria</option>
+                <label class="block text-sm font-medium text-gray-300 mb-2">Dono</label>
+                <select id="empresaDono" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition select-arrow appearance-none">
+                  <option value="">Selecione o dono</option>
                 </select>
               </div>
               <div>
@@ -53,6 +49,18 @@
               <div>
                 <label class="block text-sm font-medium text-gray-300 mb-2">Site</label>
                 <input id="empresaSite" type="url" placeholder="https://www.exemplo.com.br" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+              </div>
+              <div>
+                <label class="block text-sm font-medium text-gray-300 mb-2">Status</label>
+                <select id="empresaStatus" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition select-arrow appearance-none">
+                  <option value="">Selecione o status</option>
+                  <option value="Ativo">Ativo</option>
+                  <option value="Inativo">Inativo</option>
+                </select>
+              </div>
+              <div>
+                <label class="block text-sm font-medium text-gray-300 mb-2">Origem Captação</label>
+                <input id="empresaOrigemCaptacao" type="text" placeholder="Origem do contato" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
               </div>
             </div>
           </div>

--- a/src/html/modals/clientes/novo.html
+++ b/src/html/modals/clientes/novo.html
@@ -37,13 +37,9 @@
                 <input id="empresaCnpj" type="text" placeholder="00.000.000/0001-00" maxlength="18" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
               </div>
               <div>
-                <label class="block text-sm font-medium text-gray-300 mb-2">Segmento</label>
-                <select id="empresaSegmento" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition select-arrow appearance-none">
-                  <option value="">Selecione o segmento</option>
-                  <option value="varejo">Varejo</option>
-                  <option value="atacado">Atacado</option>
-                  <option value="servicos">Serviços</option>
-                  <option value="industria">Indústria</option>
+                <label class="block text-sm font-medium text-gray-300 mb-2">Dono</label>
+                <select id="empresaDono" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition select-arrow appearance-none">
+                  <option value="">Selecione o dono</option>
                 </select>
               </div>
               <div>
@@ -53,6 +49,18 @@
               <div>
                 <label class="block text-sm font-medium text-gray-300 mb-2">Site</label>
                 <input id="empresaSite" type="url" placeholder="https://www.exemplo.com.br" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
+              </div>
+              <div>
+                <label class="block text-sm font-medium text-gray-300 mb-2">Status</label>
+                <select id="empresaStatus" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white focus:border-primary focus:ring-2 focus:ring-primary/50 transition select-arrow appearance-none">
+                  <option value="">Selecione o status</option>
+                  <option value="Ativo">Ativo</option>
+                  <option value="Inativo">Inativo</option>
+                </select>
+              </div>
+              <div>
+                <label class="block text-sm font-medium text-gray-300 mb-2">Origem Captação</label>
+                <input id="empresaOrigemCaptacao" type="text" placeholder="Origem do contato" class="w-full bg-input border border-inputBorder rounded-lg px-4 py-3 text-white placeholder-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/50 transition" />
               </div>
             </div>
           </div>

--- a/src/js/modals/cliente-detalhes.js
+++ b/src/js/modals/cliente-detalhes.js
@@ -135,9 +135,11 @@
       empresaRazaoSocial: 'razao_social',
       empresaNomeFantasia: 'nome_fantasia',
       empresaCnpj: 'cnpj',
-      empresaSegmento: 'segmento',
       empresaInscricaoEstadual: 'inscricao_estadual',
-      empresaSite: 'site'
+      empresaSite: 'site',
+      empresaDono: 'dono_cliente',
+      empresaStatus: 'status_cliente',
+      empresaOrigemCaptacao: 'origem_captacao'
     };
     for(const id in map){
       const el = document.getElementById(id);

--- a/src/js/modals/cliente-editar.js
+++ b/src/js/modals/cliente-editar.js
@@ -27,7 +27,7 @@
       const res = await fetch(`http://localhost:3000/api/clientes/${cliente.id}`);
       const data = await res.json();
       if(data && data.cliente){
-        preencherDadosEmpresa(data.cliente);
+        await preencherDadosEmpresa(data.cliente);
         await preencherEnderecos(data.cliente);
         renderContatos(data.contatos || []);
         preencherEnderecos(data.cliente);
@@ -111,12 +111,11 @@
 
   activateTab(tabs[0], { setFocus: false });
 
-  function preencherDadosEmpresa(cli){
+  async function preencherDadosEmpresa(cli){
     const map = {
       empresaRazaoSocial: 'razao_social',
       empresaNomeFantasia: 'nome_fantasia',
       empresaCnpj: 'cnpj',
-      empresaSegmento: 'segmento',
       empresaInscricaoEstadual: 'inscricao_estadual',
       empresaSite: 'site'
     };
@@ -124,6 +123,22 @@
       const el = document.getElementById(id);
       if(el) el.value = cli[map[id]] || '';
     }
+    const donoSel = document.getElementById('empresaDono');
+    if(donoSel){
+      try{
+        const res = await fetch('http://localhost:3000/api/usuarios/lista');
+        const usuarios = await res.json();
+        donoSel.innerHTML = '<option value="">Selecione o dono</option>' +
+          usuarios.map(u => `<option value="${u.nome}">${u.nome}</option>`).join('');
+        donoSel.value = cli.dono_cliente || '';
+      }catch(err){
+        console.error('Erro ao carregar usuários', err);
+      }
+    }
+    const statusSel = document.getElementById('empresaStatus');
+    if(statusSel) statusSel.value = cli.status_cliente || '';
+    const origemInput = document.getElementById('empresaOrigemCaptacao');
+    if(origemInput) origemInput.value = cli.origem_captacao || '';
     const avatar = document.getElementById('empresaAvatar');
     if(avatar){
       const name = cli.nome_fantasia || cli.razao_social || '';
@@ -322,6 +337,9 @@
       cnpj: getVal('empresaCnpj'),
       inscricao_estadual: getVal('empresaInscricaoEstadual'),
       site: getVal('empresaSite'),
+      status_cliente: getVal('empresaStatus'),
+      dono_cliente: getVal('empresaDono'),
+      origem_captacao: getVal('empresaOrigemCaptacao'),
       endereco_registro: reg,
       endereco_cobranca: cob,
       endereco_entrega: ent,

--- a/src/js/modals/cliente-novo.js
+++ b/src/js/modals/cliente-novo.js
@@ -105,6 +105,21 @@
   }
   initToggles();
 
+  async function carregarUsuarios(){
+    try {
+      const res = await fetch('http://localhost:3000/api/usuarios/lista');
+      const usuarios = await res.json();
+      const sel = document.getElementById('empresaDono');
+      if(sel){
+        sel.innerHTML = '<option value="">Selecione o dono</option>' +
+          usuarios.map(u => `<option value="${u.nome}">${u.nome}</option>`).join('');
+      }
+    } catch(err){
+      console.error('Erro ao carregar usuários', err);
+    }
+  }
+  carregarUsuarios();
+
   async function ensureGeo(){
     if(window.geoService) return;
     await new Promise((resolve, reject) => {
@@ -196,7 +211,8 @@
       empresaRazaoSocial: 'Razão Social',
       empresaNomeFantasia: 'Nome Fantasia',
       empresaCnpj: 'CNPJ',
-      empresaSegmento: 'Segmento',
+      empresaDono: 'Dono',
+      empresaStatus: 'Status',
       empresaInscricaoEstadual: 'Inscrição Estadual'
     };
     for(const id in requiredEmpresa){
@@ -250,9 +266,11 @@
       razao_social: getVal('empresaRazaoSocial'),
       nome_fantasia: getVal('empresaNomeFantasia'),
       cnpj: getVal('empresaCnpj'),
-      segmento: getVal('empresaSegmento'),
       inscricao_estadual: getVal('empresaInscricaoEstadual'),
       site: getVal('empresaSite') || 'Não Informado',
+      status_cliente: getVal('empresaStatus'),
+      dono_cliente: getVal('empresaDono'),
+      origem_captacao: getVal('empresaOrigemCaptacao'),
       endereco_registro: reg,
       endereco_cobranca: cob,
       endereco_entrega: ent,


### PR DESCRIPTION
## Summary
- replace segmento with dono across cliente modals
- persist dono, status_cliente and origem_captacao in backend
- fetch usuarios to populate dono dropdowns

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af67abd0e48322873a907d786488d4