### PR TITLE
Fix client table not refreshing after new registration

### DIFF
--- a/src/js/clientes.js
+++ b/src/js/clientes.js
@@ -198,6 +198,7 @@ window.abrirEditarCliente = abrirEditarCliente;
 
 window.addEventListener('clienteEditado', () => carregarClientes(true));
 window.addEventListener('clienteExcluido', () => carregarClientes(true));
+window.addEventListener('clienteAdicionado', () => carregarClientes(true));
 
 function renderTotais(clientes) {
     const container = document.getElementById('totaisBadges');

--- a/src/js/modals/cliente-novo.js
+++ b/src/js/modals/cliente-novo.js
@@ -294,8 +294,8 @@
       }
       if(!res.ok) throw new Error('Erro ao registrar');
       showToast('Cliente registrado com sucesso');
+      window.dispatchEvent(new Event('clienteAdicionado'));
       close();
-      if(typeof carregarClientes === 'function') await carregarClientes(true);
     }catch(err){
       console.error('Erro ao registrar cliente', err);
       showToast('Erro ao registrar cliente', 'error');


### PR DESCRIPTION
## Summary
- Dispatch clientAdded event when registering new client
- Refresh client list when clientAdded event is fired

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af703529a48322a3aa9256482beedb