### PR TITLE
Refine Budget Conversion Review Popup

### DIFF
--- a/src/html/modals/orcamentos/converter.html
+++ b/src/html/modals/orcamentos/converter.html
@@ -44,6 +44,7 @@
                     <th class="text-left py-3 px-2 text-gray-300 font-medium">Peça</th>
                     <th class="text-center py-3 px-2 text-gray-300 font-medium">Qtd Orçada</th>
                     <th class="text-center py-3 px-2 text-gray-300 font-medium">Em Estoque</th>
+                    <th class="text-center py-3 px-2 text-gray-300 font-medium">Pronta</th>
                     <th class="text-center py-3 px-2 text-gray-300 font-medium">Produzir Total</th>
                     <th class="text-center py-3 px-2 text-gray-300 font-medium">Produzir Parcial</th>
                     <th class="text-center py-3 px-2 text-gray-300 font-medium">Status</th>


### PR DESCRIPTION
## Summary
- fix production quantity calculations by excluding ready items from stock
- show reload-style spinner when toggling 'Somente faltantes'

## Testing
- `node --test backend/*.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b74be294b483228930d0f4982df8bd