### PR TITLE
Create dedicated filter bars for relatório sections

### DIFF
--- a/src/css/relatorios.css
+++ b/src/css/relatorios.css
@@ -219,6 +219,58 @@ body {
     accent-color: var(--color-primary);
 }
 
+.relatorios-filter-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.relatorios-filter-tag {
+    padding: 0.35rem 0.85rem;
+    border-radius: 999px;
+    font-size: 0.8rem;
+    font-weight: 500;
+    color: #f3f4f6;
+    background: rgba(94, 234, 212, 0.15);
+    border: 1px solid rgba(94, 234, 212, 0.3);
+    transition: all 0.2s ease;
+}
+
+.relatorios-filter-tag:hover,
+.relatorios-filter-tag:focus {
+    background: rgba(94, 234, 212, 0.3);
+    border-color: rgba(94, 234, 212, 0.45);
+}
+
+.relatorios-filter-tag:focus {
+    outline: 2px solid rgba(94, 234, 212, 0.45);
+    outline-offset: 2px;
+}
+
+.relatorios-filter-hint {
+    font-size: 0.75rem;
+    color: rgba(255, 255, 255, 0.55);
+}
+
+.relatorios-filter-slider {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.relatorios-slider {
+    flex: 1;
+    width: 100%;
+    accent-color: var(--color-primary);
+}
+
+.relatorios-slider-value {
+    font-size: 0.85rem;
+    color: rgba(255, 255, 255, 0.7);
+    min-width: 3rem;
+    text-align: center;
+}
+
 .relatorios-filter-status {
     width: 100%;
     margin-top: 0.75rem;
@@ -242,6 +294,10 @@ body {
 
     .relatorios-filter-status {
         justify-content: flex-start;
+    }
+
+    .relatorios-filter-slider {
+        align-items: stretch;
     }
 }
 

--- a/src/html/relatorios.html
+++ b/src/html/relatorios.html
@@ -79,6 +79,9 @@
                 <button role="tab" aria-selected="false" class="tab-inactive" data-relatorios-tab="clientes">
                     Clientes
                 </button>
+                <button role="tab" aria-selected="false" class="tab-inactive" data-relatorios-tab="contatos">
+                    Contatos
+                </button>
                 <button role="tab" aria-selected="false" class="tab-inactive" data-relatorios-tab="prospeccoes">
                     Prospecções
                 </button>
@@ -98,138 +101,603 @@
         <section class="glass-surface rounded-xl p-6 animate-fade-in-up">
             <h2 class="section-title">Filtros</h2>
 
-            <!-- Common Filters -->
-            <div class="filter-bar relatorios-filter-bar mb-4">
-                <div class="relatorios-filter-field">
-                    <label class="relatorios-filter-label text-white">Período</label>
-                    <select class="input-glass text-white rounded-md px-4 py-3 w-full">
-                        <option value="">Selecione...</option>
-                        <option value="7">Últimos 7 dias</option>
-                        <option value="30">Últimos 30 dias</option>
-                        <option value="90">Últimos 90 dias</option>
-                        <option value="custom">Período personalizado</option>
-                    </select>
-                </div>
-
-                <div class="relatorios-filter-field">
-                    <label class="relatorios-filter-label text-white">Status</label>
-                    <input type="text" class="input-glass text-white rounded-md px-4 py-3 w-full" placeholder="Status do relatório">
-                </div>
-
-                <div class="relatorios-filter-field">
-                    <label class="relatorios-filter-label text-white">Responsável</label>
-                    <select class="input-glass text-white rounded-md px-4 py-3 w-full">
-                        <option value="">Todos</option>
-                        <option value="joao">João Silva</option>
-                        <option value="maria">Maria Santos</option>
-                        <option value="pedro">Pedro Lima</option>
-                    </select>
-                </div>
-
-                <div class="relatorios-filter-field">
-                    <label class="relatorios-filter-label text-white">Buscar</label>
-                    <input type="text" class="input-glass text-white rounded-md px-4 py-3 w-full" placeholder="Palavra-chave ou termo">
-                </div>
-
-                <div id="bt-actions" class="flex items-center gap-2 flex-shrink-0">
-                    <button id="btnFiltrar" class="btn-secondary text-white rounded-md px-4 py-3 text-sm font-medium">
-                        Filtrar
-                    </button>
-                    <button id="btnLimpar" class="btn-warning text-white rounded-md px-4 py-3 text-sm font-medium">
-                        Limpar
-                    </button>
-                </div>
-            </div>
-
-            <!-- Tab-specific Filters -->
-            <div id="relatoriosSpecificFilters">
+            <div id="relatoriosSpecificFilters" class="space-y-6">
+                <!-- Matéria-prima -->
                 <div class="relatorios-tab-content" data-relatorios-tab-content="materia-prima">
-                    <div class="filter-bar relatorios-filter-bar">
-                        <div class="relatorios-filter-field">
-                            <label class="relatorios-filter-label text-white">Categoria</label>
-                            <select class="input-glass text-white rounded-md px-4 py-3 w-full">
-                                <option value="">Todas</option>
-                                <option value="madeira">Madeira</option>
-                                <option value="metal">Metal</option>
-                                <option value="tecido">Tecido</option>
-                            </select>
+                    <div class="space-y-4">
+                        <div class="filter-bar relatorios-filter-bar">
+                            <div class="relatorios-filter-field">
+                                <label class="relatorios-filter-label text-white">Buscar Insumo</label>
+                                <input type="search" class="input-glass text-white rounded-md px-4 py-3 w-full" placeholder="Nome, categoria ou processo">
+                            </div>
+
+                            <div class="relatorios-filter-field">
+                                <label class="relatorios-filter-label text-white">Processo</label>
+                                <select class="input-glass text-white rounded-md px-4 py-3 w-full">
+                                    <option value="">Todos</option>
+                                    <option value="corte">Corte</option>
+                                    <option value="montagem">Montagem</option>
+                                    <option value="acabamento">Acabamento</option>
+                                    <option value="embalagem">Embalagem</option>
+                                </select>
+                            </div>
+
+                            <div class="relatorios-filter-field">
+                                <label class="relatorios-filter-label text-white">Categoria</label>
+                                <select class="input-glass text-white rounded-md px-4 py-3 w-full">
+                                    <option value="">Todas</option>
+                                    <option value="madeira">Madeira</option>
+                                    <option value="metal">Metal</option>
+                                    <option value="quimico">Químico</option>
+                                    <option value="tecido">Têxtil</option>
+                                </select>
+                            </div>
+
+                            <div class="relatorios-filter-checkbox-group">
+                                <label class="relatorios-filter-checkbox-option text-white">
+                                    <input type="checkbox" class="relatorios-filter-checkbox rounded border-white/30 bg-transparent">
+                                    <span>0 Estoque</span>
+                                </label>
+                                <label class="relatorios-filter-checkbox-option text-white">
+                                    <input type="checkbox" class="relatorios-filter-checkbox rounded border-white/30 bg-transparent">
+                                    <span>Abaixo do mínimo</span>
+                                </label>
+                            </div>
                         </div>
 
-                        <div class="relatorios-filter-field">
-                            <label class="relatorios-filter-label text-white">Unidade</label>
-                            <select class="input-glass text-white rounded-md px-4 py-3 w-full">
-                                <option value="">Todas</option>
-                                <option value="un">Unidade</option>
-                                <option value="kg">Quilograma</option>
-                                <option value="m">Metro</option>
-                            </select>
+                        <div class="filter-bar relatorios-filter-bar">
+                            <div class="relatorios-filter-field">
+                                <label class="relatorios-filter-label text-white">Quantidade mínima</label>
+                                <input type="number" class="input-glass text-white rounded-md px-4 py-3 w-full" placeholder="0">
+                            </div>
+
+                            <div class="relatorios-filter-field">
+                                <label class="relatorios-filter-label text-white">Quantidade máxima</label>
+                                <input type="number" class="input-glass text-white rounded-md px-4 py-3 w-full" placeholder="500">
+                            </div>
+
+                            <div class="relatorios-filter-field">
+                                <label class="relatorios-filter-label text-white">Preço unitário mínimo</label>
+                                <input type="number" class="input-glass text-white rounded-md px-4 py-3 w-full" placeholder="R$ 0,00">
+                            </div>
+
+                            <div class="relatorios-filter-field">
+                                <label class="relatorios-filter-label text-white">Preço unitário máximo</label>
+                                <input type="number" class="input-glass text-white rounded-md px-4 py-3 w-full" placeholder="R$ 500,00">
+                            </div>
+
+                            <div class="relatorios-filter-actions">
+                                <button class="btn-secondary">Filtrar</button>
+                                <button class="btn-warning">Limpar</button>
+                            </div>
                         </div>
 
-                        <div class="relatorios-filter-field">
-                            <label class="relatorios-filter-label text-white">Processo</label>
-                            <select class="input-glass text-white rounded-md px-4 py-3 w-full">
-                                <option value="">Todos</option>
-                                <option value="corte">Corte</option>
-                                <option value="montagem">Montagem</option>
-                                <option value="acabamento">Acabamento</option>
-                            </select>
-                        </div>
-
-                        <div class="relatorios-filter-checkbox-group">
-                            <label class="relatorios-filter-checkbox-option text-white">
-                                <input type="checkbox" class="relatorios-filter-checkbox rounded border-white/30 bg-transparent">
-                                <span>Apenas infinitos</span>
-                            </label>
-                            <label class="relatorios-filter-checkbox-option text-white">
-                                <input type="checkbox" class="relatorios-filter-checkbox rounded border-white/30 bg-transparent">
-                                <span>Abaixo do mínimo</span>
-                            </label>
+                        <div class="relatorios-filter-tags" aria-label="Totais por tipo/processo">
+                            <button class="relatorios-filter-tag" type="button">Disponíveis</button>
+                            <button class="relatorios-filter-tag" type="button">Processo Crítico</button>
+                            <button class="relatorios-filter-tag" type="button">Importados</button>
+                            <button class="relatorios-filter-tag" type="button">Consignados</button>
                         </div>
                     </div>
                 </div>
 
+                <!-- Produtos -->
                 <div class="relatorios-tab-content hidden" data-relatorios-tab-content="produtos">
-                    <div class="filter-bar relatorios-filter-bar">
-                        <div class="relatorios-filter-field">
-                            <label class="relatorios-filter-label text-white">Categoria</label>
-                            <select class="input-glass text-white rounded-md px-4 py-3 w-full">
-                                <option value="">Todas</option>
-                                <option value="moveis">Móveis</option>
-                                <option value="decoracao">Decoração</option>
-                            </select>
+                    <div class="space-y-4">
+                        <div class="filter-bar relatorios-filter-bar">
+                            <div class="relatorios-filter-field">
+                                <label class="relatorios-filter-label text-white">Buscar Produto</label>
+                                <input type="search" class="input-glass text-white rounded-md px-4 py-3 w-full" placeholder="Código ou nome">
+                            </div>
+
+                            <div class="relatorios-filter-field">
+                                <label class="relatorios-filter-label text-white">Coleção</label>
+                                <select class="input-glass text-white rounded-md px-4 py-3 w-full">
+                                    <option value="">Todas</option>
+                                    <option value="essenciais">Essenciais</option>
+                                    <option value="premium">Premium</option>
+                                    <option value="corporativo">Corporativo</option>
+                                </select>
+                            </div>
+
+                            <div class="relatorios-filter-field">
+                                <label class="relatorios-filter-label text-white">Status</label>
+                                <select class="input-glass text-white rounded-md px-4 py-3 w-full">
+                                    <option value="">Todos</option>
+                                    <option value="ativo">Ativo</option>
+                                    <option value="inativo">Inativo</option>
+                                    <option value="em-desenvolvimento">Em desenvolvimento</option>
+                                </select>
+                            </div>
+
+                            <div class="relatorios-filter-checkbox-group">
+                                <label class="relatorios-filter-checkbox-option text-white">
+                                    <input type="checkbox" class="relatorios-filter-checkbox rounded border-white/30 bg-transparent">
+                                    <span>0 Estoque</span>
+                                </label>
+                                <label class="relatorios-filter-checkbox-option text-white">
+                                    <input type="checkbox" class="relatorios-filter-checkbox rounded border-white/30 bg-transparent">
+                                    <span>Somente destaque</span>
+                                </label>
+                            </div>
                         </div>
 
-                        <div class="relatorios-filter-field">
-                            <label class="relatorios-filter-label text-white">Status</label>
-                            <select class="input-glass text-white rounded-md px-4 py-3 w-full">
-                                <option value="">Todas</option>
-                                <option value="ativo">Ativo</option>
-                                <option value="inativo">Inativo</option>
-                            </select>
+                        <div class="filter-bar relatorios-filter-bar">
+                            <div class="relatorios-filter-field">
+                                <label class="relatorios-filter-label text-white">Preço mínimo</label>
+                                <input type="number" class="input-glass text-white rounded-md px-4 py-3 w-full" placeholder="R$ 0,00">
+                            </div>
+
+                            <div class="relatorios-filter-field">
+                                <label class="relatorios-filter-label text-white">Preço máximo</label>
+                                <input type="number" class="input-glass text-white rounded-md px-4 py-3 w-full" placeholder="R$ 10.000,00">
+                            </div>
+
+                            <div class="relatorios-filter-field">
+                                <label class="relatorios-filter-label text-white">Quantidade mínima</label>
+                                <input type="number" class="input-glass text-white rounded-md px-4 py-3 w-full" placeholder="0">
+                            </div>
+
+                            <div class="relatorios-filter-field">
+                                <label class="relatorios-filter-label text-white">Quantidade máxima</label>
+                                <input type="number" class="input-glass text-white rounded-md px-4 py-3 w-full" placeholder="5.000">
+                            </div>
+
+                            <div class="relatorios-filter-actions">
+                                <button class="btn-secondary">Filtrar</button>
+                                <button class="btn-warning">Limpar</button>
+                            </div>
                         </div>
 
-                        <div class="relatorios-filter-field">
-                            <label class="relatorios-filter-label text-white">Etapa</label>
-                            <select class="input-glass text-white rounded-md px-4 py-3 w-full">
-                                <option value="">Todas</option>
-                                <option value="projeto">Projeto</option>
-                                <option value="producao">Produção</option>
-                                <option value="finalizado">Finalizado</option>
-                            </select>
+                        <div class="relatorios-filter-slider">
+                            <label class="relatorios-filter-label text-white">Margem (%)</label>
+                            <div class="flex items-center gap-4">
+                                <span class="relatorios-slider-value">0%</span>
+                                <input type="range" min="0" max="100" value="35" class="relatorios-slider">
+                                <span class="relatorios-slider-value">100%</span>
+                            </div>
                         </div>
 
-                        <div class="relatorios-filter-field">
-                            <label class="relatorios-filter-label text-white">Markup mínimo (%)</label>
-                            <input type="number" class="input-glass text-white rounded-md px-4 py-3 w-full" placeholder="Valor mínimo">
+                        <div class="relatorios-filter-tags" aria-label="Totais por tipo">
+                            <button class="relatorios-filter-tag" type="button">Lançamentos</button>
+                            <button class="relatorios-filter-tag" type="button">Mais Vendidos</button>
+                            <button class="relatorios-filter-tag" type="button">Em Revisão</button>
                         </div>
                     </div>
                 </div>
-            </div>
 
-            <div class="relatorios-filter-status animate-fade-in-up">
-                <span class="badge-success px-3 py-1 rounded-full text-xs font-medium">Ativo</span>
-                <span class="badge-warning px-3 py-1 rounded-full text-xs font-medium">Pendente</span>
-                <span class="badge-neutral px-3 py-1 rounded-full text-xs font-medium">Em Análise</span>
+                <!-- Clientes -->
+                <div class="relatorios-tab-content hidden" data-relatorios-tab-content="clientes">
+                    <div class="space-y-4">
+                        <div class="filter-bar relatorios-filter-bar">
+                            <div class="relatorios-filter-field">
+                                <label class="relatorios-filter-label text-white">Buscar Cliente</label>
+                                <input type="search" class="input-glass text-white rounded-md px-4 py-3 w-full" placeholder="Nome, CNPJ, país ou estado">
+                            </div>
+
+                            <div class="relatorios-filter-field">
+                                <label class="relatorios-filter-label text-white">Dono</label>
+                                <select class="input-glass text-white rounded-md px-4 py-3 w-full">
+                                    <option value="">Todos</option>
+                                    <option value="joao">João Silva</option>
+                                    <option value="maria">Maria Santos</option>
+                                    <option value="pedro">Pedro Lima</option>
+                                </select>
+                            </div>
+
+                            <div class="relatorios-filter-field">
+                                <label class="relatorios-filter-label text-white">Status</label>
+                                <select class="input-glass text-white rounded-md px-4 py-3 w-full">
+                                    <option value="">Todos</option>
+                                    <option value="ativo">Ativo</option>
+                                    <option value="suspenso">Suspenso</option>
+                                    <option value="inativo">Inativo</option>
+                                </select>
+                            </div>
+
+                            <div class="relatorios-filter-actions">
+                                <button class="btn-secondary">Filtrar</button>
+                                <button class="btn-warning">Limpar</button>
+                            </div>
+                        </div>
+
+                        <div class="filter-bar relatorios-filter-bar">
+                            <div class="relatorios-filter-field">
+                                <label class="relatorios-filter-label text-white">País</label>
+                                <select class="input-glass text-white rounded-md px-4 py-3 w-full" multiple>
+                                    <option value="br">Brasil</option>
+                                    <option value="us">Estados Unidos</option>
+                                    <option value="pt">Portugal</option>
+                                    <option value="ar">Argentina</option>
+                                </select>
+                                <span class="relatorios-filter-hint">Use CTRL/⌘ para selecionar vários</span>
+                            </div>
+
+                            <div class="relatorios-filter-field">
+                                <label class="relatorios-filter-label text-white">Estado</label>
+                                <select class="input-glass text-white rounded-md px-4 py-3 w-full" multiple>
+                                    <option value="sp">São Paulo</option>
+                                    <option value="rj">Rio de Janeiro</option>
+                                    <option value="mg">Minas Gerais</option>
+                                    <option value="pr">Paraná</option>
+                                </select>
+                                <span class="relatorios-filter-hint">Seleção múltipla</span>
+                            </div>
+                        </div>
+
+                        <div class="relatorios-filter-tags" aria-label="Totais por tipo">
+                            <button class="relatorios-filter-tag" type="button">Ativos</button>
+                            <button class="relatorios-filter-tag" type="button">Inadimplentes</button>
+                            <button class="relatorios-filter-tag" type="button">Recentes</button>
+                            <button class="relatorios-filter-tag" type="button">VIP</button>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Contatos -->
+                <div class="relatorios-tab-content hidden" data-relatorios-tab-content="contatos">
+                    <div class="space-y-4">
+                        <div class="filter-bar relatorios-filter-bar">
+                            <div class="relatorios-filter-field">
+                                <label class="relatorios-filter-label text-white">Buscar Contato</label>
+                                <input type="search" class="input-glass text-white rounded-md px-4 py-3 w-full" placeholder="Nome ou empresa">
+                            </div>
+
+                            <div class="relatorios-filter-field">
+                                <label class="relatorios-filter-label text-white">Tipo de Contato</label>
+                                <select class="input-glass text-white rounded-md px-4 py-3 w-full">
+                                    <option value="">Todos</option>
+                                    <option value="fornecedor">Fornecedor</option>
+                                    <option value="parceiro">Parceiro</option>
+                                    <option value="cliente">Cliente</option>
+                                    <option value="prospect">Prospect</option>
+                                </select>
+                            </div>
+
+                            <div class="relatorios-filter-field">
+                                <label class="relatorios-filter-label text-white">Empresa</label>
+                                <input type="text" class="input-glass text-white rounded-md px-4 py-3 w-full" placeholder="Empresa">
+                            </div>
+
+                            <div class="relatorios-filter-actions">
+                                <button class="btn-secondary">Filtrar</button>
+                                <button class="btn-warning">Limpar</button>
+                            </div>
+                        </div>
+
+                        <div class="filter-bar relatorios-filter-bar">
+                            <div class="relatorios-filter-field">
+                                <label class="relatorios-filter-label text-white">Celular</label>
+                                <input type="tel" class="input-glass text-white rounded-md px-4 py-3 w-full" placeholder="(00) 00000-0000">
+                            </div>
+
+                            <div class="relatorios-filter-field">
+                                <label class="relatorios-filter-label text-white">Telefone</label>
+                                <input type="tel" class="input-glass text-white rounded-md px-4 py-3 w-full" placeholder="(00) 0000-0000">
+                            </div>
+
+                            <div class="relatorios-filter-tags" aria-label="Totais por tipo">
+                                <button class="relatorios-filter-tag" type="button">Clientes</button>
+                                <button class="relatorios-filter-tag" type="button">Fornecedores</button>
+                                <button class="relatorios-filter-tag" type="button">Parceiros</button>
+                                <button class="relatorios-filter-tag" type="button">Outros</button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Prospecções -->
+                <div class="relatorios-tab-content hidden" data-relatorios-tab-content="prospeccoes">
+                    <div class="space-y-4">
+                        <div class="filter-bar relatorios-filter-bar">
+                            <div class="relatorios-filter-field">
+                                <label class="relatorios-filter-label text-white">Buscar Lead</label>
+                                <input type="search" class="input-glass text-white rounded-md px-4 py-3 w-full" placeholder="Nome ou domínio do e-mail">
+                            </div>
+
+                            <div class="relatorios-filter-field">
+                                <label class="relatorios-filter-label text-white">Status</label>
+                                <select class="input-glass text-white rounded-md px-4 py-3 w-full">
+                                    <option value="">Todos</option>
+                                    <option value="novo">Novo</option>
+                                    <option value="contactado">Contactado</option>
+                                    <option value="qualificado">Qualificado</option>
+                                    <option value="desqualificado">Desqualificado</option>
+                                </select>
+                            </div>
+
+                            <div class="relatorios-filter-field">
+                                <label class="relatorios-filter-label text-white">Origem do Lead</label>
+                                <select class="input-glass text-white rounded-md px-4 py-3 w-full">
+                                    <option value="">Todas</option>
+                                    <option value="site">Site</option>
+                                    <option value="indicacao">Indicação</option>
+                                    <option value="evento">Evento</option>
+                                    <option value="midia">Mídia paga</option>
+                                </select>
+                            </div>
+
+                            <div class="relatorios-filter-field">
+                                <label class="relatorios-filter-label text-white">Responsável</label>
+                                <select class="input-glass text-white rounded-md px-4 py-3 w-full">
+                                    <option value="">Todos</option>
+                                    <option value="joao">João Silva</option>
+                                    <option value="maria">Maria Santos</option>
+                                    <option value="ana">Ana Paula</option>
+                                </select>
+                            </div>
+                        </div>
+
+                        <div class="filter-bar relatorios-filter-bar">
+                            <div class="relatorios-filter-field">
+                                <label class="relatorios-filter-label text-white">Cidade</label>
+                                <input type="text" class="input-glass text-white rounded-md px-4 py-3 w-full" placeholder="Digite a cidade">
+                            </div>
+
+                            <div class="relatorios-filter-field">
+                                <label class="relatorios-filter-label text-white">Estado</label>
+                                <input type="text" class="input-glass text-white rounded-md px-4 py-3 w-full" placeholder="UF">
+                            </div>
+
+                            <div class="relatorios-filter-field">
+                                <label class="relatorios-filter-label text-white">Data de criação (início)</label>
+                                <input type="date" class="input-glass text-white rounded-md px-4 py-3 w-full">
+                            </div>
+
+                            <div class="relatorios-filter-field">
+                                <label class="relatorios-filter-label text-white">Data de criação (fim)</label>
+                                <input type="date" class="input-glass text-white rounded-md px-4 py-3 w-full">
+                            </div>
+
+                            <div class="relatorios-filter-actions">
+                                <button class="btn-secondary">Filtrar</button>
+                                <button class="btn-warning">Limpar</button>
+                            </div>
+                        </div>
+
+                        <div class="relatorios-filter-tags" aria-label="Totais por status">
+                            <button class="relatorios-filter-tag" type="button">Novos</button>
+                            <button class="relatorios-filter-tag" type="button">Em Negociação</button>
+                            <button class="relatorios-filter-tag" type="button">Ganhos</button>
+                            <button class="relatorios-filter-tag" type="button">Perdidos</button>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Orçamentos -->
+                <div class="relatorios-tab-content hidden" data-relatorios-tab-content="orcamentos">
+                    <div class="space-y-4">
+                        <div class="filter-bar relatorios-filter-bar">
+                            <div class="relatorios-filter-field">
+                                <label class="relatorios-filter-label text-white">Status</label>
+                                <select class="input-glass text-white rounded-md px-4 py-3 w-full">
+                                    <option value="">Todos</option>
+                                    <option value="rascunho">Rascunho</option>
+                                    <option value="pendente">Pendente</option>
+                                    <option value="aprovado">Aprovado</option>
+                                    <option value="rejeitado">Rejeitado</option>
+                                    <option value="expirado">Expirado</option>
+                                </select>
+                            </div>
+
+                            <div class="relatorios-filter-field">
+                                <label class="relatorios-filter-label text-white">Período</label>
+                                <select class="input-glass text-white rounded-md px-4 py-3 w-full">
+                                    <option value="">Selecione...</option>
+                                    <option value="semana">Última semana</option>
+                                    <option value="mes">Último mês</option>
+                                    <option value="trimestre">Último trimestre</option>
+                                    <option value="custom">Personalizado</option>
+                                </select>
+                            </div>
+
+                            <div class="relatorios-filter-field">
+                                <label class="relatorios-filter-label text-white">Dono</label>
+                                <select class="input-glass text-white rounded-md px-4 py-3 w-full">
+                                    <option value="">Todos</option>
+                                    <option value="joao">João Silva</option>
+                                    <option value="maria">Maria Santos</option>
+                                    <option value="ana">Ana Paula</option>
+                                </select>
+                            </div>
+
+                            <div class="relatorios-filter-field">
+                                <label class="relatorios-filter-label text-white">Cliente</label>
+                                <select class="input-glass text-white rounded-md px-4 py-3 w-full">
+                                    <option value="">Todos</option>
+                                    <option value="acme">ACME Corp.</option>
+                                    <option value="alpha">Alpha Design</option>
+                                    <option value="beta">Beta Construções</option>
+                                </select>
+                            </div>
+                        </div>
+
+                        <div class="filter-bar relatorios-filter-bar">
+                            <div class="relatorios-filter-field">
+                                <label class="relatorios-filter-label text-white">Código do orçamento</label>
+                                <input type="search" class="input-glass text-white rounded-md px-4 py-3 w-full" placeholder="Buscar por código">
+                            </div>
+
+                            <div class="relatorios-filter-field">
+                                <label class="relatorios-filter-label text-white">Valor mínimo</label>
+                                <input type="number" class="input-glass text-white rounded-md px-4 py-3 w-full" placeholder="R$ 0,00">
+                            </div>
+
+                            <div class="relatorios-filter-field">
+                                <label class="relatorios-filter-label text-white">Valor máximo</label>
+                                <input type="number" class="input-glass text-white rounded-md px-4 py-3 w-full" placeholder="R$ 50.000,00">
+                            </div>
+
+                            <div class="relatorios-filter-field">
+                                <label class="relatorios-filter-label text-white">Condição comercial</label>
+                                <select class="input-glass text-white rounded-md px-4 py-3 w-full">
+                                    <option value="">Todas</option>
+                                    <option value="padrao">Padrão</option>
+                                    <option value="especial">Especial</option>
+                                    <option value="promocional">Promocional</option>
+                                </select>
+                            </div>
+
+                            <div class="relatorios-filter-actions">
+                                <button class="btn-secondary">Filtrar</button>
+                                <button class="btn-warning">Limpar</button>
+                            </div>
+                        </div>
+
+                        <div class="relatorios-filter-tags" aria-label="Totais por status">
+                            <button class="relatorios-filter-tag" type="button">Pendentes</button>
+                            <button class="relatorios-filter-tag" type="button">Aprovados</button>
+                            <button class="relatorios-filter-tag" type="button">Rejeitados</button>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Pedidos -->
+                <div class="relatorios-tab-content hidden" data-relatorios-tab-content="pedidos">
+                    <div class="space-y-4">
+                        <div class="filter-bar relatorios-filter-bar">
+                            <div class="relatorios-filter-field">
+                                <label class="relatorios-filter-label text-white">Status</label>
+                                <select class="input-glass text-white rounded-md px-4 py-3 w-full">
+                                    <option value="">Todos</option>
+                                    <option value="producao">Em Produção</option>
+                                    <option value="enviado">Enviado</option>
+                                    <option value="entregue">Entregue</option>
+                                    <option value="cancelado">Cancelado</option>
+                                </select>
+                            </div>
+
+                            <div class="relatorios-filter-field">
+                                <label class="relatorios-filter-label text-white">Período</label>
+                                <select class="input-glass text-white rounded-md px-4 py-3 w-full">
+                                    <option value="">Selecione...</option>
+                                    <option value="semana">Última semana</option>
+                                    <option value="mes">Último mês</option>
+                                    <option value="trimestre">Último trimestre</option>
+                                    <option value="custom">Personalizado</option>
+                                </select>
+                            </div>
+
+                            <div class="relatorios-filter-field">
+                                <label class="relatorios-filter-label text-white">Dono</label>
+                                <select class="input-glass text-white rounded-md px-4 py-3 w-full">
+                                    <option value="">Todos</option>
+                                    <option value="joao">João Silva</option>
+                                    <option value="maria">Maria Santos</option>
+                                    <option value="pedro">Pedro Lima</option>
+                                </select>
+                            </div>
+
+                            <div class="relatorios-filter-field">
+                                <label class="relatorios-filter-label text-white">Cliente</label>
+                                <select class="input-glass text-white rounded-md px-4 py-3 w-full">
+                                    <option value="">Todos</option>
+                                    <option value="acme">ACME Corp.</option>
+                                    <option value="alpha">Alpha Design</option>
+                                    <option value="beta">Beta Construções</option>
+                                </select>
+                            </div>
+                        </div>
+
+                        <div class="filter-bar relatorios-filter-bar">
+                            <div class="relatorios-filter-field">
+                                <label class="relatorios-filter-label text-white">Código do pedido</label>
+                                <input type="search" class="input-glass text-white rounded-md px-4 py-3 w-full" placeholder="Buscar por código">
+                            </div>
+
+                            <div class="relatorios-filter-field">
+                                <label class="relatorios-filter-label text-white">Valor mínimo</label>
+                                <input type="number" class="input-glass text-white rounded-md px-4 py-3 w-full" placeholder="R$ 0,00">
+                            </div>
+
+                            <div class="relatorios-filter-field">
+                                <label class="relatorios-filter-label text-white">Valor máximo</label>
+                                <input type="number" class="input-glass text-white rounded-md px-4 py-3 w-full" placeholder="R$ 50.000,00">
+                            </div>
+
+                            <div class="relatorios-filter-field">
+                                <label class="relatorios-filter-label text-white">Condição de pagamento</label>
+                                <select class="input-glass text-white rounded-md px-4 py-3 w-full">
+                                    <option value="">Todas</option>
+                                    <option value="avista">À vista</option>
+                                    <option value="30d">30 dias</option>
+                                    <option value="parcelado">Parcelado</option>
+                                </select>
+                            </div>
+
+                            <div class="relatorios-filter-actions">
+                                <button class="btn-secondary">Filtrar</button>
+                                <button class="btn-warning">Limpar</button>
+                            </div>
+                        </div>
+
+                        <div class="relatorios-filter-tags" aria-label="Totais por status">
+                            <button class="relatorios-filter-tag" type="button">Em Produção</button>
+                            <button class="relatorios-filter-tag" type="button">Prontos para Envio</button>
+                            <button class="relatorios-filter-tag" type="button">Atrasados</button>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Usuários -->
+                <div class="relatorios-tab-content hidden" data-relatorios-tab-content="usuarios">
+                    <div class="space-y-4">
+                        <div class="filter-bar relatorios-filter-bar">
+                            <div class="relatorios-filter-field">
+                                <label class="relatorios-filter-label text-white">Buscar Usuário</label>
+                                <input type="search" class="input-glass text-white rounded-md px-4 py-3 w-full" placeholder="Nome ou e-mail">
+                            </div>
+
+                            <div class="relatorios-filter-field">
+                                <label class="relatorios-filter-label text-white">Perfil</label>
+                                <select class="input-glass text-white rounded-md px-4 py-3 w-full">
+                                    <option value="">Todos</option>
+                                    <option value="admin">Admin</option>
+                                    <option value="operacional">Operacional</option>
+                                    <option value="cliente">Cliente</option>
+                                </select>
+                            </div>
+
+                            <div class="relatorios-filter-field">
+                                <label class="relatorios-filter-label text-white">Situação</label>
+                                <select class="input-glass text-white rounded-md px-4 py-3 w-full">
+                                    <option value="">Todas</option>
+                                    <option value="online">Online</option>
+                                    <option value="offline">Offline</option>
+                                    <option value="aguardando">Aguardando login</option>
+                                </select>
+                            </div>
+
+                            <div class="relatorios-filter-actions">
+                                <button class="btn-secondary">Filtrar</button>
+                                <button class="btn-warning">Limpar</button>
+                            </div>
+                        </div>
+
+                        <div class="filter-bar relatorios-filter-bar">
+                            <div class="relatorios-filter-checkbox-group">
+                                <label class="relatorios-filter-checkbox-option text-white">
+                                    <input type="checkbox" class="relatorios-filter-checkbox rounded border-white/30 bg-transparent">
+                                    <span>Ativo</span>
+                                </label>
+                                <label class="relatorios-filter-checkbox-option text-white">
+                                    <input type="checkbox" class="relatorios-filter-checkbox rounded border-white/30 bg-transparent">
+                                    <span>Inativo</span>
+                                </label>
+                                <label class="relatorios-filter-checkbox-option text-white">
+                                    <input type="checkbox" class="relatorios-filter-checkbox rounded border-white/30 bg-transparent">
+                                    <span>Aguardando</span>
+                                </label>
+                            </div>
+
+                            <div class="relatorios-filter-tags" aria-label="Totais por perfil">
+                                <button class="relatorios-filter-tag" type="button">Administradores</button>
+                                <button class="relatorios-filter-tag" type="button">Operacionais</button>
+                                <button class="relatorios-filter-tag" type="button">Clientes</button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
             </div>
         </section>
 


### PR DESCRIPTION
## Summary
- add per-area filter bars for relatórios, covering clientes, contatos, produtos, matéria-prima, pedidos, orçamentos, prospecções e usuários
- expose the novos filtros via updated tab list, incluindo atalho para contatos e quick tags baseadas em badges
- estilize componentes de filtro adicionais como tags clicáveis, dicas e slider de margem na listagem de produtos

## Testing
- no tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dedac39f188322a94a66601e004931