### PR TITLE
Fix Client Deletion Without Notes Table

### DIFF
--- a/backend/clientesController.js
+++ b/backend/clientesController.js
@@ -345,7 +345,9 @@ router.delete('/:id', async (req, res) => {
     try {
       await pool.query('DELETE FROM contratos WHERE cliente_id = $1', [id]);
     } catch (_) {}
-    await pool.query('DELETE FROM cliente_notas WHERE cliente_id = $1', [id]);
+    try {
+      await pool.query('DELETE FROM cliente_notas WHERE cliente_id = $1', [id]);
+    } catch (_) {}
     await pool.query('DELETE FROM clientes WHERE id = $1', [id]);
     await pool.query('COMMIT');
 


### PR DESCRIPTION
## Summary
- avoid failing when removing clients without a `cliente_notas` table

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af6d31b3f883229160bb39469274fb